### PR TITLE
added factors of geo.fill to routines which increment heating estimators

### DIFF
--- a/source/compton.c
+++ b/source/compton.c
@@ -177,7 +177,7 @@ total_comp (one, t_e)
   xplasma = &plasmamain[nplasma];	//copy the plasma structure for that cell to local variable
 
   x = 16. * PI * THOMPSON * BOLTZMANN / (MELEC * C * C);	//Keep all the constants together
-  x *= xplasma->ne * one->vol * xplasma->j * t_e;	//multiply by the volume (from wind) and j (from plasma) and t_e
+  x *= xplasma->ne * xplasma->vol * xplasma->j * t_e;	//multiply by the volume (from wind) and j (from plasma) and t_e
 
 
   return (x);

--- a/source/compton.c
+++ b/source/compton.c
@@ -68,6 +68,8 @@ kappa_comp (xplasma, freq)
 
   x = (sigma * H) / (MELEC * C * C);	//Calculate the constant
   x *= xplasma->ne * freq;	//Multiply by cell electron density and frequency of the packet.
+
+  x *= geo.fill;    // multiply by the filling factor- should cancel with density enhancement
   return (x);
 }
 
@@ -128,6 +130,8 @@ kappa_ind_comp (xplasma, freq)
   x = (xplasma->ne) / (MELEC);
   x *= sigma * J;		// NSH 130214 factor of THOMPSON removed, since alpha is now the actual compton cross section
   x *= 1 / (2 * freq * freq);
+
+  x *= geo.fill;    // multiply by the filling factor- should cancel with density enhancement
 
   if (sane_check (x)) //For some reason we have a problem
     {

--- a/source/dielectronic.c
+++ b/source/dielectronic.c
@@ -179,7 +179,7 @@ total_dr (one, t_e)
       else
 	{
 	  x +=
-	    one->vol * xplasma->ne * xplasma->density[n +
+	    xplasma->vol * xplasma->ne * xplasma->density[n +
 						      1] * dr_coeffs[n] *
 	    meanke;
 	}

--- a/source/direct_ion.c
+++ b/source/direct_ion.c
@@ -149,7 +149,7 @@ total_di (one, t_e)
 	{
 
 	  x +=
-	    one->vol * xplasma->ne * xplasma->density[n] * di_coeffs[n] *
+	    xplasma->vol * xplasma->ne * xplasma->density[n] * di_coeffs[n] *
 	    dere_di_rate[ion[n].nxderedi].xi*EV2ERGS;
 //printf ("n=%i V=%e ne=%e rho=%e coeff=%e xi=%e cooling=%e\n",n, V , xplasma->ne , xplasma->density[n] , di_coeffs[n] ,
 //	    dere_di_rate[ion[n].nxderedi].xi*EV2ERGS,x);

--- a/source/emission.c
+++ b/source/emission.c
@@ -322,7 +322,7 @@ adiabatic_cooling (one, t)
   xplasma = &plasmamain[nplasma];
 
   //JM 1401 -- here was an old factor of 3/2 which KSL and JM believe to be incorrect. 
-  cooling = xplasma->ne * BOLTZMANN * t * one->vol * one->div_v;
+  cooling = xplasma->ne * BOLTZMANN * t * xplasma->vol * one->div_v;
 
   return (cooling);
 }
@@ -686,7 +686,7 @@ total_free (one, t_e, f1, f2)
       x = BREMS_CONSTANT * xplasma->ne * (sum) / H_OVER_K;
     }
 
-  x *= sqrt (t_e) * one->vol;
+  x *= sqrt (t_e) * xplasma->vol;
   x *= (exp (-H_OVER_K * f1 / t_e) - exp (-H_OVER_K * f2 / t_e));
 
   return (x);
@@ -780,7 +780,7 @@ ff (one, t_e, freq)
     }
 
 
