### PR TITLE
Fix for q_recomb returning NAN

### DIFF
--- a/get_atomicdata.c
+++ b/get_atomicdata.c
@@ -1310,7 +1310,7 @@ for the ionstate.
 		      if (config[n].n_bfd_jump > NBFJUMPS)
 			{
 			  Error
-			    ("get_atomic_data: Too many downward b-f jump for ion %s\n",
+			    ("get_atomic_data: Too many downward b-f jump for ion %d\n",
 			     config[n].istate);
 			  exit (0);
 			}

--- a/matom.c
+++ b/matom.c
@@ -3036,6 +3036,10 @@ Calculated from inverse of q_ioniz.
 
 JM 1301 -- Edited this to avoid need to call q_ioniz and exponential.
 Should improve speed and stability
+
+This equation comes from considering TE and getting the expression
+q_recomb = 2.07e-16 * gl/gu * exp(E/kT) * q_ioniz
+then substituting the above expression for q_ioniz.
 */
 
 double
@@ -3049,9 +3053,9 @@ q_recomb (cont_ptr, electron_temperature)
 
   gaunt = 0.1;			//for now - from Mihalas for hydrogen
 
-  coeff = 3.2085e-3  / electron_temperature * gaunt * cont_ptr->x[0];
+  coeff = 3.2085e-3  / electron_temperature * gaunt * cont_ptr->x[0];	// normal constants * 1/T times gaunt * cross section
 
-  coeff /= cont_ptr->freq[0] * H_OVER_K;
+  coeff /= cont_ptr->freq[0] * H_OVER_K;			// divide by h nu / k
   coeff *= config[cont_ptr->nlev].g / config[cont_ptr->uplev].g;
 
   return (coeff);

--- a/matom.c
+++ b/matom.c
@@ -3033,6 +3033,9 @@ q_ioniz (cont_ptr, electron_temperature)
 
 /* q_recomb. This returns the collisional recombination co-efficient
 Calculated from inverse of q_ioniz.
+
+JM 1301 -- Edited this to avoid need to call q_ioniz and exponential.
+Should improve speed and stability
 */
 
 double
@@ -3041,15 +3044,15 @@ q_recomb (cont_ptr, electron_temperature)
      double electron_temperature;
 {
   double coeff;
-  double root_etemp;
-  double q_ioniz ();
+  double gaunt;
 
-  root_etemp = sqrt (electron_temperature);
-  coeff = 2.07e-16 / (root_etemp * root_etemp * root_etemp);
-  coeff *= exp (cont_ptr->freq[0] * H_OVER_K / electron_temperature);
+
+  gaunt = 0.1;			//for now - from Mihalas for hydrogen
+
+  coeff = 3.2085e-3  / electron_temperature * gaunt * cont_ptr->x[0];
+
+  coeff /= cont_ptr->freq[0] * H_OVER_K;
   coeff *= config[cont_ptr->nlev].g / config[cont_ptr->uplev].g;
-  coeff *= q_ioniz (cont_ptr, electron_temperature);
-
 
   return (coeff);
 }


### PR DESCRIPTION
q_recomb changed from 

```
 2.07e-16 / (T**3/2) * exp (h nu / kT) * gl/gu * q_ioniz
```

to the equivalent

```
3.2085e-3 * gl / gu  / electron_temperature * gaunt * cont_ptr->x[0] * (k / h nu)
```

to stop the exponential blowing up at low temperatures
