### PR TITLE
Dynamic allocation of NION dimensioned arrays in plasma structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ LDFLAGS= -L$(LIB) -L$(LIB2)  -lm -lcfitsio -lgsl -lgslcblas
 
 #Note that version should be a single string without spaces. 
 
-VERSION = 78a_dev
+VERSION = 78a_dev_nsh
 
 CHOICE=1             // Compress plasma as much as possible
 # CHOICE=0           //  Keep relation between plasma and wind identical

--- a/foo.h
+++ b/foo.h
@@ -403,6 +403,7 @@ int calloc_plasma(int nelem);
 int check_plasma(PlasmaPtr xplasma, char message[]);
 int calloc_macro(int nelem);
 int calloc_estimators(int nelem);
+int calloc_dyn_plasma(int nelem);
 /* partition.c */
 int partition_functions(PlasmaPtr xplasma, int mode);
 int partition_functions_2(PlasmaPtr xplasma, int xnion, double temp, double weight);

--- a/gridwind.c
+++ b/gridwind.c
@@ -728,9 +728,7 @@ calloc_dyn_plasma (nelem)
 {
   int n;
 
-printf ("NSH Doing calloc dyn for %i elements\n",nelem);
-
-for (n=0;n<nelem+2;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
+for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
 	{
   	if ((plasmamain[n].density =calloc (sizeof (double), nions)) == NULL)
 	{

--- a/gridwind.c
+++ b/gridwind.c
@@ -214,7 +214,7 @@ calloc_plasma (nelem)
     }
   else
     {
-      Log_silent
+      Log
 	("Allocated %10d bytes for each of %5d elements of      plasma totaling %10.1f Mb \n",
 	 sizeof (plasma_dummy), (nelem + 1),
 	 1.e-6 * (nelem + 1) * sizeof (plasma_dummy));
@@ -689,6 +689,127 @@ calloc_estimators (nelem)
     {
       Log_silent ("Allocated no space for macro since nlevels_macro==0\n");
     }
+
+  return (0);
+}
+
+/***********************************************************
+                                       West Lulworth
+
+ Synopsis:
+	This subroutine allocates space for dynamic arrays in the plasma 
+	structure
+
+ Arguments:
+	nelem - the number of plasma cells (actually NPLASMA+1) to allow for empty cell
+
+	
+ Returns:
+
+
+Description:
+	This subroutine allocates space for variable length arrays in the plasma structure.
+	This is to save space over the previous versions of python, which allocated arrays
+	based on guesses as to the lengths. 
+
+Notes:
+	Arrays sized to the number of ions are largest,
+	and dominate the size of nplasma, so these were first to be dynamically allocated.
+
+History:
+	1407	nsh	Started out allocating arrays that have length nion
+
+**************************************************************/
+
+
+int
+calloc_dyn_plasma (nelem)
+     int nelem;
+{
+  int n;
+
+
+
+for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
+	{
+  	if ((plasmamain[n].density =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for density\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].partition =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for partition\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].PWdenom =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for PWdenom\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].PWdtemp =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for PWtemp\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].PWnumer =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for PWnumer\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].PWntemp =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for PWntemp\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].ioniz =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for ioniz\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].recomb =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for recomb\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].scatters =calloc (sizeof (int), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for scatters\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].xscatters =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for xscatters\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].heat_ion =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for heat_ion\n");
+	  exit (0);
+	}
+	if ((plasmamain[n].lum_ion =calloc (sizeof (double), nions)) == NULL)
+	{
+	  Error
+	    ("calloc_dyn_plasma: Error in allocating memory for lum_ion\n");
+	  exit (0);	
+	}
+}
+
+     Log
+	("Allocated %10d bytes for each of %5d elements variable length plasma arrays totaling %10.1f Mb \n",
+	 sizeof (double)*nions*12, (nelem+1),
+	 1.e-6 * (nelem+1 ) * sizeof (double)*nions*12);
 
   return (0);
 }

--- a/gridwind.c
+++ b/gridwind.c
@@ -214,7 +214,7 @@ calloc_plasma (nelem)
     }
   else
     {
-      Log
+      Log_silent
 	("Allocated %10d bytes for each of %5d elements of      plasma totaling %10.1f Mb \n",
 	 sizeof (plasma_dummy), (nelem + 1),
 	 1.e-6 * (nelem + 1) * sizeof (plasma_dummy));
@@ -806,7 +806,7 @@ for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding
 	}
 }
 