-  fnu *= exp (-H_OVER_K * freq / t_e) / sqrt (t_e) * one->vol;
+  fnu *= exp (-H_OVER_K * freq / t_e) / sqrt (t_e) * xplasma->vol;
 
   return (fnu);
 

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -128,7 +128,7 @@ bf_estimators_increment (one, p, ds)
 
 	  if (phot_top[n].macro_info == 1 && geo.macro_simple == 0)	// it is a macro atom
 	    {
-	      x = kap_bf[nn] / density;	//this is the cross section
+	      x = kap_bf[nn] / (density * geo.fill);	//this is the cross section
 
 	      /* Now identify which of the BF processes from this level this is. */
 
@@ -150,20 +150,29 @@ bf_estimators_increment (one, p, ds)
 	      // Now calculate the contributions and add them on.
 	      weight_of_packet = p->w;
 	      y = weight_of_packet * x * ds;
+
 	      exponential =
 		y * exp (-(freq_av - ft) / BOLTZMANN / xplasma->t_e);
+
 	      mplasma->gamma[config[llvl].bfu_indx_first + m] += y / freq_av;
+
 	      mplasma->alpha_st[config[llvl].bfu_indx_first + m] +=
 		exponential / freq_av;
+
 	      mplasma->gamma_e[config[llvl].bfu_indx_first + m] += y / ft;
+
 	      mplasma->alpha_st_e[config[llvl].bfu_indx_first + m] +=
 		exponential / ft;
 
 	      /* Now record the contribution to the energy absorbed by macro atoms. */
-	      yy = y * den_config (xplasma, llvl);
+        /* JM1411 -- added filling factor - density enhancement cancels with geo.fill */
+	      yy = y * den_config (xplasma, llvl) * geo.fill;
+
 	      mplasma->matom_abs[phot_top[n].uplev] += abs_cont =
 		yy * ft / freq_av;
+
 	      xplasma->kpkt_abs += yy - abs_cont;
+
 	      /* the following is just a check that flags packets that appear to travel a 
 	         suspiciously large optical depth in the continuum */
 	      if ((yy / weight_of_packet) > 50)
@@ -186,8 +195,11 @@ bf_estimators_increment (one, p, ds)
 		  weight_of_packet = p->w;
 		  y = weight_of_packet * x * ds;
 
+ 
+      /* JM1411 -- added filling factor - density enhancement cancels with geo.fill */
 		  xplasma->heat_photo += heat_contribution =
-		    y * density * (1.0 - (ft / freq_av));
+		    y * density * (1.0 - (ft / freq_av)) * geo.fill;
+
 		  xplasma->heat_tot += heat_contribution;
 		  /* This heat contribution is also the contibution to making k-packets in this volume. So we record it. */
 
@@ -196,6 +208,9 @@ bf_estimators_increment (one, p, ds)
 	    }
 	}
     }
+
+  /* JM1411 -- the below processes have the factor geo.fill incorporated directly
+     into the kappa subroutines */
 
   /* Now for contribution to heating due to ff processes. (SS, Apr 04) */
 

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -260,7 +260,7 @@ bf_estimators_increment (one, p, ds)
 	  x = sigma_phot_verner (&augerion[n], freq_av);	//this is the cross section
 	  y = weight_of_packet * x * ds;
 
-	  xplasma->gamma_inshl[n] += y / freq_av / H / one->vol;
+	  xplasma->gamma_inshl[n] += y / freq_av / H / xplasma->vol;
 	}
     }
 
@@ -473,7 +473,8 @@ mc_estimator_normalise (n)
   mplasma = &macromain[xplasma->nplasma];
 
   /* All the estimators need the volume so get that first. */
-  volume = one->vol;
+  /* JM 1411 - changed to use filled volume */
+  volume = xplasma->vol;
 
   /* bf estimators. During the mc calculation the quantity stored
      was weight * cross-section * path-length / frequency.
@@ -703,7 +704,7 @@ total_fb_matoms (xplasma, t_e, f1, f2)
 		 - mplasma->alpha_st_old[config[i].bfu_indx_first + j]
 		 - alpha_sp (cont_ptr, xplasma, 0))
 		* H * phot_top[config[i].bfu_jump[j]].freq[0] * density *
-		xplasma->ne * wmain[xplasma->nwind].vol;
+		xplasma->ne * xplasma->vol;
 
 	      /* Now add the collisional ionization term. */
 	      density = den_config (xplasma, cont_ptr->nlev);
