### PR TITLE
Reporting issues from mean_intensity

### DIFF
--- a/python.h
+++ b/python.h
@@ -1102,3 +1102,8 @@ int cell_phot_stats;		//1=do  it, 0=dont do it
 #define  NCSTAT 10		//The maximum number of cells we are going to log
 int ncstat;			// the actual number we are going to log
 int ncell_stats[NCSTAT];	//the numbers of the cells we are going to log
+
+
+
+int nerr_no_Jmodel;
+int nerr_Jmodel_wrong_freq;

--- a/python.h
+++ b/python.h
@@ -1104,6 +1104,6 @@ int ncstat;			// the actual number we are going to log
 int ncell_stats[NCSTAT];	//the numbers of the cells we are going to log
 
 
-
+/* Added variables which count number of times two situations occur (See #91) */
 int nerr_no_Jmodel;
 int nerr_Jmodel_wrong_freq;

--- a/wind2d.c
+++ b/wind2d.c
@@ -450,6 +450,10 @@ be optional which variables beyond here are moved to structures othere than Wind
   dvds_ave ();
   wind_check (w, -1);		// Check the wind for reasonability
 
+  /* zero the counters which record diagnositcs from mean_intensity */
+  nerr_Jmodel_wrong_freq = 0;
+  nerr_no_Jmodel = 0;
+
 /*
      Check that m_dot is correct.  This calculation is very approximate.  It only calculates mdot
      flowing up through the grid, i.e. any material that leaks out the side will not be counted.  A

--- a/wind_updates2d.c
+++ b/wind_updates2d.c
@@ -712,7 +712,7 @@ free (commbuffer);
   	  	     nerr_Jmodel_wrong_freq / 1e6);
 
 
-  /* zero the counters which record diagnositcs from mean_intensity */
+  /* zero the counters which record diagnositics from mean_intensity */
   nerr_Jmodel_wrong_freq = 0;
   nerr_no_Jmodel = 0;
 

