### PR TITLE
Matom hotfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 LDFLAGS= -L$(LIB) -L$(LIB2)  -lm -lcfitsio -lgsl -lgslcblas 
 
 #Note that version should be a single string without spaces. 
-VERSION = 76c_dev
+VERSION = 76c_store
 CHOICE=1             // Compress plasma as much as possible
 # CHOICE=0           //  Keep relation between plasma and wind identical
 

--- a/atomic.h
+++ b/atomic.h
@@ -74,14 +74,6 @@ int nlines_macro;		/* Actual number of Macro Atom lines that were read in.  New 
 int nauger;			/*Actual number of innershell edges for which autoionization is to be computed */
 
 
-#define UPLVL_UNKNOWN -999	// flag for if upper level for this macro atom has not been calculated
-double last_jprbs_known[NLEVELS_MACRO][2 * (NBBJUMPS + NBFJUMPS)];
-double last_eprbs_known[NLEVELS_MACRO][2 * (NBBJUMPS + NBFJUMPS)];
-double last_pjnorm_known[NLEVELS_MACRO];
-double last_penorm_known[NLEVELS_MACRO];
-int known[NLEVELS_MACRO]; 
-int last_nplasma;				// number of macro atom
-
 
 
 typedef struct elements

--- a/atomic.h
+++ b/atomic.h
@@ -74,6 +74,15 @@ int nlines_macro;		/* Actual number of Macro Atom lines that were read in.  New 
 int nauger;			/*Actual number of innershell edges for which autoionization is to be computed */
 
 
+#define UPLVL_UNKNOWN -999	// flag for if upper level for this macro atom has not been calculated
+double last_jprbs_known[NLEVELS_MACRO][2 * (NBBJUMPS + NBFJUMPS)];
+double last_eprbs_known[NLEVELS_MACRO][2 * (NBBJUMPS + NBFJUMPS)];
+double last_pjnorm_known[NLEVELS_MACRO];
+double last_penorm_known[NLEVELS_MACRO];
+int known[NLEVELS_MACRO]; 
+int last_nplasma;				// number of macro atom
+
+
 
 typedef struct elements
 {				/* Element contains physical parameters that apply to element as a whole and 

--- a/foo.h
+++ b/foo.h
@@ -399,6 +399,7 @@ int calloc_plasma(int nelem);
 int check_plasma(PlasmaPtr xplasma, char message[]);
 int calloc_macro(int nelem);
 int calloc_estimators(int nelem);
+int calloc_jumping(int nelem_track, int array_track[100]);
 /* partition.c */
 int partition_functions(PlasmaPtr xplasma, int mode);
 int partition_functions_2(PlasmaPtr xplasma, int xnion, double temp, double weight);

--- a/gridwind.c
+++ b/gridwind.c
@@ -694,7 +694,7 @@ calloc_estimators (nelem)
      We store these to prevemtnt problems with very very long k->A*->k chains
      This loops simply sets the values in the arrays of the probabilities we store
      to -999 (UPLVL_UNKNOWN) i.e. flags every probability as unknown */
-  last_nplasma = -1;
+  /*last_nplasma = -1;
   for (i = 0; i < NLEVELS_MACRO; i++)
     {
       last_pjnorm_known[i] = UPLVL_UNKNOWN;
@@ -706,7 +706,7 @@ calloc_estimators (nelem)
 	  last_jprbs_known[i][j] = UPLVL_UNKNOWN;
 	}
     }
-
+  */
   /*n_high_density = 0;
      for (n = 0; n < NPLASMA; n++)
      {
@@ -754,18 +754,21 @@ calloc_jumping (nelem_track, array_track)
      int array_track[MAX_MACRO_TRACKS];
 
 {
-  int n;
+  int n, i, njumps;
   
-  jumps_store = (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
+
+  jumps_store =
+    (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
+
   for (n = 0; n < nlevels_macro; n++)
     {
       Log
-	("calloc_estimators: level %d has n_bbu_jump %d  n_bbd_jump %d n_bfu_jump %d n_bfd_jump %d\n",
+	("calloc_jumping: level %d has n_bbu_jump %d  n_bbd_jump %d n_bfu_jump %d n_bfd_jump %d\n",
 	 n, config[n].n_bbu_jump, config[n].n_bbd_jump, config[n].n_bfu_jump,
 	 config[n].n_bfd_jump);
     }
-    
-   
+
+
 
   if (jumps_store == NULL)
     {
@@ -776,79 +779,82 @@ calloc_jumping (nelem_track, array_track)
   else if (nlevels_macro > 0 || geo.nmacro > 0)
     {
       Log
-	("Allocated %10d bytes for each of %5d elements of       macro totaling %10.1f Mb \n",
-	 sizeof (jumping_dummy), (nelem + 1),
-	 1.e-6 * (nelem + 1) * sizeof (macro_dummy));
+	("Allocated %10d bytes for each of %5d elements of jumps_store totaling %10.1f Mb \n",
+	 sizeof (jumping_dummy), (nelem_track + 1),
+	 1.e-6 * (nelem_track + 1) * sizeof (jumping_dummy));
     }
 
+  
+  //size_prbs = 0;
+  
+  /*for (n = 0; n < nlevels_macro; n++ )
+  {
+    njumps = config[n].n_bbd_jump + config[n].n_bfd_jump + config[n].n_bfu_jump + config[n].n_bbu_jump;
+    size_prbs += njumps;
+  }*/
+  
+  size_norm = nlevels_macro;
+  size_prbs = nlevels_macro;
+  size_track = nelem_track;
 
-  for (i=0; i < nelem_track; i++)
+
+
+  for (i = 0; i < nelem_track; i++)
+
     {
-    n = array_track [i];
-    
-    if ((jumps_store[n].eprbs =
+      n = array_track[i];
+      jumps_store[i].nplasma = n;
+
+      if ((jumps_store[i].eprbs =
 	   calloc (sizeof (double), size_prbs)) == NULL)
-      {
-        Error
-  	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
-	    exit (0);
-      }
-    
-    if ((jumps_store[n].jprbs =
-	   calloc (sizeof (double), size_prbs)) == NULL)
-      {
-        Error
-	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
-	    exit (0);
-      }
-    
-    if ((jumps_store[n].eprbs_norm =
-	   calloc (sizeof (double), size_norm)) == NULL)
-      {
-        Error
-	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
-	    exit (0);
-      }
-    
-    if ((jumps_store[n].jprbs_norm =
-	   calloc (sizeof (double), size_norm)) == NULL)
-      {
-        Error
-	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
-	    exit (0);
-      }
-    if ((jumps_store[n].jprbs_norm =
-	   calloc (sizeof (double), size_tracks)) == NULL)
-      {
-        Error
-  	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
 	  exit (0);
-      }
+	}
+
+      if ((jumps_store[i].jprbs =
+	   calloc (sizeof (double), size_prbs)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	  exit (0);
+	}
+
+      if ((jumps_store[i].eprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	  exit (0);
+	}
+
+      if ((jumps_store[i].jprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	  exit (0);
+	}
+	
     }
 
 
-    
+
   if (nlevels_macro > 0 || geo.nmacro > 0)
     {
       Log_silent
 	("Allocated %10.1f Mb for MA jumping probs \n",
-	 1.e-6 * (nelem + 1) * (2. * size_prbs + 2. * size_norm +
-				size_tracks) * sizeof (double));
+	 1.e-6 * (nelem_track + 1) * (2. * size_prbs + 2. * size_norm) * sizeof (double));
     }
+    
   else
     {
       Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
-    }  
+    }
 
 
 
-    
+
   return (0);
 }
-    
-    
-    
-    
-    
-    
-    

--- a/gridwind.c
+++ b/gridwind.c
@@ -723,16 +723,72 @@ calloc_estimators (nelem)
 
 
 
-/*int
+/***********************************************************
+                                       Space Telescope Science Institute
+
+ Synopsis:
+	calloc_jumping  allocates space to store jumping probabilities
+
+Arguments:		
+	nelem_track;			The number of macro atoms to track
+	array_track;			The array storing the plasma cell numbers
+						of the macro atoms to track
+ 
+Returns:
+ 
+Description:
+	This routine is designed to store transition probabilities for macro atoms
+	in dense parts of the wind in order to stop the performance problems
+	associated with k->A*->k chains. These problems are detailed under bug report 
+	#54, "Performance problems with CV macro models".
+		
+Notes:
+
+History:
+	131111 -- JM		Coding began
+              
+***********************************************************/
+
+int
 calloc_jumping (nelem_track, array_track)
-     int nelem;
+     int nelem_track;
+     int array_track[MAX_MACRO_TRACKS];
 
 {
-  macro_jumping = (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem + 1))
-    for (n = 0; n < nlevels_macro; n++)
+  int n;
+  
+  jumps_store = (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
+  for (n = 0; n < nlevels_macro; n++)
     {
       Log
 	("calloc_estimators: level %d has n_bbu_jump %d  n_bbd_jump %d n_bfu_jump %d n_bfd_jump %d\n",
 	 n, config[n].n_bbu_jump, config[n].n_bbd_jump, config[n].n_bfu_jump,
 	 config[n].n_bfd_jump);
+    }
+    
+    
+    /*  macromain = (MacroPtr) calloc (sizeof (macro_dummy), (nelem + 1));
+  geo.nmacro = nelem;
+
+  if (macromain == NULL)
+    {
+      Error
+	("calloc_macro: There is a problem in allocating memory for the macro structure\n");
+      exit (0);
+    }
+  else if (nlevels_macro > 0 || geo.nmacro > 0)
+    {
+      Log
+	("Allocated %10d bytes for each of %5d elements of       macro totaling %10.1f Mb \n",
+	 sizeof (macro_dummy), (nelem + 1),
+	 1.e-6 * (nelem + 1) * sizeof (macro_dummy));
     }*/
+  return (0);
+}
+    
+    
+    
+    
+    
+    
+    

--- a/gridwind.c
+++ b/gridwind.c
@@ -1,5 +1,4 @@
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -766,23 +765,84 @@ calloc_jumping (nelem_track, array_track)
 	 config[n].n_bfd_jump);
     }
     