@@ -711,7 +712,7 @@ total_fb_matoms (xplasma, t_e, f1, f2)
 		q_ioniz (cont_ptr,
 			 t_e) * density * xplasma->ne * H *
 		phot_top[config[i].bfu_jump[j]].freq[0] *
-		wmain[xplasma->nwind].vol;
+		xplasma->vol;
 
 	      /* That's the bf cooling contribution. */
 	      total += cool_contribution;
@@ -782,7 +783,7 @@ total_bb_cooling (xplasma, t_e)
 	  lower_density = den_config (xplasma, line_ptr->nconfigl);
 	  cool_contribution =
 	    (lower_density * q12 (line_ptr, t_e)) * xplasma->ne *
-	    wmain[xplasma->nwind].vol * line_ptr->freq * H;
+	    xplasma->vol * line_ptr->freq * H;
 	}
       else
 	{			//It's a simple line - don't know the level populations
@@ -801,7 +802,7 @@ total_bb_cooling (xplasma, t_e)
 	    (lower_density * line_ptr->gu / line_ptr->gl -
 	     upper_density) * coll_rate / (exp (H_OVER_K * line_ptr->freq /
 						t_e) -
-					   1.) * wmain[xplasma->nwind].vol *
+					   1.) * xplasma->vol *
 	    line_ptr->freq * H;
 
 
@@ -850,6 +851,7 @@ History:
           May 04  SS   Corrections made to get energy rather than number of heating events.
           May 04  SS   Macro_simple option added (for all ions to be "simple")
 	06may	ksl	57+ -- Modified for plasma structue.  Note that volume is used
+  1411  JM  changed to use filled volume
           
 ************************************************************/
 
@@ -876,7 +878,7 @@ macro_bb_heating (xplasma, t_e)
 	  heat_contribution =
 	    upper_density * q21 (line_ptr,
 				 t_e) * xplasma->ne *
-	    wmain[xplasma->nwind].vol * line_ptr->freq * H;
+	    xplasma->vol * line_ptr->freq * H;
 	  total += heat_contribution;
 	}
     }
@@ -917,6 +919,7 @@ History:
                      but with the inclusion of three body recombination it makes
                      more sense to put it all in one subroutine.
 	06may	ksl	57+ -- Modified for plama structue
+  1411  JM  changed to use filled volume
           
 ************************************************************/
 
@@ -947,7 +950,7 @@ macro_bf_heating (xplasma, t_e)
 	    (mplasma->gamma_e_old[config[i].bfu_indx_first + j] -
 	     mplasma->gamma_old[config[i].bfu_indx_first + j]) * H *
 	    phot_top[config[i].bfu_jump[j]].freq[0] * lower_density *
-	    wmain[xplasma->nwind].vol;
+	    xplasma->vol;
 
 	  /* Three body recombination part. */
 	  upper_density =
@@ -955,7 +958,7 @@ macro_bf_heating (xplasma, t_e)
 	  heat_contribution +=
 	    q_recomb (&phot_top[config[i].bfu_jump[j]],
 		      t_e) * xplasma->ne * xplasma->ne * H * upper_density *
-	    wmain[xplasma->nwind].vol *
+	    xplasma->vol *
 	    phot_top[config[i].bfu_jump[j]].freq[0];
 
 	  total += heat_contribution;

--- a/source/extract.c
+++ b/source/extract.c
@@ -317,7 +317,7 @@ have been changed */
 	    pp->w *= (1. - exp (-tau)) / tau;
 	  tau = 0.0;
 	}
-
+	
 /* But in any event we have to reposition wind photons so thath they don't go through
 the same resonance again */
 

--- a/source/lines.c
+++ b/source/lines.c
@@ -131,7 +131,9 @@ lum_lines (one, nmin, nmax)
 	  q = 1. - scattering_fraction (lin_ptr[n], xplasma);
 
 	  x *= foo2 = q * a21 (lin_ptr[n]) * z / (1. - z);