-     Log
+     Log_silent
 	("Allocated %10d bytes for each of %5d elements variable length plasma arrays totaling %10.1f Mb \n",
 	 sizeof (double)*nions*12, (nelem+1),
 	 1.e-6 * (nelem+1 ) * sizeof (double)*nions*12);

--- a/gridwind.c
+++ b/gridwind.c
@@ -730,7 +730,7 @@ calloc_dyn_plasma (nelem)
 
 printf ("NSH Doing calloc dyn for %i elements\n",nelem);
 
-for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
+for (n=0;n<nelem+2;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
 	{
   	if ((plasmamain[n].density =calloc (sizeof (double), nions)) == NULL)
 	{

--- a/gridwind.c
+++ b/gridwind.c
@@ -728,7 +728,7 @@ calloc_dyn_plasma (nelem)
 {
   int n;
 
-
+printf ("NSH Doing calloc dyn for %i elements\n",nelem);
 
 for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding one for an empty cell used for extrapolations.
 	{
@@ -806,7 +806,7 @@ for (n=0;n<nelem+1;n++)  //We loop over all elements in the plasma array, adding
 	}
 }
 
-     Log_silent
+     Log
 	("Allocated %10d bytes for each of %5d elements variable length plasma arrays totaling %10.1f Mb \n",
 	 sizeof (double)*nions*12, (nelem+1),
 	 1.e-6 * (nelem+1 ) * sizeof (double)*nions*12);

--- a/python.h
+++ b/python.h
@@ -517,6 +517,8 @@ plasma in regions of the geometry that are actually included n the wind
 /* ksl - It would probably make more sense to define these in the same ways that bands are done for the generation of photons, or to
  * do both the same way at least.  Choosing to do this in two different ways makes the program confusing. The structure that has
  * the photon generation is called xband */
+/* 78 - 1407 - NSH - changed several elements (initially those of size nions) in the plasma array to by dynamically allocated.
+They are now pointers in the array. */
 
 
 typedef struct plasma
@@ -527,21 +529,21 @@ typedef struct plasma
   double rho;			/*density at the center of the cell */
   double vol;			/* valid volume of this cell (more specifically the volume of one of the
 				   two annular regions that this cell represents). */
-  double density[NIONS];	/*The number density of a specific ion.  This needs to correspond
-				   to the ion order obtained by get_atomic_data */
-  double partition[NIONS];	/*The partition function for each  ion */
+  double *density;	/*The number density of a specific ion.  This needs to correspond
+				   to the ion order obtained by get_atomic_data. 78 - changed to dynamic allocation*/
+  double *partition;	/*The partition function for each  ion. 78 - changed to dynamic allocation */
   double levden[NLTE_LEVELS];	/*The number density (occupation number?) of a specific level */
 
-  double PWdenom[NIONS];	/*The denominator in the pairwise ionization solver. Sicne this is computed at a temperature 
+  double *PWdenom;	/*The denominator in the pairwise ionization solver. Sicne this is computed at a temperature 
 				   chosen from basic ioinzation proerties to be good for this ion, it should not change
 				   very much from cycle to cycle - hence we shold be able to speed up the code by storing 
-				   it and refering to it if the temperature has not changed much */
-  double PWdtemp[NIONS];	/*The temperature at which the pairwise denominator was calculated last */
-  double PWnumer[NIONS];	/* The numberator in the pairwise approach. When we are chasing the true density
+				   it and refering to it if the temperature has not changed much. 78 - changed to dynamic allocation */
+  double *PWdtemp;	/*The temperature at which the pairwise denominator was calculated last. 78 - changed to dynamic allocation */
+  double *PWnumer;	/* The numberator in the pairwise approach. When we are chasing the true density
 				   by carying n_e - this value will not change, so we canspeed things up a lot
-				   by not recomputing it! */
-  double PWntemp[NIONS];	/* The temperature at which the stored pairwise numerator was last computed at. This
-				   is used in the BB version of the pairwise correction factor */
+				   by not recomputing it!. 78 - changed to dynamic allocation */
+  double *PWntemp;	/* The temperature at which the stored pairwise numerator was last computed at. This
+				   is used in the BB version of the pairwise correction factor. 78 - changed to dynamic allocation */
 
   double kappa_ff_factor;	/* Multiplicative factor for calculating the FF heating for                                      a photon. */
 
@@ -605,15 +607,15 @@ typedef struct plasma
   int n_ds;			/* NSH 6/9/12 Added to allow the mean dsto be computed */
   int nrad;			/* Total number of photons radiated within the cell */
   int nioniz;			/* Total number of photons capable of ionizing H */
-  double ioniz[NIONS], recomb[NIONS];	/* Number of ionizations and recombinations for each ion.
+  double *ioniz, *recomb;	/* Number of ionizations and recombinations for each ion.
 					   The sense is ionization from ion[n], and recombinations 
-					   to each ion[n] */
-  int scatters[NIONS];		/* 68b - The number of scatters in this cell for each ion. */
-  double xscatters[NIONS];	/* 68b - Diagnostic measure of energy scattered out of beam on extract */
-  double heat_ion[NIONS];	/* The amount of energy being transferred to the electron pool
-				   sby this ion via photoionization */
-  double lum_ion[NIONS];	/* The amount of energy being released from the electron pool
-				   by this ion via recombination */
+					   to each ion[n] . 78 - changed to dynamic allocation*/
+  int *scatters;		/* 68b - The number of scatters in this cell for each ion. 78 - changed to dynamic allocation*/
+  double *xscatters;	/* 68b - Diagnostic measure of energy scattered out of beam on extract. 78 - changed to dynamic allocation */
+  double *heat_ion;	/* The amount of energy being transferred to the electron pool
+				   sby this ion via photoionization. 78 - changed to dynamic allocation */
+  double *lum_ion;	/* The amount of energy being released from the electron pool
+				   by this ion via recombination. 78 - changed to dynamic allocation */
   double j, ave_freq, lum;	/*Respectively mean intensity, intensity_averaged frequency, 
 				   luminosity and absorbed luminosity of shell */
   double xj[NXBANDS], xave_freq[NXBANDS];	/* 1108 NSH frequency limited versions of j and ave_freq */

--- a/radiation.c
+++ b/radiation.c
@@ -846,6 +846,7 @@ History:
    1212	ksl	Added sane check; note that this routine
    		is poorly documented.  Somewhere this 
 		should be discribed better.  
+   1407 nsh	changed loop to only go over NPLASMA cells not NPLASMA+1
  
 **************************************************************/
 
@@ -858,7 +859,7 @@ pop_kappa_ff_array ()
   int i, j;
 
 
-  for (i = 0; i < NPLASMA + 1; i++)
+  for (i = 0; i < NPLASMA ; i++)  //Changed to loop only up to NPLASMA, not NPLASMA+1
     {
       sum = 0.0;
       for (j = 0; j < nions; j++)

--- a/templates.h
+++ b/templates.h
@@ -403,6 +403,7 @@ int calloc_plasma(int nelem);
 int check_plasma(PlasmaPtr xplasma, char message[]);
 int calloc_macro(int nelem);
 int calloc_estimators(int nelem);
+int calloc_dyn_plasma(int nelem);
 /* partition.c */
 int partition_functions(PlasmaPtr xplasma, int mode);
 int partition_functions_2(PlasmaPtr xplasma, int xnion, double temp, double weight);

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
-#define VERSION  "78a_dev"
+#define VERSION  "78a_dev_nsh"
 #define CHOICE 1 // Compress plasma as much as possible

--- a/wind2d.c
+++ b/wind2d.c
@@ -333,6 +333,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 printf ("about to do density\n");
       plasmamain[n].rho = model_rho (x);
 printf ("done density\n");
+printf ("nwind=%i\n",nwind);
       plasmamain[n].vol = w[nwind].vol;	// Copy volumes
 printf ("done volumes\n");
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */

--- a/wind2d.c
+++ b/wind2d.c
@@ -327,7 +327,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 
   for (n = 0; n < NPLASMA; n++)
     {
-	
+	printf ("doing cell %i\n",n);
       nwind = plasmamain[n].nwind;
       stuff_v (w[nwind].xcen, x);
       plasmamain[n].rho = model_rho (x);
@@ -348,6 +348,7 @@ be optional which variables beyond here are moved to structures othere than Wind
           plasmamain[n].fmax_mod[nn] = geo.xfreq[i]; /* Set the maximum model frequency to the min frequency in the band */
 	}
 
+printf ("done initialising models\n");
       nh = plasmamain[n].rho * rho2nh;
 
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */
@@ -389,7 +390,7 @@ be optional which variables beyond here are moved to structures othere than Wind
 	}
       else
 	plasmamain[n].w = 0.5;	//Modification to allow for possibility that grid point is inside star
-
+printf ("about to do initial concentrations\n");
       /* Determine the initial ionizations, either LTE or  fixed_concentrations */
       if (geo.ioniz_mode != IONMODE_FIXED)
 	{			/* Carry out an LTE determination of the ionization */

--- a/wind2d.c
+++ b/wind2d.c
@@ -339,26 +339,31 @@ printf ("done volumes\n");
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */
       for (nn = 0; nn < NXBANDS; nn++)
 	{
-printf ("Band %i\n",nn);
+printf ("1Band %i\n",nn);
 
 	  plasmamain[n].spec_mod_type[nn] = -1;	/*NSH 120817 - setting this to a negative number means that at the outset, we assume we do not have a suitable model for the cell */
-printf ("Band %i\n",nn);
+printf ("2Band %i\n",nn);
 	  plasmamain[n].exp_temp[nn] = geo.tmax;	/*NSH 120817 - as an initial guess, set this number to the hottest part of the model - this should define where any exponential dropoff becomes important */
-printf ("Band %i\n",nn);
+printf ("3Band %i\n",nn);
 	  plasmamain[n].exp_w[nn] = 0.0;	/* 120817 Who knows what this should be! */
-printf ("Band %i\n",nn);
+printf ("4Band %i\n",nn);
 	  plasmamain[n].pl_alpha[nn] = geo.alpha_agn;	//As an initial guess we assume the whole wind is optically thin and so the spectral index for a PL illumination will be the same everywhere.
-printf ("Band %i\n",nn);
+printf ("5Band %i\n",nn);
 	  /*     plasmamain[n].pl_w[nn] = geo.const_agn / (4.0*PI*(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]));  // constant / area of a sphere
 	     plasmamain[n].pl_w[nn] /= 4.*PI;   // take account of solid angle NSH 120817 removed - if PL not suitable, it will be set to zero anyway, so safe to keep it at zero from the outset! */
 //	  plasmamain[n].pl_w[nn] = 0.0;
 	  plasmamain[n].pl_log_w[nn] = -1e99; /*131114 - a tiny weight - just to fill the variable */ 
-printf ("Band %i\n",nn);
+printf ("6Band %i\n",nn);
           plasmamain[n].fmin_mod[nn] = geo.xfreq[i+1]; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
-printf ("Band %i\n",nn);
+printf ("7Band %i\n",nn);
           plasmamain[n].fmax_mod[nn] = geo.xfreq[i]; /* Set the maximum model frequency to the min frequency in the band */
 	}
 
+printf ("done initialising models\n");
+printf ("done initialising models\n");
+printf ("done initialising models\n");
+printf ("done initialising models\n");
+printf ("done initialising models\n");
 printf ("done initialising models\n");
       nh = plasmamain[n].rho * rho2nh;
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -340,15 +340,22 @@ printf ("done volumes\n");
       for (nn = 0; nn < NXBANDS; nn++)
 	{
 printf ("Band %i\n",nn);
+
 	  plasmamain[n].spec_mod_type[nn] = -1;	/*NSH 120817 - setting this to a negative number means that at the outset, we assume we do not have a suitable model for the cell */
+printf ("Band %i\n",nn);
 	  plasmamain[n].exp_temp[nn] = geo.tmax;	/*NSH 120817 - as an initial guess, set this number to the hottest part of the model - this should define where any exponential dropoff becomes important */
+printf ("Band %i\n",nn);
 	  plasmamain[n].exp_w[nn] = 0.0;	/* 120817 Who knows what this should be! */
+printf ("Band %i\n",nn);
 	  plasmamain[n].pl_alpha[nn] = geo.alpha_agn;	//As an initial guess we assume the whole wind is optically thin and so the spectral index for a PL illumination will be the same everywhere.
+printf ("Band %i\n",nn);
 	  /*     plasmamain[n].pl_w[nn] = geo.const_agn / (4.0*PI*(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]));  // constant / area of a sphere
 	     plasmamain[n].pl_w[nn] /= 4.*PI;   // take account of solid angle NSH 120817 removed - if PL not suitable, it will be set to zero anyway, so safe to keep it at zero from the outset! */
 //	  plasmamain[n].pl_w[nn] = 0.0;
 	  plasmamain[n].pl_log_w[nn] = -1e99; /*131114 - a tiny weight - just to fill the variable */ 
+printf ("Band %i\n",nn);
           plasmamain[n].fmin_mod[nn] = geo.xfreq[i+1]; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
+printf ("Band %i\n",nn);
           plasmamain[n].fmax_mod[nn] = geo.xfreq[i]; /* Set the maximum model frequency to the min frequency in the band */
 	}
 

--- a/wind2d.c
+++ b/wind2d.c
@@ -330,7 +330,9 @@ be optional which variables beyond here are moved to structures othere than Wind
 	printf ("doing cell %i\n",n);
       nwind = plasmamain[n].nwind;
       stuff_v (w[nwind].xcen, x);
+printf ("about to do density\n");
       plasmamain[n].rho = model_rho (x);
+printf ("done density\n");
       plasmamain[n].vol = w[nwind].vol;	// Copy volumes
 
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */

--- a/wind2d.c
+++ b/wind2d.c
@@ -354,6 +354,10 @@ printf ("5Band %i\n",nn);
 //	  plasmamain[n].pl_w[nn] = 0.0;
 	  plasmamain[n].pl_log_w[nn] = -1e99; /*131114 - a tiny weight - just to fill the variable */ 
 printf ("6Band %i\n",nn);
+printf ("i=%i\n",i);
+printf ("xfreq[i+1]=%e\n",geo.xfreq[i+1]);
+printf ("xfreq[i]=%e\n",geo.xfreq[i]);
+
           plasmamain[n].fmin_mod[nn] = geo.xfreq[i+1]; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
 printf ("7Band %i\n",nn);
           plasmamain[n].fmax_mod[nn] = geo.xfreq[i]; /* Set the maximum model frequency to the min frequency in the band */

--- a/wind2d.c
+++ b/wind2d.c
@@ -308,7 +308,6 @@ recreated when a windfile is read into the program
   else				/* Force NPLASMA to equal NDIM2 (for diagnostic reasons) */
     {
       NPLASMA = NDIM2;
-
     }
 
   calloc_plasma (NPLASMA);

--- a/wind2d.c
+++ b/wind2d.c
@@ -354,13 +354,11 @@ printf ("5Band %i\n",nn);
 //	  plasmamain[n].pl_w[nn] = 0.0;
 	  plasmamain[n].pl_log_w[nn] = -1e99; /*131114 - a tiny weight - just to fill the variable */ 
 printf ("6Band %i\n",nn);
-printf ("i=%i\n",i);
-printf ("xfreq[i+1]=%e\n",geo.xfreq[i+1]);
-printf ("xfreq[i]=%e\n",geo.xfreq[i]);
 
-          plasmamain[n].fmin_mod[nn] = geo.xfreq[i+1]; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
+
+          plasmamain[n].fmin_mod[nn] = 1e99; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
 printf ("7Band %i\n",nn);
-          plasmamain[n].fmax_mod[nn] = geo.xfreq[i]; /* Set the maximum model frequency to the min frequency in the band */
+          plasmamain[n].fmax_mod[nn] = 1e-99; /* Set the maximum model frequency to the min frequency in the band */
 	}
 
 printf ("done initialising models\n");

--- a/wind2d.c
+++ b/wind2d.c
@@ -338,6 +338,7 @@ printf ("done density\n");
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */
       for (nn = 0; nn < NXBANDS; nn++)
 	{
+printf ("Band %i\n",nn);
 	  plasmamain[n].spec_mod_type[nn] = -1;	/*NSH 120817 - setting this to a negative number means that at the outset, we assume we do not have a suitable model for the cell */
 	  plasmamain[n].exp_temp[nn] = geo.tmax;	/*NSH 120817 - as an initial guess, set this number to the hottest part of the model - this should define where any exponential dropoff becomes important */
 	  plasmamain[n].exp_w[nn] = 0.0;	/* 120817 Who knows what this should be! */

--- a/wind2d.c
+++ b/wind2d.c
@@ -334,7 +334,7 @@ printf ("about to do density\n");
       plasmamain[n].rho = model_rho (x);
 printf ("done density\n");
       plasmamain[n].vol = w[nwind].vol;	// Copy volumes
-
+printf ("done volumes\n");
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */
       for (nn = 0; nn < NXBANDS; nn++)
 	{

--- a/wind2d.c
+++ b/wind2d.c
@@ -71,6 +71,8 @@ History:
 	13sep	nsh	small change to avoid the muliplicatoin by 0.9 (lucy guess) from giving us the 				wrong zeus temperature.
 	13nov	nsh	changes to take account of log formulation of power law
 			also initialise the min and max frequencies seen in a band.
+	14jul	nsh	added call to calloc_dyn_plasma to allocate space for arrays of variable size - currently
+			those with length nion.
 
 **************************************************************/
 
@@ -310,6 +312,7 @@ recreated when a windfile is read into the program
     }
 
   calloc_plasma (NPLASMA);
+  calloc_dyn_plasma (NPLASMA); /*78a NSH 1407 - allocate space for dynamically sized arrays*/
   xplasma = plasmamain;
   create_maps (CHOICE);		// Populate the maps from plasmamain & wmain
 
@@ -408,7 +411,8 @@ be optional which variables beyond here are moved to structures othere than Wind
       /* 68b - Initialize the scatters array 73d - and the pariwise ionization denominator and temperature
        */
 
-      for (j = 0; j < NIONS; j++)
+      for (j = 0; j < nions; j++) /* NSH 1107 - changed this loop to loop over nions rather than NIONS. Dynamic
+	allocation means that these arrays are no longer of length NIONS */
 	{
 	  plasmamain[n].PWdenom[j] = 0.0;
 	  plasmamain[n].PWnumer[j] = 0.0;
@@ -1042,9 +1046,10 @@ zero_scatters ()
 {
   int n, j;
 
-  for (n = 0; n < NPLASMA; n++)
+  for (n = 0; n < NPLASMA; n++) /*NSH 1107 - changed loop to only run over nions to avoid running over the 
+	end of the array after the arry was dynamically allocated in 78a */
     {
-      for (j = 0; j < NIONS; j++)
+      for (j = 0; j < nions; j++)
 	{
 	  plasmamain[n].scatters[j] = 0;
 	}

--- a/wind2d.c
+++ b/wind2d.c
@@ -327,46 +327,27 @@ be optional which variables beyond here are moved to structures othere than Wind
 
   for (n = 0; n < NPLASMA; n++)
     {
-	printf ("doing cell %i\n",n);
       nwind = plasmamain[n].nwind;
       stuff_v (w[nwind].xcen, x);
-printf ("about to do density\n");
       plasmamain[n].rho = model_rho (x);
-printf ("done density\n");
-printf ("nwind=%i\n",nwind);
       plasmamain[n].vol = w[nwind].vol;	// Copy volumes
-printf ("done volumes\n");
 /* NSH 120817 This is where we initialise the spectral models for the wind. The pl stuff is old, I've put new things in here to initialise the exponential models */
       for (nn = 0; nn < NXBANDS; nn++)
 	{
-printf ("1Band %i\n",nn);
-
 	  plasmamain[n].spec_mod_type[nn] = -1;	/*NSH 120817 - setting this to a negative number means that at the outset, we assume we do not have a suitable model for the cell */
-printf ("2Band %i\n",nn);
 	  plasmamain[n].exp_temp[nn] = geo.tmax;	/*NSH 120817 - as an initial guess, set this number to the hottest part of the model - this should define where any exponential dropoff becomes important */
-printf ("3Band %i\n",nn);
 	  plasmamain[n].exp_w[nn] = 0.0;	/* 120817 Who knows what this should be! */
-printf ("4Band %i\n",nn);
 	  plasmamain[n].pl_alpha[nn] = geo.alpha_agn;	//As an initial guess we assume the whole wind is optically thin and so the spectral index for a PL illumination will be the same everywhere.
-printf ("5Band %i\n",nn);
 	  /*     plasmamain[n].pl_w[nn] = geo.const_agn / (4.0*PI*(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]));  // constant / area of a sphere
 	     plasmamain[n].pl_w[nn] /= 4.*PI;   // take account of solid angle NSH 120817 removed - if PL not suitable, it will be set to zero anyway, so safe to keep it at zero from the outset! */
 //	  plasmamain[n].pl_w[nn] = 0.0;
 	  plasmamain[n].pl_log_w[nn] = -1e99; /*131114 - a tiny weight - just to fill the variable */ 
-printf ("6Band %i\n",nn);
 
 
           plasmamain[n].fmin_mod[nn] = 1e99; /* Set the minium model frequency to the max frequency in the band - means it will never be used which is correct at this time - there is no model */
-printf ("7Band %i\n",nn);
           plasmamain[n].fmax_mod[nn] = 1e-99; /* Set the maximum model frequency to the min frequency in the band */
 	}
 
-printf ("done initialising models\n");
-printf ("done initialising models\n");
-printf ("done initialising models\n");
-printf ("done initialising models\n");
-printf ("done initialising models\n");
-printf ("done initialising models\n");
       nh = plasmamain[n].rho * rho2nh;
 
 /* NSH 130530 Next few lines allow the use of the temperature which can be computed from Zeus models to be used as an initial guess for the wind temperature */

--- a/wind_updates2d.c
+++ b/wind_updates2d.c
@@ -80,6 +80,9 @@ History:
    	13jul	nsh	76: added lines to deal with the case when adiacaitc cooling becomes heating in
 			complex wind geometries
 	13nov	nsh	77: Some changes in the parallel communications for new variables.
+	14jul	nsh	78a: Changed the length of the communications array to take account of
+			dynamically allocated arrays in plasma structure. Also changed some of the pack
+			and unpack commands for the same reason.
 
 
 **************************************************************/
@@ -111,8 +114,9 @@ WindPtr (w);
   int size_of_commbuffer;
   char *commbuffer;
 
-  /* the commbuffer needs to be larger enough to pack all variables in MPI_Pack and MPI_Unpack routines */
-  size_of_commbuffer = 8 * (12*NIONS + NLTE_LEVELS + 2*NTOP_PHOT + 12*NXBANDS + 2*LPDF + NAUGER + 104)*(floor(NPLASMA/np_mpi_global)+1);
+  /* the commbuffer needs to be larger enough to pack all variables in MPI_Pack and MPI_Unpack routines NSH 1407 - the 
+NIONS changed to nions for the 12 arrays in plasma that are now dynamically allocated*/
+  size_of_commbuffer = 8 * (12*nions + NLTE_LEVELS + 2*NTOP_PHOT + 12*NXBANDS + 2*LPDF + NAUGER + 104)*(floor(NPLASMA/np_mpi_global)+1);
       
   commbuffer = (char *) malloc(size_of_commbuffer*sizeof(char));
       
@@ -330,13 +334,13 @@ WindPtr (w);
 	      MPI_Pack(&plasmamain[n].ne, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].rho, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].vol, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].density, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].partition, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].density, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].partition, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(plasmamain[n].levden, NLTE_LEVELS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].PWdenom, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].PWdtemp, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].PWnumer, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].PWntemp, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].PWdenom, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].PWdtemp, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].PWnumer, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].PWntemp, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].kappa_ff_factor, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].nscat_es, 1, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD); 
 	      MPI_Pack(plasmamain[n].recomb_simple, NTOP_PHOT, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
@@ -371,12 +375,12 @@ WindPtr (w);
 	      MPI_Pack(&plasmamain[n].n_ds, 1, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].nrad, 1, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].nioniz, 1, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].ioniz, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].recomb, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].scatters, NIONS, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].xscatters, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].heat_ion, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