-    
-    /*  macromain = (MacroPtr) calloc (sizeof (macro_dummy), (nelem + 1));
-  geo.nmacro = nelem;
+   
 
-  if (macromain == NULL)
+  if (jumps_store == NULL)
     {
       Error
-	("calloc_macro: There is a problem in allocating memory for the macro structure\n");
+	("calloc_jumping: There is a problem in allocating memory for the jump structure\n");
       exit (0);
     }
   else if (nlevels_macro > 0 || geo.nmacro > 0)
     {
       Log
 	("Allocated %10d bytes for each of %5d elements of       macro totaling %10.1f Mb \n",
-	 sizeof (macro_dummy), (nelem + 1),
+	 sizeof (jumping_dummy), (nelem + 1),
 	 1.e-6 * (nelem + 1) * sizeof (macro_dummy));
-    }*/
+    }
+
+
+  for (i=0; i < nelem_track; i++)
+    {
+    n = array_track [i];
+    
+    if ((jumps_store[n].eprbs =
+	   calloc (sizeof (double), size_prbs)) == NULL)
+      {
+        Error
+  	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	    exit (0);
+      }
+    
+    if ((jumps_store[n].jprbs =
+	   calloc (sizeof (double), size_prbs)) == NULL)
+      {
+        Error
+	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	    exit (0);
+      }
+    
+    if ((jumps_store[n].eprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+      {
+        Error
+	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	    exit (0);
+      }
+    
+    if ((jumps_store[n].jprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+      {
+        Error
+	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	    exit (0);
+      }
+    if ((jumps_store[n].jprbs_norm =
+	   calloc (sizeof (double), size_tracks)) == NULL)
+      {
+        Error
+  	  ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
+	  exit (0);
+      }
+    }
+
+
+    
+  if (nlevels_macro > 0 || geo.nmacro > 0)
+    {
+      Log_silent
+	("Allocated %10.1f Mb for MA jumping probs \n",
+	 1.e-6 * (nelem + 1) * (2. * size_prbs + 2. * size_norm +
+				size_tracks) * sizeof (double));
+    }
+  else
+    {
+      Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
+    }  
+
+
+
+    
   return (0);
 }
     

--- a/gridwind.c
+++ b/gridwind.c
@@ -367,7 +367,7 @@ calloc_macro (nelem)
 
   if (nlevels_macro == 0 && geo.nmacro == 0)
     {
-      
+
       Log
 	("calloc_macro: Allocated no space for macro since nlevels_macro==0 and geo.nmacro==0\n");
       return (0);
@@ -469,10 +469,10 @@ calloc_estimators (nelem)
   for (n = 0; n < nelem; n++)
     {
       /* JM130625: Commented out free statements due to PYWIND MALLOC MATOM BUG
-	 if (macromain[n].jbar != NULL)
-	{
-	  free (macromain[n].jbar);
-	}*/
+         if (macromain[n].jbar != NULL)
+         {
+         free (macromain[n].jbar);
+         } */
       if ((macromain[n].jbar =
 	   calloc (sizeof (double), size_Jbar_est)) == NULL)
 	{
@@ -482,9 +482,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].jbar_old != NULL)
-	{
-	  free (macromain[n].jbar_old);
-	}*/
+         {
+         free (macromain[n].jbar_old);
+         } */
       if ((macromain[n].jbar_old =
 	   calloc (sizeof (double), size_Jbar_est)) == NULL)
 	{
@@ -494,9 +494,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].gamma != NULL)
-	{
-	  free (macromain[n].gamma);
-	}*/
+         {
+         free (macromain[n].gamma);
+         } */
       if ((macromain[n].gamma =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -506,9 +506,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].gamma_old != NULL)
-	{
-	  free (macromain[n].gamma_old);
-	}*/
+         {
+         free (macromain[n].gamma_old);
+         } */
       if ((macromain[n].gamma_old =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -518,9 +518,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].gamma_e != NULL)
-	{
-	  free (macromain[n].gamma_e);
-	}*/
+         {
+         free (macromain[n].gamma_e);
+         } */
       if ((macromain[n].gamma_e =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -530,9 +530,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].gamma_e_old != NULL)
-	{
-	  free (macromain[n].gamma_e_old);
-	}*/
+         {
+         free (macromain[n].gamma_e_old);
+         } */
       if ((macromain[n].gamma_e_old =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -542,9 +542,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].alpha_st != NULL)
-	{
-	  free (macromain[n].alpha_st);
-	}*/
+         {
+         free (macromain[n].alpha_st);
+         } */
       if ((macromain[n].alpha_st =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -554,9 +554,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].alpha_st_old != NULL)
-	{
-	  free (macromain[n].alpha_st_old);
-	}*/
+         {
+         free (macromain[n].alpha_st_old);
+         } */
       if ((macromain[n].alpha_st_old =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -566,9 +566,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].alpha_st_e != NULL)
-	{
-	  free (macromain[n].alpha_st_e);
-	}*/
+         {
+         free (macromain[n].alpha_st_e);
+         } */
       if ((macromain[n].alpha_st_e =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -578,9 +578,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].alpha_st_e_old)
-	{
-	  free (macromain[n].alpha_st_e_old);
-	}*/
+         {
+         free (macromain[n].alpha_st_e_old);
+         } */
       if ((macromain[n].alpha_st_e_old =
 	   calloc (sizeof (double), size_gamma_est)) == NULL)
 	{
@@ -590,9 +590,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].recomb_sp != NULL)
-	{
-	  free (macromain[n].recomb_sp);
-	}*/
+         {
+         free (macromain[n].recomb_sp);
+         } */
       if ((macromain[n].recomb_sp =
 	   calloc (sizeof (double), size_alpha_est)) == NULL)
 	{
@@ -602,9 +602,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].recomb_sp_e != NULL)
-	{
-	  free (macromain[n].recomb_sp_e);
-	}*/
+         {
+         free (macromain[n].recomb_sp_e);
+         } */
       if ((macromain[n].recomb_sp_e =
 	   calloc (sizeof (double), size_alpha_est)) == NULL)
 	{
@@ -614,9 +614,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].matom_emiss != NULL)
-	{
-	  free (macromain[n].matom_emiss);
-	}*/
+         {
+         free (macromain[n].matom_emiss);
+         } */
       if ((macromain[n].matom_emiss =
 	   calloc (sizeof (double), nlevels_macro)) == NULL)
 	{
@@ -626,9 +626,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].matom_abs != NULL)
-	{
-	  free (macromain[n].matom_abs);
-	}*/
+         {
+         free (macromain[n].matom_abs);
+         } */
       if ((macromain[n].matom_abs =
 	   calloc (sizeof (double), nlevels_macro)) == NULL)
 	{
@@ -639,9 +639,9 @@ calloc_estimators (nelem)
 
       /* Added ksl 091103 59e */
       /*if (macromain[n].cooling_bf != NULL)
-	{
-	  free (macromain[n].cooling_bf);
-	}*/
+         {
+         free (macromain[n].cooling_bf);
+         } */
       if ((macromain[n].cooling_bf =
 	   calloc (sizeof (double), ntop_phot)) == NULL)
 	{
@@ -651,9 +651,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].cooling_bf_col != NULL)
-	{
-	  free (macromain[n].cooling_bf_col);
-	}*/
+         {
+         free (macromain[n].cooling_bf_col);
+         } */
       if ((macromain[n].cooling_bf_col =
 	   calloc (sizeof (double), ntop_phot)) == NULL)
 	{
@@ -663,9 +663,9 @@ calloc_estimators (nelem)
 	}
 
       /*if (macromain[n].cooling_bb != NULL)
-	{
-	  free (macromain[n].cooling_bb);
-	}*/
+         {
+         free (macromain[n].cooling_bb);
+         } */
       if ((macromain[n].cooling_bb =
 	   calloc (sizeof (double), nlines)) == NULL)
 	{
@@ -690,8 +690,14 @@ calloc_estimators (nelem)
       Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
     }
 