-	  x *= foo3 = H * lin_ptr[n]->freq * one->vol;
+
+    /* JM 1411 -- corrected to use filled volume, rather than cell volume */
+	  x *= foo3 = H * lin_ptr[n]->freq * xplasma->vol;
 	  if (geo.line_mode == 3)
 	    x *= foo4 = p_escape (lin_ptr[n], xplasma);	// Include effects of line trapping 
 	  else

--- a/source/matom.c
+++ b/source/matom.c
@@ -888,7 +888,7 @@ kpkt (p, nres, escape)
 	{
 	  cooling_ff = mplasma->cooling_ff =
 	    total_free (one, xplasma->t_e, 0.0,
-			VERY_BIG) / one->vol / xplasma->ne;
+			VERY_BIG) / xplasma->vol / xplasma->ne;		// JM 1411 - changed to use filled volume
 	}
       else
 	{
@@ -928,7 +928,7 @@ kpkt (p, nres, escape)
 
       /* note the units here- we divide the total luminosity of the cell by volume and ne to give cooling rate */
 
-      cooling_adiabatic = xplasma->lum_adiabatic / one->vol / xplasma->ne;
+      cooling_adiabatic = xplasma->lum_adiabatic / xplasma->vol / xplasma->ne; // JM 1411 - changed to use filled volume
 
       if (geo.adiabatic == 0 && cooling_adiabatic > 0.0)
         {

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -253,9 +253,11 @@ radiation (p, ds)
 
 		  if (density > DENSITY_PHOT_MIN)
 		    {
+
+		      /* JM1411 -- added filling factor - density enhancement cancels with geo.fill */
 		      kappa_tot += x =
 			sigma_phot_topbase (x_top_ptr,
-					    freq_xs) * density * frac_path;
+					    freq_xs) * density * frac_path * geo.fill;
 
 		      /* I believe most of next steps are totally diagnsitic; it is possible if 
 		         statement could be deleted entirely 060802 -- ksl */
@@ -317,8 +319,10 @@ radiation (p, ds)
 
 		  if (density > DENSITY_PHOT_MIN)
 		    {
+
+		      /* JM1411 -- added filling factor - density enhancement cancels with geo.fill */
 		      kappa_tot += x =
-			sigma_phot (x_ptr, freq_xs) * density * frac_path;
+			sigma_phot (x_ptr, freq_xs) * density * frac_path * geo.fill;
 
 		      /* Next if statment down to kappa_ion appers to be totally diagnostic - 060802 -- ksl */
 		      if (geo.ioniz_or_extract)	// 57h -- ksl -- 060715
@@ -556,6 +560,8 @@ kappa_ff (xplasma, freq)
     }
   x *= x2 = (1. - exp (-H_OVER_K * freq / xplasma->t_e));
   x /= x3 = (sqrt (xplasma->t_e) * freq * freq * freq);
+
+  x *= geo.fill;    // multiply by the filling factor- should cancel with density enhancement
 
   return (x);
 }

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -466,7 +466,7 @@ radiation (p, ds)
 	  /* Calculate the number of photoionizations per unit volume for H and He 
 	     JM 1405 changed this to use freq_xs */
 	  xplasma->nioniz++;
-	  q = (z) / (H * freq * one->vol);
+	  q = (z) / (H * freq * xplasma->vol);
 	  /* So xplasma->ioniz for each species is just 
 	     (energy_abs)*kappa_h/kappa_tot / H*freq / volume
 	     or the number of photons absorbed in this bundle per unit volume by this ion
@@ -494,7 +494,7 @@ radiation (p, ds)
 	  x = sigma_phot_verner (&augerion[n], freq);	//this is the cross section
 	  y = weight_of_packet * x * ds;
 
-	  xplasma->gamma_inshl[n] += y / (freq * H * one->vol);
+	  xplasma->gamma_inshl[n] += y / (freq * H * xplasma->vol);
 	}
     }
 

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -426,7 +426,7 @@ total_fb (one, t, f1, f2)
 	{
 
 	  total += xplasma->lum_ion[nion] =
-	    one->vol * xplasma->ne * xplasma->density[nion + 1] * integ_fb (t,
+	    xplasma->vol * xplasma->ne * xplasma->density[nion + 1] * integ_fb (t,
 									    f1,
 									    f2,
 									    nion,

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -123,7 +123,7 @@ calculate_ds (w, p, tau_scat, tau, nres, smax, istat)
   nplasma = one->nplasma;
   xplasma = &plasmamain[nplasma];
 
-  kap_es = THOMPSON * xplasma->ne;
+  kap_es = THOMPSON * xplasma->ne * geo.fill;
   /* This is the electron scattering opacity per unit length. For the Macro Atom approach we need an 
      equivalent opacity per unit length due to each of the b-f continuua. Call it kap_bf. (SS) */
 
@@ -272,7 +272,8 @@ method). If the macro atom method is not used just get kap_bf to 0 and move on).
   /* To this point kappa is for the part ot the cell that is filled with material so
    * we must reduce this to account for the filling factor 1409 - ksl */
 