-	      MPI_Pack(plasmamain[n].lum_ion, NIONS, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].ioniz, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].recomb, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].scatters, nions, MPI_INT, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].xscatters, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].heat_ion, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+	      MPI_Pack(plasmamain[n].lum_ion, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].j, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].j_direct, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
 	      MPI_Pack(&plasmamain[n].j_scatt, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
@@ -459,13 +463,13 @@ WindPtr (w);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].ne, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].rho, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].vol, 1, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].density, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].partition, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].density, nions, MPI_DOUBLE, MPI_COMM_WORLD);
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].partition, nions, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].levden, NLTE_LEVELS, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWdenom, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWdtemp, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWnumer, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWntemp, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWdenom, nions, MPI_DOUBLE, MPI_COMM_WORLD);
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWdtemp, nions, MPI_DOUBLE, MPI_COMM_WORLD);
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWnumer, nions, MPI_DOUBLE, MPI_COMM_WORLD);
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].PWntemp, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].kappa_ff_factor, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].nscat_es, 1, MPI_INT, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].recomb_simple, NTOP_PHOT, MPI_DOUBLE, MPI_COMM_WORLD);	  
@@ -500,12 +504,12 @@ WindPtr (w);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].n_ds, 1, MPI_INT, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].nrad, 1, MPI_INT, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].nioniz, 1, MPI_INT, MPI_COMM_WORLD);
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].ioniz, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].recomb, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].scatters, NIONS, MPI_INT, MPI_COMM_WORLD);	  
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].xscatters, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].heat_ion, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
-	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].lum_ion, NIONS, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].ioniz, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].recomb, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].scatters, nions, MPI_INT, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].xscatters, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].heat_ion, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
+	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, plasmamain[n].lum_ion, nions, MPI_DOUBLE, MPI_COMM_WORLD);	  
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].j, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].j_direct, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 	      MPI_Unpack(commbuffer, size_of_commbuffer, &position, &plasmamain[n].j_scatt, 1, MPI_DOUBLE, MPI_COMM_WORLD);

