### PR TITLE
Moving estimators increments from radiation into subroutines (estimators for PPL ionization solver and IP)

### DIFF
--- a/estimators.c
+++ b/estimators.c
@@ -61,7 +61,7 @@ bf_estimators_increment (one, p, ds)
   double x, ft;
   double y, yy;
   double exponential, heat_contribution;
-  int n, m, llvl, nn, i;
+  int n, m, llvl, nn;
   double sigma_phot_topbase ();
   double density;
   double abs_cont;
@@ -79,54 +79,24 @@ bf_estimators_increment (one, p, ds)
   // the continuum neglect variation of frequency along path and
   // take as a single "average" value.  
 
-  /* JM -- 1310 -- the loop below is if the user requires extra diagnostics and
+  if (p->freq > xplasma->max_freq)  // check if photon frequency exceeds maximum frequency
+    xplasma->max_freq = p->freq;
+
+
+  /* JM -- 1310 -- check if the user requires extra diagnostics and
      has provided a file diag_cells.dat to store photons stats for cells they have specified
    */
   if (diag_on_off == 1 && ncstat > 0)
     {
-      for (i = 0; i < ncstat; i++)
-	{
-	  /* check if the cell is in the specified list */
-	  if (one->nplasma == ncell_stats[i])
-	    {
-	      fprintf (pstatptr,
-		       "PHOTON_DETAILS %3d %8.3e %8.3e %8.3e cell%3d wind cell%3d\n",
-		       geo.wcycle, p->freq, p->w, ds, one->nplasma,
-		       one->nwind);
-	    }
-	}
+      save_photon_stats(one, p, ds);  // save photon statistics (extra diagnostics)
     }
 
-  /*photon weight times distance in the shell is proportional to the mean intensity */
-  xplasma->j += p->w * ds;
 
-  /* frequency weighted by the weights and distance in the shell .  See eqn 2 ML93 */
-  xplasma->mean_ds += ds;
-  xplasma->n_ds++;
-  xplasma->ave_freq += p->freq * p->w * ds;
+  
+  /* JM 1402 -- the banded versions of j, ave_freq etc. are now updated in update_banded_estimators,
+     which also updates the ionization parameters and scattered and direct contributions */
 
-  if (p->freq > xplasma->max_freq)	// check if photon frequency exceeds maximum frequency
-    xplasma->max_freq = p->freq;
-
-  /* 1310 JM -- The next loop updates the banded versions of j and ave_freq, analogously to routine inradiation
-     nxfreq refers to how many frequencies we have defining the bands. So, if we have 5 bands, we have 6 frequencies, 
-     going from xfreq[0] to xfreq[5] Since we are breaking out of the loop when i>=nxfreq, this means the last loop 
-     will be i=nxfreq-1 */
-
-  /* note that here we can use the photon weight and don't need to calculate anm attenuated average weight
-     as energy packets are indisivible in macro atom mode */
-
-  for (i = 0; i < geo.nxfreq; i++)
-    {
-      if (geo.xfreq[i] < p->freq && p->freq <= geo.xfreq[i + 1])
-	{
-	  xplasma->xave_freq[i] += p->freq * p->w * ds;	/* 1310 JM -- frequency weighted by weight and distance */
-	  xplasma->xsd_freq[i] += p->freq * p->freq * p->w * ds;	/* 1310 JM -- input to allow standard deviation to be calculated */
-	  xplasma->xj[i] += p->w * ds;	/* 1310 JM -- photon weight times distance travelled */
-	  xplasma->nxtot[i]++;	/* 1310 JM -- increment the frequency banded photon counter */
-
-	}
-    }
+  update_banded_estimators(xplasma, p, ds, p->w);
 
   /* check that j and ave freq give sensible numbers */
   if (sane_check (xplasma->j) || sane_check (xplasma->ave_freq))