-   for (i=0; i < NLEVELS_MACRO; i++)
-      {
+
+  /* These arrays are transition probabilities for the last macro atom the photon hit.
+     We store these to prevemtnt problems with very very long k->A*->k chains
+     This loops simply sets the values in the arrays of the probabilities we store
+     to -999 (UPLVL_UNKNOWN) i.e. flags every probability as unknown */
+  last_nplasma = -1;
+  for (i = 0; i < NLEVELS_MACRO; i++)
+    {
       last_pjnorm_known[i] = UPLVL_UNKNOWN;
       last_penorm_known[i] = UPLVL_UNKNOWN;
       known[i] = -1;
@@ -702,10 +708,10 @@ calloc_estimators (nelem)
 	}
     }
 
-   n_high_density = 0;
-   for (n = 0; n < NPLASMA; n++)
+  /*n_high_density = 0;
+     for (n = 0; n < NPLASMA; n++)
      {
-       if 
+     if */
 
 
 
@@ -717,21 +723,16 @@ calloc_estimators (nelem)
 
 
 
-int
+/*int
 calloc_jumping (nelem_track, array_track)
      int nelem;
-     
+
 {
   macro_jumping = (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem + 1))
-  for (n = 0; n < nlevels_macro; n++)
+    for (n = 0; n < nlevels_macro; n++)
     {
       Log
 	("calloc_estimators: level %d has n_bbu_jump %d  n_bbd_jump %d n_bfu_jump %d n_bfd_jump %d\n",
 	 n, config[n].n_bbu_jump, config[n].n_bbd_jump, config[n].n_bfu_jump,
 	 config[n].n_bfd_jump);
-    }
-  
-  
-
-
-
+    }*/

