### PR TITLE
Fixed bug in which qdisk structure was incorrectly zeroed before photon ...

### DIFF
--- a/python.c
+++ b/python.c
@@ -1709,17 +1709,6 @@ run -- 07jul -- ksl
 		     top_bot_select, select_extract, rho_select, z_select,
 		     az_select, r_select);
 
-      /* Zero the arrays that store the heating of the disk */
-
-/* 080520 - ksl - There is a conundrum here.  One should really zero out the 
- * quantities below each time the wind structure is updated.  But relatively
- * few photons hit the disk under normal situations, and therefore the statistcs
- * are not very good.  
- */
-      for (n = 0; n < NRINGS; n++)
-	{
-	  qdisk.heat[n] = qdisk.nphot[n] = qdisk.w[n] = qdisk.ave_freq[n] = 0;
-	}
 
       wind_rad_init ();		/*Zero the parameters pertaining to the radiation field */
 
@@ -1764,6 +1753,23 @@ run -- 07jul -- ksl
 	  nphot_to_define = (long) photons_per_cycle;
 
 	  define_phot (p, freqmin, freqmax, nphot_to_define, 0, iwind, 1);
+
+      /* Zero the arrays that store the heating of the disk */
+
+      /* 080520 - ksl - There is a conundrum here.  One should really zero out the 
+       * quantities below each time the wind structure is updated.  But relatively
+       * few photons hit the disk under normal situations, and therefore the statistcs
+       * are not very good.  
+       */
+
+      /* 130213 JM -- previously this was done before define_phot, which meant that
+         the ionization state was never computed with the heated disk */
+
+      for (n = 0; n < NRINGS; n++)
+	{
+	  qdisk.heat[n] = qdisk.nphot[n] = qdisk.w[n] = qdisk.ave_freq[n] = 0;
+	}
+
 
 
 	  photon_checks (p, freqmin, freqmax, "Check before transport");


### PR DESCRIPTION
...generation.

This fixes a silly error in which the heating stored in the qdisk structure was zeroed before it was even used, meaning that the SEDs used for the ionization state was identical if you were using disk illumination mode 2 or mode 0. To fix, I simply move the zeroing line after photon_gen in python.c. I've tested that this fix moves the illuminating SED up to roughly the expected level.

Interestingly in the spectral cycles the SEDs were different because it still had the information from the last ion cycle. 

I just looked in python 58 and the same bug appears to be present there. I'm now a little worried that this may have affected @ssim 's 2005 paper, as a number of reprocessing models were used in that study. 