@@ -135,30 +105,6 @@ bf_estimators_increment (one, p, ds)
 	     xplasma->j, xplasma->ave_freq);
     }
 
-
-  /* 1401 JM -- Similarly to the above routines, this is another bit of code added to radiation
-     which therefore did not get called in macro atom mode. Duplicating code is bad practice and
-     we should probably condense these updates of MC estimators into a single subroutine
-     which gets called by both routines -- for the moment I'm leaving as is */
-
-  /* NSH had implemented a scattered and direct contribution to the IP. This doesn't really work 
-     in the same way due to the nature of macro atoms, so should instead be thought of as 
-     'direct from source' and 'reprocessed' radiation */
-  if (HEV * p->freq > 13.6)	// only record if above H ionization edge
-    {
-
-      /* IP needs to be radiation density in the cell. We sum wcontributions from
-         each photon, then it is normalised in wind_update. */
-      xplasma->ip += ((p->w * ds) / (H * p->freq));
-      if (p->nscat == 0)
-	{
-	  xplasma->ip_direct += ((p->w * ds) / (H * p->freq));
-	}
-      else
-	{
-	  xplasma->ip_scatt += ((p->w * ds) / (H * p->freq));
-	}
-    }
 
 
 

--- a/foo.h
+++ b/foo.h
@@ -130,6 +130,8 @@ double sigma_phot_topbase(struct topbase_phot *x_ptr, double freq);
 double sigma_phot_verner(struct innershell *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);
 double pop_kappa_ff_array(void);
+int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w);
+int save_photon_stats(WindPtr one, PhotPtr p, double ds);
 /* wind_updates2d.c */
 int wind_update(WindPtr (w));
 int wind_rad_init(void);

--- a/foo.h
+++ b/foo.h
@@ -130,7 +130,7 @@ double sigma_phot_topbase(struct topbase_phot *x_ptr, double freq);
 double sigma_phot_verner(struct innershell *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);
 double pop_kappa_ff_array(void);
-int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w);
+int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w_ave);
 int save_photon_stats(WindPtr one, PhotPtr p, double ds);
 /* wind_updates2d.c */
 int wind_update(WindPtr (w));

--- a/radiation.c
+++ b/radiation.c
@@ -812,7 +812,7 @@ Arguments:
 	xplasma		PlasmaPtr for the cell
 	p 			Photon pointer
 	ds 			ds travelled
-	w 			the weight of the photon. In non macro atom mode,
+	w_ave 		the weight of the photon. In non macro atom mode,
 	            this is an average weight (passed as w_ave), but 
 	            in macro atom mode weights are never reduced (so p->w 
 	            is used).
@@ -833,24 +833,24 @@ History:
  
 **************************************************************/
 
-int update_banded_estimators (xplasma, p, ds, w)
+int update_banded_estimators (xplasma, p, ds, w_ave)
     PlasmaPtr xplasma;
     PhotPtr p;
     double ds;