--- a/gridwind.c
+++ b/gridwind.c
@@ -752,9 +752,8 @@ int
 calloc_jumping (nelem_track, array_track)
      int nelem_track;
      int array_track[MAX_MACRO_TRACKS];
-
 {
-  int n, i, njumps;
+  int n, i, njumps, j;
   
 
   jumps_store =
@@ -804,6 +803,10 @@ calloc_jumping (nelem_track, array_track)
     {
       n = array_track[i];
       jumps_store[i].nplasma = n;
+    for (j = 0; j < nlevels_macro; j++)
+      {
+        jumps_store[i].known[j] =0;
+      }
 
       if ((jumps_store[i].eprbs =
 	   calloc (sizeof (double), size_prbs)) == NULL)

--- a/gridwind.c
+++ b/gridwind.c
@@ -758,7 +758,11 @@ calloc_jumping (nelem_track, array_track)
 
   jumps_store =
     (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
-
+    
+  last_matom = 
+    (LastMatomPtr) calloc (sizeof (last_dummy), (2));
+    
+    
   for (n = 0; n < nlevels_macro; n++)
     {
       Log
@@ -795,6 +799,7 @@ calloc_jumping (nelem_track, array_track)
   size_norm = nlevels_macro;
   size_prbs = nlevels_macro;
   size_track = nelem_track;
+  countit=0;
 
 
 
@@ -843,7 +848,6 @@ calloc_jumping (nelem_track, array_track)
     }
 
 
-
   if (nlevels_macro > 0 || geo.nmacro > 0)
     {
       Log_silent
@@ -858,6 +862,51 @@ calloc_jumping (nelem_track, array_track)
 
 
 
+    if ((last_matom->eprbs =
+	   calloc (sizeof (double), size_prbs)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
+	  exit (0);
+	}
+
+      if ((last_matom->jprbs =
+	   calloc (sizeof (double), size_prbs)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
+	  exit (0);
+	}
+
+      if ((last_matom->eprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
+	  exit (0);
+	}
+
+      if ((last_matom->jprbs_norm =
+	   calloc (sizeof (double), size_norm)) == NULL)
+	{
+	  Error
+	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
+	  exit (0);
+	}
+	
+	last_matom->nplasma = -999;
+	
+	for (j = 0; j < nlevels_macro; j++)
+      {
+        last_matom->known[j] =0;
+      }
+
+    if (nlevels_macro > 0 || geo.nmacro > 0)
+    {
+      Log_silent
+	("Allocated %10.1f Mb for MA jumping probs \n",
+	 1.e-6 * (1) * (2. * size_prbs + 2. * size_norm) * sizeof (double));
+    }
 
   return (0);
 }

--- a/gridwind.c
+++ b/gridwind.c
@@ -760,7 +760,7 @@ calloc_jumping (nelem_track, array_track)
     (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
     
   last_matom = 
-    (LastMatomPtr) calloc (sizeof (last_dummy), (2));
+    (LastMatomPtr) calloc (sizeof (jumping_dummy), (2));
     
     
   for (n = 0; n < nlevels_macro; n++)
@@ -788,14 +788,7 @@ calloc_jumping (nelem_track, array_track)
     }
 
   
-  //size_prbs = 0;
-  
-  /*for (n = 0; n < nlevels_macro; n++ )
-  {
-    njumps = config[n].n_bbd_jump + config[n].n_bfd_jump + config[n].n_bfu_jump + config[n].n_bbu_jump;
-    size_prbs += njumps;
-  }*/
-  
+  /* sizes for mrmory allocation of the arrays */
   size_norm = nlevels_macro;
   size_prbs = nlevels_macro;
   size_track = nelem_track;
@@ -848,7 +841,7 @@ calloc_jumping (nelem_track, array_track)
     }
 
 
-  if (nlevels_macro > 0 || geo.nmacro > 0)
+  if (nelem_track > 0)
     {
       Log_silent
 	("Allocated %10.1f Mb for MA jumping probs \n",
@@ -857,7 +850,7 @@ calloc_jumping (nelem_track, array_track)
     
   else
     {
-      Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
+      Log_silent ("Allocated no space for jumps since n to track==0\n");
     }
 
 

--- a/gridwind.c
+++ b/gridwind.c
@@ -729,16 +729,15 @@ calloc_jumping (nelem_track, array_track)
      int array_track[MAX_MACRO_TRACKS];
 {
   int n, i, j;
-  
+
 
   /* allocate memory for the structures themselves, defined in python.h */
   jumps_store =
     (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem_track + 1));
-    
-  last_matom = 
-    (JumpingPtr) calloc (sizeof (jumping_dummy), (2));
-    
-  
+
+  last_matom = (JumpingPtr) calloc (sizeof (jumping_dummy), (2));
+
+
   for (n = 0; n < nlevels_macro; n++)
     {
       Log
@@ -762,7 +761,7 @@ calloc_jumping (nelem_track, array_track)
 	 sizeof (jumping_dummy), (nelem_track + 1),
 	 1.e-6 * (nelem_track + 1) * sizeof (jumping_dummy));
     }
-    
+
   if (last_matom == NULL)
     {
       Error
@@ -773,9 +772,8 @@ calloc_jumping (nelem_track, array_track)
     {
       Log
 	("Allocated %10d bytes for each of %5d elements of last_matom totaling %10.1f Mb \n",
-	 sizeof (jumping_dummy), (2),
-	 1.e-6 * (2) * sizeof (jumping_dummy));
-    }  
+	 sizeof (jumping_dummy), (2), 1.e-6 * (2) * sizeof (jumping_dummy));
+    }
 
 
 
@@ -784,7 +782,7 @@ calloc_jumping (nelem_track, array_track)
   size_norm = nlevels_macro;
   size_prbs = nlevels_macro;
   size_track = nelem_track;
-  countit=0;
+  countit = 0;
 
 
 
@@ -796,15 +794,15 @@ calloc_jumping (nelem_track, array_track)
       /* record the plasma cell of the macro atom we are tracking */
       n = array_track[i];
       jumps_store[i].nplasma = n;
-      
-    /* set all probabilities to unknown initially */
-    for (j = 0; j < nlevels_macro; j++)
-      {
-        jumps_store[i].known[j] =0;
-      }
+
+      /* set all probabilities to unknown initially */
+      for (j = 0; j < nlevels_macro; j++)
+	{
+	  jumps_store[i].known[j] = 0;
+	}
 
 
-    /* now allocate memory for the eprbs, jprbs and normalisation arrays */
+      /* now allocate memory for the eprbs, jprbs and normalisation arrays */
       if ((jumps_store[i].eprbs =
 	   calloc (sizeof (double), size_prbs)) == NULL)
 	{
@@ -836,8 +834,8 @@ calloc_jumping (nelem_track, array_track)
 	    ("calloc_jumping: Error in allocating memory for jump elements of structure\n");
 	  exit (0);
 	}
-	
-    } // end of loop over n_elem_track
+
+    }				// end of loop over n_elem_track
 
 
   /* record space allocated for jumps_store prbs arrays */
@@ -845,76 +843,75 @@ calloc_jumping (nelem_track, array_track)
     {
       Log_silent
 	("Allocated %10.1f Mb for MA jumping probs \n",
-	 1.e-6 * (nelem_track + 1) * (2. * size_prbs + 2. * size_norm) * sizeof (double));
-    }   
+	 1.e-6 * (nelem_track + 1) * (2. * size_prbs +
+				      2. * size_norm) * sizeof (double));
+    }
   else
     {
-      Log_silent ("Allocated no space for jumps_store probs since n to track==0\n");
+      Log_silent
+	("Allocated no space for jumps_store probs since n to track==0\n");
     }
 
 
 
 
 
-    /* allocate memory for the last_matom probability arrays */
-    if ((last_matom->eprbs =
-	   calloc (sizeof (double), size_prbs)) == NULL)
-	{
-	  Error
-	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
-	  exit (0);
-	}
+  /* allocate memory for the last_matom probability arrays */
+  if ((last_matom->eprbs = calloc (sizeof (double), size_prbs)) == NULL)
+    {
+      Error
+	("calloc_jumping: Error in allocating memory for last_matom structure\n");
+      exit (0);
+    }
 
-      if ((last_matom->jprbs =
-	   calloc (sizeof (double), size_prbs)) == NULL)
-	{
-	  Error
-	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
-	  exit (0);
-	}
+  if ((last_matom->jprbs = calloc (sizeof (double), size_prbs)) == NULL)
+    {
+      Error
+	("calloc_jumping: Error in allocating memory for last_matom structure\n");
+      exit (0);
+    }
 
-      if ((last_matom->eprbs_norm =
-	   calloc (sizeof (double), size_norm)) == NULL)
-	{
-	  Error
-	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
-	  exit (0);
-	}
+  if ((last_matom->eprbs_norm = calloc (sizeof (double), size_norm)) == NULL)
+    {
+      Error
+	("calloc_jumping: Error in allocating memory for last_matom structure\n");
+      exit (0);
+    }
 
-      if ((last_matom->jprbs_norm =
-	   calloc (sizeof (double), size_norm)) == NULL)
-	{
-	  Error
-	    ("calloc_jumping: Error in allocating memory for last_matom structure\n");
-	  exit (0);
-	}
-	
-	
-	/* set nplasma to some impossible number -- there is no last matom at first! */
-	last_matom->nplasma = -999;
-	
-	/* set all levels to unknown */
-	for (j = 0; j < nlevels_macro; j++)
-      {
-        last_matom->known[j] = 0;
-      }
+  if ((last_matom->jprbs_norm = calloc (sizeof (double), size_norm)) == NULL)
+    {
+      Error
+	("calloc_jumping: Error in allocating memory for last_matom structure\n");
+      exit (0);
+    }
 
 
-    /* record space allocated for last_matom prbs arrays */
-    if (nlevels_macro > 0 || geo.nmacro > 0)
+  /* set nplasma to some impossible number -- there is no last matom at first! */
+  last_matom->nplasma = -999;
+
+  /* set all levels to unknown */
+  for (j = 0; j < nlevels_macro; j++)
+    {
+      last_matom->known[j] = 0;
+    }
+
+
+  /* record space allocated for last_matom prbs arrays */
+  if (nlevels_macro > 0 || geo.nmacro > 0)
     {
       Log_silent
 	("Allocated %10.1f Mb for last_matom jumping probs \n",
 	 1.e-6 * (2) * (2. * size_prbs + 2. * size_norm) * sizeof (double));
     }
-      else
+  else
     {
-      Log_silent ("Allocated no space for last_matom probs since nlevels_macro==0\n");
+      Log_silent
+	("Allocated no space for last_matom probs since nlevels_macro==0\n");
     }
 
 
   /* memory alocated, all done here */
 
   return (0);
-  
+
 }

