### PR TITLE
Added errors for -ve rates, moved macro_pops call out of elements loop

### DIFF
--- a/matom.c
+++ b/matom.c
@@ -1375,7 +1375,8 @@ History:
                        - some treatment of metastables is needed for 
                        doing CNO macro atoms.
 	06may	ksl	57+ -- Modified to reflect plasma structue
-
+    1404 	jm  77a -- Added test to check that populations are solution to rate matrix equation in macro_pops
+                       + more robust erro reporting in general. See pull request #75.
 ************************************************************/
 
 int

--- a/matom.c
+++ b/matom.c
@@ -1546,6 +1546,11 @@ macro_pops (xplasma, xne)
 
 		      rate_matrix[lower][lower] += -1. * rate;
 		      rate_matrix[upper][lower] += rate;
+
+		      if (rate < 0.0 || sane_check(rate))
+		      {
+		      	Error("macro_pops: bbu rate is %8.4e in cell/matom %i\n", rate, xplasma->nplasma);
+		      }
 		    }
 
 		  for (index_bbd = 0;
@@ -1571,6 +1576,11 @@ macro_pops (xplasma, xne)
 
 		      rate_matrix[upper][upper] += -1. * rate;
 		      rate_matrix[lower][upper] += rate;
+
+		      if (rate < 0.0 || sane_check(rate))
+		      {
+		      	Error("macro_pops: bbd rate is %8.4e in cell/matom %i\n", rate, xplasma->nplasma);
+		      }
 		    }
 
 
@@ -1601,6 +1611,11 @@ macro_pops (xplasma, xne)
 		      rate_matrix[lower][lower] += -1. * rate;
 		      rate_matrix[upper][lower] += rate;
 
+		      if (rate < 0.0 || sane_check(rate))
+		      {
+		      	Error("macro_pops: bfu rate is %8.4e in cell/matom %i\n", rate, xplasma->nplasma);
+		      }
+
 		      /* Now deal with the stimulated emission. */
 		      /* Lower and upper are the same, but now it contributes in the
 		         other direction. */
@@ -1612,6 +1627,11 @@ macro_pops (xplasma, xne)
 
 		      rate_matrix[upper][upper] += -1. * rate;
 		      rate_matrix[lower][upper] += rate;
+
+		      if (rate < 0.0 || sane_check(rate))
+		      {
+		      	Error("macro_pops: st. recomb rate is %8.4e in cell/matom %i\n", rate, xplasma->nplasma);
+		      }
 
 		    }
 
@@ -1649,6 +1669,11 @@ macro_pops (xplasma, xne)
 
 		      rate_matrix[upper][upper] += -1. * rate;
 		      rate_matrix[lower][upper] += rate;
+
+		      if (rate < 0.0 || sane_check(rate))
+		      {
+		      	Error("macro_pops: bfd rate is %8.4e in cell/matom %i\n", rate, xplasma->nplasma);
+		      }
 		    }
 		}
 	    }
@@ -1762,7 +1787,7 @@ macro_pops (xplasma, xne)
 		   ion[index_ion].first_nlte_level + ion[index_ion].nlte;
 		   index_lvl++)
 		{
-		  this_ion_density += gsl_vector_get (populations, nn);
+		  this_ion_density += gsl_vector_get (populations, conf_to_matrix[index_lvl]);
 		  nn++;
 		}
 

--- a/my_linalg.h
+++ b/my_linalg.h
@@ -400,5 +400,21 @@ int gsl_linalg_bidiag_unpack_B (const gsl_matrix * A,
 int gsl_linalg_balance_columns (gsl_matrix * A, gsl_vector * D);
 
 
+/* JM 140414 -- I've had to include a few definitions from gsl/gsl_cblas.h and gsl/gsl_blas_types.h here
+   instead of including the files, as some of the variables conflicted with python */
+
+typedef  enum CBLAS_TRANSPOSE   CBLAS_TRANSPOSE_t;
+enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+
+/* we use this function to multiply matrices together and check if our populations matrix
+   is a solution to the rate equations */
+int  gsl_blas_dgemv (CBLAS_TRANSPOSE_t TransA,
+                     double alpha,
+                     const gsl_matrix * A,
+                     const gsl_vector * X,
+                     double beta,
+                     gsl_vector * Y);
+
+
 __END_DECLS
 #endif /* __GSL_LINALG_H__ */

--- a/saha.c
+++ b/saha.c
@@ -653,19 +653,18 @@ lucy (xplasma)
 
 	  lucy_mazzali1 (nh, t_r, t_e, www, nelem, xplasma->ne,
 			 xplasma->density, xne, newden);
+  }
 
-	  /* Re solve for the macro atom populations with the current guess for ne */
-          /* JM1308 -- note that unlike lucy mazzali above, here we actually modify the xplasma
-	     structure for those ions which are being treated as macro ions. This means that the
-	     the newden array will contain wrong values for these particular macro ions, but due
-             to the if loop at the end of this subroutine they are never passed to xplasma */
-
+    /* Re solve for the macro atom populations with the current guess for ne */
+    /* JM1308 -- note that unlike lucy mazzali above, here we actually modify the xplasma
+       structure for those ions which are being treated as macro ions. This means that the
+       the newden array will contain wrong values for these particular macro ions, but due
+       to the if loop at the end of this subroutine they are never passed to xplasma */
 	  if (geo.macro_ioniz_mode == 1)
 	    {
 	      macro_pops (xplasma, xne);
 	    }
 
-	}
 
       for (nion = 0; nion < nions; nion++)
 	{


### PR DESCRIPTION
Some more robust errors and checks in macro_pops, and also a correction of a small error in saha.c which caused macro_pops to be called more times than necessary.