--- a/wind_updates2d.c
+++ b/wind_updates2d.c
@@ -639,26 +639,26 @@ free (commbuffer);
   for (nplasma = 0; nplasma < NPLASMA; nplasma++)
     {
       if (sane_check (plasmamain[nplasma].heat_tot))
-	Error ("wind_update:sane_check w\[%d).heat_tot is %e\n", nplasma,
+	Error ("wind_update:sane_check w(%d).heat_tot is %e\n", nplasma,
 	       plasmamain[nplasma].heat_tot);
       if (sane_check (plasmamain[nplasma].heat_photo))
-	Error ("wind_update:sane_check w\[%d).heat_photo is %e\n", nplasma,
+	Error ("wind_update:sane_check w(%d).heat_photo is %e\n", nplasma,
 	       plasmamain[nplasma].heat_photo);
       if (sane_check (plasmamain[nplasma].heat_photo_macro))
-	Error ("wind_update:sane_check w\[%d).heat_photo_macro is %e\n",
+	Error ("wind_update:sane_check w(%d).heat_photo_macro is %e\n",
 	       nplasma, plasmamain[nplasma].heat_photo_macro);
       if (sane_check (plasmamain[nplasma].heat_ff))
-	Error ("wind_update:sane_check w\[%d).heat_ff is %e\n", nplasma,
+	Error ("wind_update:sane_check w(%d).heat_ff is %e\n", nplasma,
 	       plasmamain[nplasma].heat_ff);
       if (sane_check (plasmamain[nplasma].heat_lines))
-	Error ("wind_update:sane_check w\[%d).heat_lines is %e\n", nplasma,
+	Error ("wind_update:sane_check w(%d).heat_lines is %e\n", nplasma,
 	       plasmamain[nplasma].heat_lines);
       if (sane_check (plasmamain[nplasma].heat_lines_macro))
-	Error ("wind_update:sane_check w\[%d}).heat_lines_macro is %e\n",
+	Error ("wind_update:sane_check w(%d).heat_lines_macro is %e\n",
 	       nplasma, plasmamain[nplasma].heat_lines_macro);
       /* 1108 NSH extra Sane check for compton heating */
       if (sane_check (plasmamain[nplasma].heat_comp))
-	Error ("wind_update:sane_check w\[%d).heat_comp is %e\n", nplasma,
+	Error ("wind_update:sane_check w(%d).heat_comp is %e\n", nplasma,
 	       plasmamain[nplasma].heat_comp);
       xsum += plasmamain[nplasma].heat_tot;
       psum += plasmamain[nplasma].heat_photo;
@@ -701,6 +701,27 @@ free (commbuffer);
   geo.lum_bl_ioniz = geo.lum_bl;
   geo.lum_wind_ioniz = geo.lum_wind;
   geo.lum_tot_ioniz = geo.lum_tot;
+
+  /* Added this system which counts number of times two situations occur (See #91)
+     We only report these every 100,000 times (one can typically get ) */
+
+  if (nerr_no_Jmodel > 1e5)
+    Log ("wind_update: mean_intensity: %i x10^5 occurrences this cycle of no model exists in a band, in mean intensity\n",
+  	  	      nerr_no_Jmodel / 1e5);
+
+  if (nerr_Jmodel_wrong_freq > 1e5)
+    Log ("wind_update: %i x10^5 occurrences this cycle of photon freq is outside frequency range of spectral model, in mean intensity\n",
+  	  	     nerr_Jmodel_wrong_freq / 1e5);
+
+  if (nerr_Jmodel_wrong_freq > 1e5 || nerr_no_Jmodel > 1e5)
+    {
+      Log ("wind_update: if the above numbers are >10^6 or so there could be a problem\n");
+      Log ("wind_update: check errors in spectral_estimators and low photon warnings in wind_update\n");
+    }
+
+  /* zero the counters which record diagnositcs from mean_intensity */
+  nerr_Jmodel_wrong_freq = 0;
+  nerr_no_Jmodel = 0;
 
 
 

--- a/wind_updates2d.c
+++ b/wind_updates2d.c
@@ -704,20 +704,13 @@ free (commbuffer);
 
   /* Added this system which counts number of times two situations occur (See #91)
      We only report these every 100,000 times (one can typically get ) */
+  Log ("wind_update: note, errors from mean intensity can be high in a working model\n");
+  Log ("wind_update: can be a problem with photon numbers if errors from spectral_estimators and low photon number warnings\n");
+  Log ("wind_update: mean_intensity: %i x10^6 occurrences, this cycle, this thread of 'no model exists in a band'\n",
+  	  	      nerr_no_Jmodel / 1e6);
+  Log ("wind_update: mean intensity: %i x10^6 occurrences, this cycle, this thread of 'photon freq is outside frequency range of spectral model'\n",
+  	  	     nerr_Jmodel_wrong_freq / 1e6);
 
-  if (nerr_no_Jmodel > 1e5)
-    Log ("wind_update: mean_intensity: %i x10^5 occurrences this cycle of no model exists in a band, in mean intensity\n",
-  	  	      nerr_no_Jmodel / 1e5);
-
-  if (nerr_Jmodel_wrong_freq > 1e5)
-    Log ("wind_update: %i x10^5 occurrences this cycle of photon freq is outside frequency range of spectral model, in mean intensity\n",
-  	  	     nerr_Jmodel_wrong_freq / 1e5);
-
-  if (nerr_Jmodel_wrong_freq > 1e5 || nerr_no_Jmodel > 1e5)
-    {
-      Log ("wind_update: if the above numbers are >10^6 or so there could be a problem\n");
-      Log ("wind_update: check errors in spectral_estimators and low photon warnings in wind_update\n");
-    }
 
   /* zero the counters which record diagnositcs from mean_intensity */
   nerr_Jmodel_wrong_freq = 0;


### PR DESCRIPTION
Fix for #91

@kslong - have added counter which counts number of times the two situations we encounter in mean_intensity occur. Then  report with a log statement in wind_updates which looks like this

``` C
/* Added this system which counts number of times two situations occur (See #91)
     We only report these every 100,000 times (one can typically get ) */
  Log ("wind_update: note, errors from mean intensity can be high in a working model\n");
  Log ("wind_update: can be a problem with photon numbers if errors from spectral_estimators and low photon number warnings\n");
  Log ("wind_update: mean_intensity: %i x10^6 occurrences, this cycle, this thread of 'no model exists in a band'\n",
              nerr_no_Jmodel / 1e6);
  Log ("wind_update: mean intensity: %i x10^6 occurrences, this cycle, this thread of 'photon freq is outside frequency range of spectral model'\n",
             nerr_Jmodel_wrong_freq / 1e6);
```

Few other cosmetic changes too. If you're happy I'll merge.