--- a/gridwind.c
+++ b/gridwind.c
@@ -428,7 +428,7 @@ int
 calloc_estimators (nelem)
      int nelem;
 {
-  int n;
+  int n, i, j;
 
   if (nlevels_macro == 0 && geo.nmacro == 0)
     {
@@ -690,5 +690,48 @@ calloc_estimators (nelem)
       Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
     }
 
+   for (i=0; i < NLEVELS_MACRO; i++)
+      {
+      last_pjnorm_known[i] = UPLVL_UNKNOWN;
+      last_penorm_known[i] = UPLVL_UNKNOWN;
+      known[i] = -1;
+      for (j = 0; j < 2 * (NBBJUMPS + NBFJUMPS); j++)
+	{
+	  last_eprbs_known[i][j] = UPLVL_UNKNOWN;
+	  last_jprbs_known[i][j] = UPLVL_UNKNOWN;
+	}
+    }
+
+   n_high_density = 0;
+   for (n = 0; n < NPLASMA; n++)
+     {
+       if 
+
+
+
+
+
   return (0);
 }
+
+
+
+
+int
+calloc_jumping (nelem_track, array_track)
+     int nelem;
+     
+{
+  macro_jumping = (JumpingPtr) calloc (sizeof (jumping_dummy), (nelem + 1))
+  for (n = 0; n < nlevels_macro; n++)
+    {
+      Log
+	("calloc_estimators: level %d has n_bbu_jump %d  n_bbd_jump %d n_bfu_jump %d n_bfd_jump %d\n",
+	 n, config[n].n_bbu_jump, config[n].n_bbd_jump, config[n].n_bfu_jump,
+	 config[n].n_bfd_jump);
+    }
+  
+  
+
+
+

--- a/python.h
+++ b/python.h
@@ -776,6 +776,7 @@ typedef struct macro
   double cooling_normalisation;
   double cooling_bbtot, cooling_bftot, cooling_bf_coltot;
   double cooling_ff;
+  int stored;
 
 } macro_dummy, *MacroPtr;
 
@@ -784,6 +785,7 @@ MacroPtr macromain;
 int xxxpdfwind;			// When 1, line luminosity calculates pdf
 
 int size_Jbar_est, size_gamma_est, size_alpha_est;
+int size_prbs, size_norm, size_track;
 
 // These definitions define a photon type, generally it's origin
 #define PTYPE_STAR	    0
@@ -838,11 +840,12 @@ phot.istat below */
    
 typedef struct jumping_store
 {
-  double *jprbs;		// array of jumping probabilities
-  double *eprbs;		// array of emission probabilities
+  double (*jprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of jumping probabilities
+  double (*eprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of emission probabilities
   double *jprbs_norm;	// array of jumping normalisation
   double *eprbs_norm;	// array of emission normalisation
   int nplasma;
+  int known;
 } jumping_dummy, *JumpingPtr;  
 
 JumpingPtr jumps_store;

--- a/python.h
+++ b/python.h
@@ -842,7 +842,7 @@ typedef struct jumping_store
   double *eprbs;		// array of emission probabilities
   double *jprbs_norm;	// array of jumping normalisation
   double *eprbs_norm;	// array of emission normalisation
-  int nplasma[MAX_MACRO_TRACKS];
+  int nplasma;
 } jumping_dummy, *JumpingPtr;  
 
 JumpingPtr jumps_store;

--- a/python.h
+++ b/python.h
@@ -831,6 +831,7 @@ phot.istat below */
    MAX_MACRO_TRACKS is the maximum number of cells to track */
 #define MACRO_TRACKING_DENSITY 1e13	
 #define MAX_MACRO_TRACKS 100
+int n_macro_tracking;
 
 /* jumps_store is the structure which stores macro atom probabilities
    for macro atoms in dense regions of the wind. These arrays
@@ -845,7 +846,7 @@ typedef struct jumping_store
   double *jprbs_norm;	// array of jumping normalisation
   double *eprbs_norm;	// array of emission normalisation
   int nplasma;
-  int known;
+  int known[NLEVELS_MACRO];
 } jumping_dummy, *JumpingPtr;  
 
 JumpingPtr jumps_store;

--- a/python.h
+++ b/python.h
@@ -823,6 +823,31 @@ phot.istat below */
 #define THETAMAX	 1e4	//Used in initial calculation of n_e
 #define MIN_TEMP	100.	//  ??? this is another minimum temperature - it is used as the minimum tempersture in
 
+/* MACRO_TRACKING_DENSITY isthe minumum density above which we keep track 
+   of probabilities for a given macro atom. This is in order to prevent k->A*->k
+   chains causing performance problems.
+   MAX_MACRO_TRACKS is the maximum number of cells to track */
+#define MACRO_TRACKING_DENSITY 1e13	
+#define MAX_MACRO_TRACKS 100
+
+/* jumps_store is the structure which stores macro atom probabilities
+   for macro atoms in dense regions of the wind. These arrays
+   are dynamically allocated in calloc_jumping. It is indexed
+   by cell, element, initial level, final level, in that order
+   e.g. jump_store[nplasma][nelem].jprbs[uplvl][i]  */
+   
+typedef struct jumping_store
+{
+  double *jprbs;		// array of jumping probabilities
+  double *eprbs;		// array of emission probabilities
+  double *jprbs_norm;	// array of jumping normalisation
+  double *eprbs_norm;	// array of emission normalisation
+  int nplasma[MAX_MACRO_TRACKS];
+} jumping_dummy, *JumpingPtr;  
+
+JumpingPtr jumps_store;
+
+
 
 #define NDIM_MAX 500
 double wind_x[NDIM_MAX], wind_z[NDIM_MAX];	/* These define the edges of the cells in the x and z directions */

--- a/python.h
+++ b/python.h
@@ -841,6 +841,7 @@ int countit;
    
 typedef struct jumping_store
 {
+  /* jumping arrays are arrays containing pointers to 2nd dimension of the array */
   double (*jprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of jumping probabilities
   double (*eprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of emission probabilities
   double *jprbs_norm;	// array of jumping normalisation
@@ -851,18 +852,11 @@ typedef struct jumping_store
 
 JumpingPtr jumps_store;
 
-typedef struct last
-{
-  double (*jprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of jumping probabilities
-  double (*eprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of emission probabilities
-  double *jprbs_norm;	// array of jumping normalisation
-  double *eprbs_norm;	// array of emission normalisation
-  int nplasma;
-  int known[NLEVELS_MACRO];
-} last_dummy, *LastMatomPtr;
+/* last_matom is similar to jumping store, but will only store 
+   for the last macro atom we were in */
+JumpingPtr last_matom;
 
 
-LastMatomPtr last_matom;
 
 
 

--- a/python.h
+++ b/python.h
@@ -2,6 +2,7 @@
 #include "mpi.h"
 #endif 
 
+int count;
 int np_mpi_global;               /// Global variable which holds the number of MPI processes
 int rank_global; 
 

--- a/python.h
+++ b/python.h
@@ -832,7 +832,7 @@ phot.istat below */
 #define MACRO_TRACKING_DENSITY 1e13	
 #define MAX_MACRO_TRACKS 100
 int n_macro_tracking;
-
+int countit;
 /* jumps_store is the structure which stores macro atom probabilities
    for macro atoms in dense regions of the wind. These arrays
    are dynamically allocated in calloc_jumping. It is indexed
@@ -850,6 +850,19 @@ typedef struct jumping_store
 } jumping_dummy, *JumpingPtr;  
 
 JumpingPtr jumps_store;
+
+typedef struct last
+{
+  double (*jprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of jumping probabilities
+  double (*eprbs) [ 2 * (NBBJUMPS + NBFJUMPS)];		// array of emission probabilities
+  double *jprbs_norm;	// array of jumping normalisation
+  double *eprbs_norm;	// array of emission normalisation
+  int nplasma;
+  int known[NLEVELS_MACRO];
+} last_dummy, *LastMatomPtr;
+
+
+LastMatomPtr last_matom;
 
 
 

--- a/resonate.c
+++ b/resonate.c
@@ -905,7 +905,7 @@ calls to two_level atom
   tau_x_dvds = PI_E2_OVER_M * xden_ion * lptr->f / (lptr->freq);
   tau = tau_x_dvds / dvds;
 
-  return (tau);
+  return (0);
 }
 
 

--- a/templates.h
+++ b/templates.h
@@ -399,6 +399,7 @@ int calloc_plasma(int nelem);
 int check_plasma(PlasmaPtr xplasma, char message[]);
 int calloc_macro(int nelem);
 int calloc_estimators(int nelem);
+int calloc_jumping(int nelem_track, int array_track[100]);
 /* partition.c */
 int partition_functions(PlasmaPtr xplasma, int mode);
 int partition_functions_2(PlasmaPtr xplasma, int xnion, double temp, double weight);

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
-#define VERSION  "76c_dev"
+#define VERSION  "76c_store"
 #define CHOICE 1 // Compress plasma as much as possible

--- a/wind2d.c
+++ b/wind2d.c
@@ -85,10 +85,11 @@ define_wind ()
   int ierr;
   int n_vol, n_inwind, n_part;
   int n_comp, n_comp_part;
+  
+  int macro_track[MAX_MACRO_TRACKS];
 
   int nwind;
   int nplasma;
-  int n_to_track, matom_track_cells[MAX_MACRO_TRACKS];	// JM 131111 index and array for tracking macro atom probabilities
 
   WindPtr w;
   PlasmaPtr xplasma;
@@ -323,7 +324,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 
 
 /* Now calculate parameters that need to be calculated at the center of the grid cell */
-  n_to_track = 0;
+  n_macro_tracking = 0;
 
   for (n = 0; n < NPLASMA; n++)
     {
@@ -353,19 +354,19 @@ be optional which variables beyond here are moved to structures othere than Wind
       if (geo.rt_mode == 2)
 	{
 
-	  if (nh > MACRO_TRACKING_DENSITY && n_to_track < MAX_MACRO_TRACKS)	// initially I set this density to 1e13
+	  if (nh > MACRO_TRACKING_DENSITY && n_macro_tracking <= MAX_MACRO_TRACKS)	// initially I set this density to 1e13
 	    {
-	    
-	      matom_track_cells[n_to_track] = n;	// add the plasma number to an array
 	      
 	      macromain[n].stored = 1;
 	      
-	      n_to_track++;	// increment the count of cells we are tracking
+	      macro_track[n_macro_tracking] = n;
+	      
+	      n_macro_tracking++;	// increment the count of cells we are tracking
 	      
 	    }
 	    
 	  else if (nh > MACRO_TRACKING_DENSITY
-		   && n_to_track < MAX_MACRO_TRACKS)
+		   && n_macro_tracking > MAX_MACRO_TRACKS)
 	    {
 	      Warning
 		("wind2d macro atom tracking: plasma cell %i has density %8.4e > %8.4e, but already tracking too many macro atoms!\n",
@@ -455,8 +456,8 @@ be optional which variables beyond here are moved to structures othere than Wind
 /* now dynamically allocate space for the number of cells we have decided to track in macro atom mode */
   if (geo.rt_mode == 2)
     {
-      Log("%i macro atoms have nh higher than %8.2e, so tracking MA probabilities\n", n_to_track, MACRO_TRACKING_DENSITY);
-      calloc_jumping (n_to_track, matom_track_cells);
+      Log("%i macro atoms have nh higher than %8.2e, so tracking MA probabilities\n", n_macro_tracking, MACRO_TRACKING_DENSITY);
+      calloc_jumping (n_macro_tracking, macro_track);
     }
 
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -348,11 +348,11 @@ be optional which variables beyond here are moved to structures othere than Wind
 
      /* if the density is sufficiently high then we want to track this cell in macro atom mode and record 
         its jumping probabilities */
-     if (nh > 1.0e13)
+     /*if (nh > 1.0e13)
        {
          matom_track_cells[n_to_track] = n;
          n_to_track += 1;
-       }
+       }*/
 
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */
       if (geo.wind_type == 3)
@@ -426,10 +426,10 @@ be optional which variables beyond here are moved to structures othere than Wind
     }
 
 /* now dynamically allocate space for the number of cells we have decided to track in macro atom mode */
-  if (geo.rt_mode = 2)
+  /*if (geo.rt_mode = 2)
     {
       calloc_jumping (n_to_track,  matom_track_cells);
-    }
+    }*/
       
 
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -323,7 +323,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 
 
 /* Now calculate parameters that need to be calculated at the center of the grid cell */
-
+  n_to_track = 0;
 
   for (n = 0; n < NPLASMA; n++)
     {
@@ -350,22 +350,35 @@ be optional which variables beyond here are moved to structures othere than Wind
 
       /* JM 131016 -- If we are in macro atom mode and the density is sufficiently high 
          then we want to track this cell in macro atom mode and record jumping probabilities */
-      n_to_track = 0;
       if (geo.rt_mode == 2)
 	{
-	  if (nh > MACRO_TRACKING_DENSITY && n_to_track < MAX_MACRO_TRACKS)	// initially I set this to 1e13
+
+	  if (nh > MACRO_TRACKING_DENSITY && n_to_track < MAX_MACRO_TRACKS)	// initially I set this density to 1e13
 	    {
+	    
 	      matom_track_cells[n_to_track] = n;	// add the plasma number to an array
-	      n_to_track += 1;	// increment the count of cells we are tracking
+	      
+	      macromain[n].stored = 1;
+	      
+	      n_to_track++;	// increment the count of cells we are tracking
+	      
 	    }
+	    
 	  else if (nh > MACRO_TRACKING_DENSITY
 		   && n_to_track < MAX_MACRO_TRACKS)
 	    {
 	      Warning
 		("wind2d macro atom tracking: plasma cell %i has density %8.4e > %8.4e, but already tracking too many macro atoms!\n",
 		 n, nh, MACRO_TRACKING_DENSITY);
+		   macromain[n].stored=0;
+	    }
+	  else
+	    {
+	    macromain[n].stored=0;
 	    }
 	}
+
+
 
 
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */
@@ -442,6 +455,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 /* now dynamically allocate space for the number of cells we have decided to track in macro atom mode */
   if (geo.rt_mode == 2)
     {
+      Log("%i macro atoms have nh higher than %8.2e, so tracking MA probabilities\n", n_to_track, MACRO_TRACKING_DENSITY);
       calloc_jumping (n_to_track, matom_track_cells);
     }
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -346,13 +346,18 @@ be optional which variables beyond here are moved to structures othere than Wind
 
       nh = plasmamain[n].rho * rho2nh;
 
-     /* if the density is sufficiently high then we want to track this cell in macro atom mode and record 
-        its jumping probabilities */
-     /*if (nh > 1.0e13)
+
+     /* JM 131016 -- If we are in macro atom mode and the density is sufficiently high 
+        then we want to track this cell in macro atom mode and record jumping probabilities */
+     if (geo.rt_mode == 2)
        {
-         matom_track_cells[n_to_track] = n;
-         n_to_track += 1;
-       }*/
+       if ( nh > MACRO_TRACKING_DENSITY )	// initially I set this to 1e13
+         {
+           matom_track_cells[n_to_track] = n;	// add the plasma number to an array
+           n_to_track += 1;			// increment the count of cells we are tracking
+         }
+       }
+
 
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */
       if (geo.wind_type == 3)
@@ -426,10 +431,10 @@ be optional which variables beyond here are moved to structures othere than Wind
     }
 
 /* now dynamically allocate space for the number of cells we have decided to track in macro atom mode */
-  /*if (geo.rt_mode = 2)
+  if (geo.rt_mode = 2)
     {
       calloc_jumping (n_to_track,  matom_track_cells);
-    }*/
+    }
       
 
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -346,6 +346,14 @@ be optional which variables beyond here are moved to structures othere than Wind
 
       nh = plasmamain[n].rho * rho2nh;
 
+     /* if the density is sufficiently high then we want to track this cell in macro atom mode and record 
+        its jumping probabilities */
+     if (nh > 1.0e13)
+       {
+         matom_track_cells[n_to_track] = n;
+         n_to_track += 1;
+       }
+
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */
       if (geo.wind_type == 3)
 	{
@@ -356,7 +364,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 	  plasmamain[n].t_r = geo.twind;
 	}
 
-
+ 
 
 
       /* 70b - Initialize the temperature in the torus to a different value */
@@ -416,6 +424,13 @@ be optional which variables beyond here are moved to structures othere than Wind
 	  plasmamain[n].xscatters[j] = 0;
 	}
     }
+
+/* now dynamically allocate space for the number of cells we have decided to track in macro atom mode */
+  if (geo.rt_mode = 2)
+    {
+      calloc_jumping (n_to_track,  matom_track_cells);
+    }
+      
 
 
 /* Calculate the the divergence of the wind at the center of each grid cell */

--- a/wind_updates2d.c
+++ b/wind_updates2d.c
@@ -790,7 +790,29 @@ WindPtr (w);
 
 
 
+  /* JM 131115 -- Finally, we want to set all the stored macro atom 
+     probabilities to unknown. Related to bugfix for #54 */
+  if (geo.rt_mode == 2)
+    {
+      /* m is the level index */
+      for (m = 0; m < nlevels_macro; m++)
+	{
 
+	  /* first set each level m to unknown for 
+	     each of the n matoms we are tracking */
+	  for (n = 0; n < n_macro_tracking; n++)
+	    {
+	      jumps_store[n].known[m] = 0;	// n is the number of the matom we are tracking 
+	    }
+
+	  /* then set the last_matom known values to zero */
+	  last_matom->known[m] = 0;
+	}
+
+      /* set nplasma to some impossible number -- there is no last matom at first! */
+      last_matom->nplasma = -999;
+      
+    }
 
 
 


### PR DESCRIPTION
This is an open pull request which contains JM's attempt at fixing bug #54. **DO NOT MERGE!**

At the moment this involves creating a structure jumps_store which stores macro atom probabilities for any macro atoms with densities > 1e13. There is also a last_matom structure which stores only for the last macro atom. There are a number of additions here
- matom.c: matom() additions to check if a probability is stored
- gridwind.c- new function calloc_jumping() dynamically allocates memory for the arrays within structures, similar to the method employed for the macromain ptr.
- wind2d.c - checks for if the density is high enough to be tracked
- python.h - additional variables, definitions and structures.

Feel free to discuss and post suggestions here.