-    double w;
+    double w_ave;
 {
   int i;
 
   /*photon weight times distance in the shell is proportional to the mean intensity */
-  xplasma->j += w * ds;
+  xplasma->j += w_ave * ds;
 
   if (p->nscat == 0)
 	{
-  	xplasma->j_direct += w * ds;
+  	xplasma->j_direct += w_ave * ds;
 	}
   else
 	{
-	xplasma->j_scatt += w * ds;
+	xplasma->j_scatt += w_ave * ds;
 	}
 
 
@@ -858,7 +858,7 @@ int update_banded_estimators (xplasma, p, ds, w)
 /* frequency weighted by the weights and distance       in the shell .  See eqn 2 ML93 */
   xplasma->mean_ds += ds;
   xplasma->n_ds++;
-  xplasma->ave_freq += p->freq * w * ds;
+  xplasma->ave_freq += p->freq * w_ave * ds;
 
 
 
@@ -877,9 +877,9 @@ int update_banded_estimators (xplasma, p, ds, w)
       if (geo.xfreq[i] < p->freq && p->freq <= geo.xfreq[i + 1])
 	{
 
-	  xplasma->xave_freq[i] += p->freq * w * ds;	/* 1310 JM -- frequency weighted by weight and distance */
-	  xplasma->xsd_freq[i] += p->freq * p->freq * w * ds;	/* 1310 JM -- input to allow standard deviation to be calculated */
-	  xplasma->xj[i] += w * ds;	/* 1310 JM -- photon weight times distance travelled */
+	  xplasma->xave_freq[i] += p->freq * w_ave * ds;	/* 1310 JM -- frequency weighted by weight and distance */
+	  xplasma->xsd_freq[i] += p->freq * p->freq * w_ave * ds;	/* 1310 JM -- input to allow standard deviation to be calculated */
+	  xplasma->xj[i] += w_ave * ds;	/* 1310 JM -- photon weight times distance travelled */
 	  xplasma->nxtot[i]++;	/* 1310 JM -- increment the frequency banded photon counter */
 
       /* 1311 NSH lines added below to work out the range of frequencies within a band where photons have been seen */
@@ -913,15 +913,15 @@ int update_banded_estimators (xplasma, p, ds, w)
 
       /* IP needs to be radiation density in the cell. We sum wcontributions from
          each photon, then it is normalised in wind_update. */
-      xplasma->ip += ((w * ds) / (H * p->freq));
+      xplasma->ip += ((w_ave * ds) / (H * p->freq));
 
       if (p->nscat == 0)
 	{
-	  xplasma->ip_direct += ((w * ds) / (H * p->freq));
+	  xplasma->ip_direct += ((w_ave * ds) / (H * p->freq));
 	}
       else
 	{
-	  xplasma->ip_scatt += ((w * ds) / (H * p->freq));
+	  xplasma->ip_scatt += ((w_ave * ds) / (H * p->freq));
 	}
     }
 

--- a/radiation.c
+++ b/radiation.c
@@ -125,7 +125,7 @@ radiation (p, ds)
   double frac_ion[NIONS];
   double density, ft, tau, tau2;
   double energy_abs;
-  int n, nion, i;		/* nsh 1108 i added as counter for banded j and ave_freq */
+  int n, nion;
   double q, x, z;
   double w_ave, w_in, w_out;
   double den_config ();
@@ -284,23 +284,8 @@ statement could be deleted entirely 060802 -- ksl */
 
   xplasma->ntot++;
 
-/* NSH 131213 slight change to the line computing IP, we now split out direct and scattered - this was 
-mainly for the progha_13 work, but is of general interest */
-      /* 70h -- nsh -- 111004 added to try to calculate the IP for the cell. Note that 
-       * this may well end up not being correct, since the same photon could be counted 
-       * several times if it is rattling around.... */
-  if (HEV * p->freq > 13.6)
-    {
-      xplasma->ip += ((w_ave * ds) / (H * p->freq));
- if (p->nscat == 0)
-	{
-  	xplasma->ip_direct += ((w_ave * ds) / (H * p->freq));
-	}
-  else
-	{
-	xplasma->ip_scatt += ((w_ave * ds) / (H * p->freq));
-	}
-    }
+
+
 
 /* NSH 15/4/11 Lines added to try to keep track of where the photons are coming from, 
  * and hence get an idea of how 'agny' or 'disky' the cell is. */
@@ -335,72 +320,23 @@ mainly for the progha_13 work, but is of general interest */
     xplasma->ntot_agn++;
 
 
-/*photon weight times distance in the shell is proportional to the mean intensity */
-  xplasma->j += w_ave * ds;
 
-  if (p->nscat == 0)
-	{
-  	xplasma->j_direct += w_ave * ds;
-	}
-  else
-	{
-	xplasma->j_scatt += w_ave * ds;
-	}
-
-
-
-/* frequency weighted by the weights and distance       in the shell .  See eqn 2 ML93 */
-  xplasma->mean_ds += ds;
-  xplasma->n_ds++;
-  xplasma->ave_freq += p->freq * w_ave * ds;
-
-  if (p->freq > xplasma->max_freq)
+  if (p->freq > xplasma->max_freq)  // check if photon frequency exceeds maximum frequency
     xplasma->max_freq = p->freq;
 
+  /* JM -- 1310 -- check if the user requires extra diagnostics and
+     has provided a file diag_cells.dat to store photons stats for cells they have specified
+   */
   if (diag_on_off == 1 && ncstat > 0)
     {
-      for (i = 0; i < ncstat; i++)
-	{
-	  if (one->nplasma == ncell_stats[i])
-	    {
-	      fprintf (pstatptr,
-		       "PHOTON_DETAILS %3d %3d %3d %8.3e %8.3e %8.3e cell%3d wind cell%3d\n",
-		       geo.wcycle, ii, jj, p->freq, w_ave, ds, one->nplasma,
-		       one->nwind);
-	    }
-	}
+      save_photon_stats(one, p, ds); 	// save photon statistics (extra diagnostics)
     }
 
 
-/* 1108 NSH  THe next loop updates the banded versions of j and ave_freq, note that the lines above still update 
- * the parameters for all the photons produced. We are simply controlling which photons are used for the sim powewr 
- * law stuff by banding.
- * nxfreq refers to how many frequencies we have defining the bands. So, if we have 5 bands, we have 6 frequencies, 
- * going from xfreq[0] to xfreq[5] Since we are breaking out of the loop when i>=nxfreq, this means the last loop 
- * will be i=nxfreq-1*/
+  /* JM 1402 -- the banded versions of j, ave_freq etc. are now updated in update_banded_estimators,
+     which also updates the ionization parameters and scattered and direct contributions */
 
-/* 71 - 111229 - ksl - modified to reflect fact that I have moved nxbands and xfreq into the geo structure */
-
-  for (i = 0; i < geo.nxfreq; i++)
-    {
-      if (geo.xfreq[i] < p->freq && p->freq <= geo.xfreq[i + 1])
-	{
-	  xplasma->xave_freq[i] += p->freq * w_ave * ds;	/*1108 NSH/KSL frequency weighted by weight and distance */
-	  xplasma->xsd_freq[i] += p->freq * p->freq * w_ave * ds;	/*1208 NSH imput to allow standard deviation to be calculated */
-	  xplasma->xj[i] += w_ave * ds;	/*1108 NSH/KSL photon weight times distance travelled */
-	  xplasma->nxtot[i]++;	/*1108 NSH increment the frequency banded photon counter */
-/* 1311 NSH lines added below to work out the range of frequencies within a band where photons have been seen */
-	  if (p->freq < xplasma->fmin[i])
-		{
-		xplasma->fmin[i]=p->freq;
-		}
-	  if (p->freq > xplasma->fmax[i]) 
-		{
-		xplasma->fmax[i]=p->freq;
-		}
-	}
-    }
-
+  update_banded_estimators(xplasma, p, ds, w_ave);
 
 
   if (sane_check (xplasma->j) || sane_check (xplasma->ave_freq))
@@ -860,5 +796,191 @@ pop_kappa_ff_array ()
 
   return (0);
 }