-  kap_cont*=geo.fill;
+  //kap_cont*=geo.fill;
+  //JM 1411 -- I've incorporated the filling factor directly into the kappa routines 
 
 
 
@@ -650,7 +651,7 @@ kappa_bf (xplasma, freq, macro_all)
       if (freq > ft && freq < phot_top[n].freq[phot_top[n].np - 1]
 	  && phot_top[n].macro_info > macro_all)
 	{
-	  /*Need the appropriate density at this point. */
+	  /* Need the appropriate density at this point. */
 
 	  nconf = phot_top[n].nlev;	//Returning lower level = correct (SS)
 
@@ -661,7 +662,8 @@ kappa_bf (xplasma, freq, macro_all)
 	    {
 
 	      /*          kap_tot += x = (delete) */
-	      kap_bf[nn] = x = sigma_phot_topbase (&phot_top[n], freq) * density;	//stimulated recombination? (SS)
+	      /* JM1411 -- added filling factor - density enhancement cancels with geo.fill */
+	      kap_bf[nn] = x = sigma_phot_topbase (&phot_top[n], freq) * density * geo.fill;	//stimulated recombination? (SS)
 	      kap_bf_tot += x;
 	    }
 	}

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -84,6 +84,7 @@ History:
 			dynamically allocated arrays in plasma structure. Also changed some of the pack
 			and unpack commands for the same reason.
 	14sept	nsh	78b: Changes to deal with the inclusion of direct recombination
+	14nov 	JM 78b: Changed volume to be the filled volume
 
 
 **************************************************************/
@@ -176,7 +177,8 @@ WindPtr (w);
 
 
       nwind = plasmamain[n].nwind;
-      volume = w[nwind].vol;
+      //volume = w[nwind].vol;
+      volume = plasmamain[n].vol; 	// 1411 JM -- we want volume to be the filled volume
 
 
       /* Start with a call to the routine which normalises all the macro atom 


### PR DESCRIPTION
When microclumping was first implemented- and even when I updated the routines- we only included factors of geo.fill in the calculated opacities in the following routines:
- in calculate_ds when we use opacities to work out when a photon scatters, both in continuum and line opacities
- in the tau_sobolev which is passed to the routines which calculate the bb/line heating- in both macro-atom and normal mode

We therefore failed to include factors of geo.fill when incrementing some of our heating estimators for each cell. This request should be discussed before merging. I have added the following factors of geo.fill:
- in kappa_compton, kappa_ind_comp in compton.c. These propagate correctly into the routines which calculate the heating in macro-atom (bf_estimators_increment) and non macro-atom (radiation) mode.
- in kappa_ff and kappa_bf, as above
- removed some factors in radiation() as the factor is now intrinsic to the relevant kappa routine
- in the calculation of bf opacities in calculate_ds and radiation

This may have a significant impact on the clumped models I've run, so take those results with a pinch of salt.

There's an outstanding problem here which is that I believe some volumes are not done consistently, i.e. they use the actual volume of the cell when they should use the filled volume. This is true of both diagnostic quantities like the IP, but also normalisations which we do in macro-atoms. I'm not sure these instances will affect actual resulting calculations but they should be done self-consistently. I'm trying to review any instance where we calculate things based on densities and volumes.
