### PR TITLE
Adopted astropy file formats for spectrum and py_wind, and updated py_read_output.py

### DIFF
--- a/source/py_wind_write.c
+++ b/source/py_wind_write.c
@@ -148,6 +148,10 @@ are linear, and x otherwise.  This is not particularly transparent ?? ksl */
 
       if (geo.coord_type == SPHERICAL)
 	{
+    
+    /* JM 1411 -- added header for reading with astropy ascii module */
+    fprintf (fptr, "r var inwind i\n");
+
 	  for (i = 0; i < NDIM; i++)
 	    {
 	      fprintf (fptr, "%8.2e %8.2e %3d %3d \n", wmain[i].r, aaa[i],
@@ -156,6 +160,10 @@ are linear, and x otherwise.  This is not particularly transparent ?? ksl */
 	}
       else
 	{
+
+    /* JM 1411 -- added header for reading with astropy ascii module */
+    fprintf (fptr, "x z var inwind i j\n");
+
 	  for (i = 0; i < NDIM2; i++)
 	    {
 	      wind_n_to_ij (i, &ii, &jj);
@@ -200,6 +208,9 @@ are linear, and x otherwise.  This is not particularly transparent ?? ksl */
       fprintf (fptr, "# Resampled outputs\n");
       for (jj = 0; jj < ODIM; jj++)
 	{
+    /* JM 1411 -- added header for reading with astropy ascii module */
+    fprintf (fptr, "r z var\n");
+
 	  z = zmin + (zmax - zmin) * jj / (ODIM - 1);
 	  for (ii = 0; ii < ODIM; ii++)
 	    {

--- a/source/spectra.c
+++ b/source/spectra.c
@@ -690,8 +690,8 @@ spectrum_summary (filename, mode, nspecmin, nspecmax, select_spectype, renorm,
 
 
   /* Write the rest of the header for the spectrum file */
-
-  fprintf (fptr, "# \n# Freq.        Lambda");
+  /* JM 1411 -- Removed comment line for column headers, see #122 */
+  fprintf (fptr, "# \nFreq.        Lambda");
 
   for (n = nspecmin; n <= nspecmax; n++)
     {


### PR DESCRIPTION
Spectrum formats are now

```
Freq.        Lambda  Created  Emitted   CenSrc  Disk     Wind     HitSurf Scattered A10P0.50 
1.499187e+15 1999.700  2.07e-12 2.07e-12 2.07e-12        0        0        0        0 5.39e-12
```

i.e. the headers are not commented.

py_wind outputs are now

```
# TITLE= "sv.ne.dat"
# Coord_Sys CYLIND
x z var inwind i j
1.4000e+09 3.5000e+08 0.00e+00  -2   0   0
1.4000e+09 8.0805e+08 0.00e+00  -1   0   1
```

for 2d systems and 

```
# TITLE= "sv.ne.dat"
# Coord_Sys SPHERICAL
r var inwind i 
1.4000e+09  0.00e+00  -2   0  
```

for 1d systems.

This is originally raised in issue #122 . Diagnostic outputs should be updated once #120 is merged. 

This pull request has also updated some python scripts in py_progs. Using these is described [here](https://github.com/agnwinds/python/wiki/Useful-python-commands-for-reading-and-processing-outputs).