+
+
+
+
+/***********************************************************
+                Southampton University
+
+Synopsis: 
+	update_banded_estimators updates the estimators required for
+	mode 7 ionization- the Power law, pairwise, modified saha ionization solver.
+	It also records the values of IP.
+
+Arguments:	
+	xplasma		PlasmaPtr for the cell
+	p 			Photon pointer
+	ds 			ds travelled
+	w 			the weight of the photon. In non macro atom mode,
+	            this is an average weight (passed as w_ave), but 
+	            in macro atom mode weights are never reduced (so p->w 
+	            is used).
+
+Returns:
+	increments the estimators in xplasma
+ 
+Description:	
+	This routine does not contain new code on initial writing, but instead 
+	moves duplicated code from increment_bf_estimators and radiation() 
+	to here, as duplicating code is bad practice.
+
+Notes:
+
+
+History:
+   1402 JM 		Coding began
+ 
+**************************************************************/
+
+int update_banded_estimators (xplasma, p, ds, w)
+    PlasmaPtr xplasma;
+    PhotPtr p;
+    double ds;
+    double w;
+{
+  int i;
+
+  /*photon weight times distance in the shell is proportional to the mean intensity */
+  xplasma->j += w * ds;
+
+  if (p->nscat == 0)
+	{
+  	xplasma->j_direct += w * ds;
+	}
+  else
+	{
+	xplasma->j_scatt += w * ds;
+	}
+
+
+
+/* frequency weighted by the weights and distance       in the shell .  See eqn 2 ML93 */
+  xplasma->mean_ds += ds;
+  xplasma->n_ds++;
+  xplasma->ave_freq += p->freq * w * ds;
+
+
+
+  /* 1310 JM -- The next loop updates the banded versions of j and ave_freq, analogously to routine inradiation
+  nxfreq refers to how many frequencies we have defining the bands. So, if we have 5 bands, we have 6 frequencies, 
+  going from xfreq[0] to xfreq[5] Since we are breaking out of the loop when i>=nxfreq, this means the last loop 
+  will be i=nxfreq-1 */
+
+  /* note that here we can use the photon weight and don't need to calculate anm attenuated average weight
+     as energy packets are indisivible in macro atom mode */
+
+  /* 71 - 111229 - ksl - modified to reflect fact that I have moved nxbands and xfreq into the geo structure */
+
+  for (i = 0; i < geo.nxfreq; i++)
+    {
+      if (geo.xfreq[i] < p->freq && p->freq <= geo.xfreq[i + 1])
+	{
+
+	  xplasma->xave_freq[i] += p->freq * w * ds;	/* 1310 JM -- frequency weighted by weight and distance */
+	  xplasma->xsd_freq[i] += p->freq * p->freq * w * ds;	/* 1310 JM -- input to allow standard deviation to be calculated */
+	  xplasma->xj[i] += w * ds;	/* 1310 JM -- photon weight times distance travelled */
+	  xplasma->nxtot[i]++;	/* 1310 JM -- increment the frequency banded photon counter */
+
+      /* 1311 NSH lines added below to work out the range of frequencies within a band where photons have been seen */
+	  if (p->freq < xplasma->fmin[i])
+		{
+		  xplasma->fmin[i]=p->freq;
+		}
+	  if (p->freq > xplasma->fmax[i]) 
+		{
+		  xplasma->fmax[i]=p->freq;
+		}
+
+	}
+    }
+
+  /* NSH 131213 slight change to the line computing IP, we now split out direct and scattered - this was 
+     mainly for the progha_13 work, but is of general interest */
+  /* 70h -- nsh -- 111004 added to try to calculate the IP for the cell. Note that 
+   * this may well end up not being correct, since the same photon could be counted 
+   * several times if it is rattling around.... */
+
+  /* 1401 JM -- Similarly to the above routines, this is another bit of code added to radiation
+     which originally did not get called in macro atom mode. */
+
+  /* NSH had implemented a scattered and direct contribution to the IP. This doesn't really work 
+     in the same way in macro atoms, so should instead be thought of as 
+     'direct from source' and 'reprocessed' radiation */
+
+  if (HEV * p->freq > 13.6)	// only record if above H ionization edge
+    {
+
+      /* IP needs to be radiation density in the cell. We sum wcontributions from
+         each photon, then it is normalised in wind_update. */
+      xplasma->ip += ((w * ds) / (H * p->freq));
+
+      if (p->nscat == 0)
+	{
+	  xplasma->ip_direct += ((w * ds) / (H * p->freq));
+	}
+      else
+	{
+	  xplasma->ip_scatt += ((w * ds) / (H * p->freq));
+	}
+    }
+
+  return (0);
+}
+
+
+
+
+/***********************************************************
+                Southampton University
+
+Synopsis: 
+	save_photon_stats prints photon statistics to a file
+
+Arguments:	
+	One 		WindPtr for the cell
+	p 			Photon pointer
+	ds 			ds travelled
+
+Returns:
+ 
+Description:
+   the loop below is if the user requires extra diagnostics and
+   has provided a file diag_cells.dat to store photons stats for cells they have specified
+
+Notes:
+   Moved here to save duplicating code between bf_estimators_increment and radiation.
+
+History:
+   1402 JM 		Coding began
+ 
+**************************************************************/
+
+
+int save_photon_stats(one, p, ds)
+    WindPtr one;
+    PhotPtr p;
+    double ds;
+{
+  int i;
+
+  /* JM -- 1310 -- the loop below is if the user requires extra diagnostics and
+     has provided a file diag_cells.dat to store photons stats for cells they have specified
+   */
+
+  for (i = 0; i < ncstat; i++)
+	{
+	  /* check if the cell is in the specified list - ncell_stats is global variable */
+	  if (one->nplasma == ncell_stats[i])
+	    {
+	      fprintf (pstatptr,
+		       "PHOTON_DETAILS %3d %8.3e %8.3e %8.3e cell%3d wind cell%3d\n",
+		       geo.wcycle, p->freq, p->w, ds, one->nplasma,
+		       one->nwind);
+	    }
+	}
+  return (0);
+}
+
 
 

