### PR TITLE
Fix for Bug #73. Now use frequency shifted to frame of cell then averaged

### DIFF
--- a/radiation.c
+++ b/radiation.c
@@ -166,13 +166,15 @@ radiation (p, ds)
   freq = 0.5 * (freq_inner + freq_outer);
 
 
-  
+
+  /* calculate free-free, compton and ind-compton opacities 
+     note that we also call these with the average frequency along ds */
 
   kappa_tot = frac_ff = kappa_ff (xplasma, freq);	/* Add ff opacity */
   kappa_tot += frac_comp = kappa_comp (xplasma, freq);	/* 70 NSH 1108 calculate compton opacity, store it in kappa_comp and also add it to kappa_tot, the total opacity for the photon path */
   kappa_tot += frac_ind_comp = kappa_ind_comp (xplasma, freq);
   frac_tot = frac_z = 0;	/* 59a - ksl - Moved this line out of loop to avoid warning, but notes 
-				   indicate this is all disagnostic and might be removed */
+				                           indicate this is all disagnostic and might be removed */
 
 
   if (freq > phot_freq_min)

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
-#define VERSION  "77a_dev"
+#define VERSION  "ff"
 #define CHOICE 1 // Compress plasma as much as possible

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
-#define VERSION  "ff"
+#define VERSION  "77a_dev"
 #define CHOICE 1 // Compress plasma as much as possible


### PR DESCRIPTION
This is the first initial fix for Bug #73.  

We now choose doppler shift the frequency of the photon to the rest frame of the cell in question when calculated the continuum opacities. These opacities are use to work out both the heating contribution and the weight reduction of the photon in question. 

Note that as KSL pointed out, this is not the best we can do and we may cross an edge over the frequency difference between the initial position and the initial position + ds. This may want to be improved to have something which checks if an edge has been crossed.