--- a/windsave.c
+++ b/windsave.c
@@ -40,6 +40,8 @@ History:
 			to allow python to restart. Modified the call to
 			wind_save to eliminate superfluous passing of
 			the wind ptr.
+	14jul	nsh	78a - Added code to allow dynamically allocated arrays
+			in the plasma structure to be read in and written out.
  
 **************************************************************/
 
@@ -72,6 +74,32 @@ wind_save (filename)
   n += fwrite (&geo, sizeof (geo), 1, fptr);
   n += fwrite (wmain, sizeof (wind_dummy), NDIM2, fptr);
   n += fwrite (plasmamain, sizeof (plasma_dummy), NPLASMA, fptr);
+
+/* NSH 1407 - The following loop writes out the variable length arrays
+in the plasma structure */
+      for (m = 0; m < NPLASMA; m++)
+{
+  n += fwrite (plasmamain[m].density,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].partition,sizeof(double),nions,fptr);
+
+  n += fwrite (plasmamain[m].PWdenom,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].PWdtemp,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].PWnumer,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].PWntemp,sizeof(double),nions,fptr);
+
+  n += fwrite (plasmamain[m].ioniz,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].recomb,sizeof(double),nions,fptr);
+
+  n += fwrite (plasmamain[m].scatters,sizeof(int),nions,fptr);
+  n += fwrite (plasmamain[m].xscatters,sizeof(double),nions,fptr);
+
+  n += fwrite (plasmamain[m].heat_ion,sizeof(double),nions,fptr);
+  n += fwrite (plasmamain[m].lum_ion,sizeof(double),nions,fptr);
+}
+
+
+
+
   if (geo.nmacro)
     {
       n += fwrite (macromain, sizeof (macro_dummy), NPLASMA, fptr);
@@ -138,6 +166,7 @@ wind_save (filename)
 11dec	ksl	Updated so returns -1 if it cannot open the windsave file.  This
 		was done to enable one to handle missing files differently in
 		different cases
+14jul	nsh	Code added to read in variable length arrays in plasma structure
 */
 int
 wind_read (filename)
@@ -184,7 +213,32 @@ wind_read (filename)
   n += fread (wmain, sizeof (wind_dummy), NDIM2, fptr);
 
   calloc_plasma (NPLASMA);
+
   n += fread (plasmamain, sizeof (plasma_dummy), NPLASMA, fptr);
+
+  calloc_dyn_plasma (NPLASMA); /*NSH 1407 allocate space for the dynamically allocated plasma arrays */
+  for (m = 0; m < NPLASMA; m++)
+{
+
+  n += fread (plasmamain[m].density,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].partition,sizeof(double),nions,fptr);
+
+  n += fread (plasmamain[m].PWdenom,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].PWdtemp,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].PWnumer,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].PWntemp,sizeof(double),nions,fptr);
+
+  n += fread (plasmamain[m].ioniz,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].recomb,sizeof(double),nions,fptr);
+
+  n += fread (plasmamain[m].scatters,sizeof(int),nions,fptr);
+  n += fread (plasmamain[m].xscatters,sizeof(double),nions,fptr);
+
+  n += fread (plasmamain[m].heat_ion,sizeof(double),nions,fptr);
+  n += fread (plasmamain[m].lum_ion,sizeof(double),nions,fptr);
+}
+
+
 
   if (geo.nmacro > 0)
     {


### PR DESCRIPTION
Very large models (e.g. PK04 zeus model) use a great deal of memory to hold the plasma array. This change dynamically allocates memory for all 12 arrays in the plasma structure that were of length NIONS. This has approximately halved the size of a typical windsave file, and hence the memory usage to store the plasma structure. This related to issue #93.