--- a/templates.h
+++ b/templates.h
@@ -130,6 +130,8 @@ double sigma_phot_topbase(struct topbase_phot *x_ptr, double freq);
 double sigma_phot_verner(struct innershell *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);
 double pop_kappa_ff_array(void);
+int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w);
+int save_photon_stats(WindPtr one, PhotPtr p, double ds);
 /* wind_updates2d.c */
 int wind_update(WindPtr (w));
 int wind_rad_init(void);

--- a/templates.h
+++ b/templates.h
@@ -130,7 +130,7 @@ double sigma_phot_topbase(struct topbase_phot *x_ptr, double freq);
 double sigma_phot_verner(struct innershell *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);
 double pop_kappa_ff_array(void);
-int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w);
+int update_banded_estimators(PlasmaPtr xplasma, PhotPtr p, double ds, double w_ave);
 int save_photon_stats(WindPtr one, PhotPtr p, double ds);
 /* wind_updates2d.c */
 int wind_update(WindPtr (w));

--- a/wind2d.c
+++ b/wind2d.c
@@ -839,7 +839,7 @@ wind_div_v (w)
       vwind_xyz (&ppp, v2);
       ppp.x[2] -= delta;
       vwind_xyz (&ppp, v1);
-      div += xxx[2] = (v2[1] - v1[1]) / delta;
+      div += xxx[2] = (v2[2] - v1[2]) / delta;
 
 
       /* we have now evaluated the divergence, so can store in the wind pointer */


### PR DESCRIPTION
Currently we duplicate code between radiation() and bf_estimators_increment(), which are the corresponding routines which increment estimators in non-macro atom and macro atom mode when a photon travels ds inside a cell.

To avoid this, I've moved all the duplicated incrementing to a subroutine called update_banded_estimators(). This routine
- updates j, j_direct, j_scatter
- updates ip, ip_direct, ip_scatter
- updates the banded estimators we use e.g. xave_freq, xj etc for each band
- updates n_ds, mean_ds and ave_freq

I've also moved the part where photon stats are saved to a file as part of Extra_diagnostics to a new subroutine called save_photon_stats.

This shouldn't change how anything works and is merely to avoid duplication. Only files modified are radiation.c and estimators.c
