### PR TITLE
Reorganise the matrix scheme

### DIFF
--- a/source/foo.h
+++ b/source/foo.h
@@ -463,6 +463,8 @@ double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
 int matrix_solv(PlasmaPtr xplasma, int mode);
+int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
+int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* py_wind_sub.c */
 int zoom(int direction);
 int overview(WindPtr w, char rootname[]);

--- a/source/foo.h
+++ b/source/foo.h
@@ -462,7 +462,7 @@ double tb_planck1(double freq);
 double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
-int matrix_solv(PlasmaPtr xplasma, int mode);
+int matrix_ion_populations(PlasmaPtr xplasma, int mode);
 int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
 int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* py_wind_sub.c */

--- a/source/matom.c
+++ b/source/matom.c
@@ -1400,21 +1400,16 @@ macro_pops (xplasma, xne)
   double this_ion_density, level_population;
   double inversion_test;
   double q_ioniz (), q_recomb ();
-  int s;			//NEWKSL
   double *a_data, *b_data;
-  gsl_permutation *p;		//NEWKSL
-  gsl_matrix_view m;		//NEWKSL
-  gsl_vector_view b;		//NEWKSL
-  gsl_vector *populations, *test_vector;	//NEWKSL
-  gsl_matrix *test_matrix;
+  double *populations;
   int index_fast_col, ierr;
-  double test_val;
 
   MacroPtr mplasma;
   mplasma = &macromain[xplasma->nplasma];
 
   /* Start with an outer loop over elements: there are no rates that couple
      levels of different elements so we can always separate them out. */
+
 
   for (index_element = 0; index_element < nelements; index_element++)
     {
@@ -1732,76 +1727,21 @@ macro_pops (xplasma, xne)
 	     calloc also sets the elements to zero, which is required */
 
 	  b_data = (double *) calloc (sizeof (rate), n_macro_lvl);
+	  populations = (double *) calloc (sizeof (rate), n_macro_lvl);
 
 	  /* replace the first entry with 1.0- this is part of the normalisation constraint */
 	  b_data[0] = 1.0;
 
-      /* create gsl matrix/vector views of the arrays of rates */
-	  m = gsl_matrix_view_array (a_data, n_macro_lvl, n_macro_lvl);	//KSLNEW
+      /* this next routine is a general routine which solves the matrix equation
+         via LU decomposition */
+	  ierr = solve_matrix(a_data, b_data, n_macro_lvl, populations);
 
-	  /* these are used for testing the solution below */
-	  test_matrix = gsl_matrix_alloc(n_macro_lvl, n_macro_lvl);
-	  test_vector = gsl_vector_alloc (n_macro_lvl);
+	  if (ierr != 0)
+	  	Error("macro_pops: bad return from solve_matrix\n");
 
-	  gsl_matrix_memcpy(test_matrix, &m.matrix); 	// create copy for testing 
-
-	  b = gsl_vector_view_array (b_data, n_macro_lvl);	//KSLNEW
-
-	  /* the populations vector will be a gsl vector which stores populations */
-	  populations = gsl_vector_alloc (n_macro_lvl);	//KSLNEW
-
-
-	  p = gsl_permutation_alloc (n_macro_lvl);	//NEWKSL
-
-	  gsl_linalg_LU_decomp (&m.matrix, p, &s);
-
-	  gsl_linalg_LU_solve (&m.matrix, p, &b.vector, populations);
-
-	  gsl_permutation_free (p);
-
-
-	  /**********************************************************/
-
-      /* JM 140414 -- before we clean, we should check that the populations vector we 
-         have just created really is a solution to the matrix equation */
-      
-      /* declaration contained in my_linalg.h, taken from gsl library */
-      ierr = gsl_blas_dgemv(CblasNoTrans, 1.0, test_matrix, populations, 0.0, test_vector);
-
-      if (ierr != 0)
-        {
-      	  Error("macro_pops: bad return when testing matrix solution to rate equations.\n");
-        }
-
-      /* now cycle through and check the solution to y = m * populations really is
-         (1, 0, 0 ... 0) */
-
-      for (mm = 0; mm < n_macro_lvl; mm++)
-        {
-
-          /* get the element of the vector we want to check */
-          test_val = gsl_vector_get (test_vector, mm);
-          
-          if (mm == 0)		// 0th element should be 1
-          {
-      	    if ( (fabs(test_val - 1.0)) > EPSILON)
-      	      Error("macro_pops: test vector has first element = %8.4e, should be 1.0\n",
-      	      	     test_val);    
-          }     
-
-          else 				// all other elements should be zero
-          {
-          	if ( fabs(test_val)  > EPSILON)
-      	      Error("macro_pops: test vector has element %i = %8.4e, should be 0.0\n",
-      	      	     mm, test_val);    
-          }
-        }
-
-        /* free memory */
-        free (a_data);	
-	    free (b_data);	
-	    free (test_vector);
-	    free (test_matrix);
+      /* free memory */
+      free (a_data);	
+	  free (b_data);	
 
 
 
@@ -1832,12 +1772,10 @@ macro_pops (xplasma, xne)
               /* this if statement means we only clean if there's a radiative jump between the levels */
               if (radiative_flag[index_lvl][nn])
               {
-		        inversion_test = gsl_vector_get (populations, conf_to_matrix[index_lvl]) * config[nn].g / config[index_lvl].g * 0.999999;	//include a correction factor 
-		        if (gsl_vector_get (populations, conf_to_matrix[nn]) >
-			    inversion_test)
+		        inversion_test = populations[conf_to_matrix[index_lvl]] * config[nn].g / config[index_lvl].g * 0.999999;	//include a correction factor 
+		        if (populations[conf_to_matrix[nn]] > inversion_test)
 			  {
-			    gsl_vector_set (populations, conf_to_matrix[nn],
-					  inversion_test);
+			    populations[conf_to_matrix[nn]] = inversion_test;
 			  }
 		      }
 		    }
@@ -1864,7 +1802,7 @@ macro_pops (xplasma, xne)
 		   ion[index_ion].first_nlte_level + ion[index_ion].nlte;
 		   index_lvl++)
 		{
-		  level_population = gsl_vector_get (populations, conf_to_matrix[index_lvl]);	
+		  level_population = populations[conf_to_matrix[index_lvl]];	
 		  this_ion_density += level_population;
 
 		  /* JM 140409 -- add error check for negative populations */
@@ -1885,8 +1823,7 @@ macro_pops (xplasma, xne)
 		{
 
 		  xplasma->levden[config[index_lvl].nden] =
-		    gsl_vector_get (populations,
-				    conf_to_matrix[index_lvl]) /
+		    populations[conf_to_matrix[index_lvl]] /
 		    this_ion_density;
 
 		  mm++;
@@ -1902,7 +1839,6 @@ macro_pops (xplasma, xne)
 
 	    }
 
-	  gsl_vector_free (populations);
 	}
     }
 

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -643,8 +643,8 @@ int solve_matrix(a_data, b_data, nrows, x)
       
       if ( (fabs((test_val - b_data[mm]))/test_val) > EPSILON)
         {
-      	  Error("solve_matrix: test solution fails for row %i %e != %e\n",
-      	      	mm, test_val, b_data[mm]);
+      	  //Error("solve_matrix: test solution fails for row %i %e != %e\n",
+      	  //    	mm, test_val, b_data[mm]);
       	  ierr = 1;
       	}
     }

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -3,7 +3,7 @@
 
   Synopsis:   
 
-int   matrix_solv (xplasma,mode)
+int   matrix_ion_populations (xplasma,mode)
   
   Arguments:		
      PlasmaPtr xplasma;		The cell in question -
@@ -18,7 +18,7 @@ int   matrix_solv (xplasma,mode)
  	
   Description:	
 
-	The general structure of matrix_solv is as follows:
+	The general structure of matrix_ion_populations is as follows:
 	First we compute all of the rates that we have data for linking all ionization stages 
 	We make an initial guess at the electron density
 	We attempt to solve the ionization rates matrix, and produce a new guess at the electron density
@@ -49,301 +49,310 @@ int   matrix_solv (xplasma,mode)
 #include <string.h>
 #include <math.h>
 #include "atomic.h"
-//struct topbase_phot *xtop;
-//double g1, g2, xne, xip;
+// struct topbase_phot *xtop;
+// double g1, g2, xne, xip;
 #define SAHA 4.82907e15
-//double xip, xxxne, qromb_temp;
+// double xip, xxxne, qromb_temp;
 #include "python.h"
 
 
 #include <gsl/gsl_block.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_matrix.h>
-//#include <gsl/gsl_blas.h>
+// #include <gsl/gsl_blas.h>
 #include "my_linalg.h"
 
 
-int matrix_solv(xplasma,mode)
-	PlasmaPtr xplasma;
-	int mode;
+int matrix_ion_populations(xplasma, mode)
+		 PlasmaPtr xplasma;
+		 int mode;
 
 {
-  int nn,mm,nrows;
-  double rate_matrix[nions][nions];
-  double newden[NIONS];
-  double nh,t_e,t_r,www;
-  double xne,xxne,xxxne;
-  double xsaha,x,theta;
-  int s; /*s is the 'sign' of the permutation - is had the value -1^n where n is the number of permutations. 
-We dont use it anywhere, but in principle it can be used to refine the solution via gsl_linalg_LU_refine */
-  double b_temp[nions]; 
-  double *b_data,*a_data;
-  double *populations;
-  int ierr,niterate;
-  double xnew;
-  double xden[nelements];
-  int xion[nions]; //This array keeps track of what ion is in each line
-  int xelem[nions]; //This array keeps track of the element for each ion
-  double pi_rates[nions];
-  double rr_rates[nions];
+	int nn, mm, nrows;
+	double rate_matrix[nions][nions];
+	double newden[NIONS];
+	double nh, t_e, t_r, www;
+	double xne, xxne, xxxne;
+	double xsaha, x, theta;
+	int s;												/* s is the 'sign' of the permutation - is had the value -1^n where n is the number of
+																   permutations. We dont use it anywhere, but in principle it can be used to refine the
+																   solution via gsl_linalg_LU_refine */
+	double b_temp[nions];
+	double *b_data, *a_data;
+	double *populations;
+	int ierr, niterate;
+	double xnew;
+	double xden[nelements];
+	int xion[nions];							// This array keeps track of what ion is in each line
+	int xelem[nions];							// This array keeps track of the element for each ion
+	double pi_rates[nions];
+	double rr_rates[nions];
 
-/* Copy some quantities from the cell into local variables */
+	/* Copy some quantities from the cell into local variables */
 
-  nh = xplasma->rho * rho2nh;	//The number density of hydrogen ions - computed from density
-  t_e = xplasma->t_e;		//The electron temperature in the cell - used for collisional processes	
-  t_r = xplasma->t_r;		//The radiation temperature - used for PI if we have a BB approximation
-  www = xplasma->w;		//The radiative weight in the cell - again for BB approximation for PI
+	nh = xplasma->rho * rho2nh;		// The number density of hydrogen ions - computed from density
+	t_e = xplasma->t_e;						// The electron temperature in the cell - used for collisional processes 
+	t_r = xplasma->t_r;						// The radiation temperature - used for PI if we have a BB approximation
+	www = xplasma->w;							// The radiative weight in the cell - again for BB approximation for PI
 
-/* Dielectronic recombination and direct ionization coefficients depend only on electron temperature, 
-calculate them now - they will not change */
+	/* Dielectronic recombination and direct ionization coefficients depend only on electron temperature, calculate them now -
+	   they will not change */
 
- compute_dr_coeffs (t_e);
- compute_di_coeffs (t_e);
+	compute_dr_coeffs(t_e);
+	compute_di_coeffs(t_e);
 
- /* In the following loop, over all ions in the simulation, we compute the radiative recombination rates,
-and photionization rates OUT OF each ionization stage. The PI rates are calculated either using the modelled
-mean intensity in a cell, or using the dilute blackbody approximation, depending on which mode we are in. At
-the same time, we copy the ion densities from the plasma strcuture into a local array. We will only overwrite
-the numbders in the structure if we believe the results are an improvement on what is there.*/
+	/* In the following loop, over all ions in the simulation, we compute the radiative recombination rates, and photionization
+	   rates OUT OF each ionization stage. The PI rates are calculated either using the modelled mean intensity in a cell, or
+	   using the dilute blackbody approximation, depending on which mode we are in. At the same time, we copy the ion densities
+	   from the plasma strcuture into a local array. We will only overwrite the numbders in the structure if we believe the
+	   results are an improvement on what is there. */
 
-  for (mm = 0; mm < nions; mm++)
-    {
-      newden[mm] = xplasma->density[mm]; //newden is our local density array
-      xion[mm] = mm;			//xion is an array we use to track which ion is in which row of the matrix
-      if (ion[mm].istate != 1) //We can recombine since we are not in the first ionization stage
-		{
-	  rr_rates[mm]=total_rrate (mm, xplasma->t_e);  //radiative recombination rates
-		}
-      if (ion[mm].istate != ion[mm].z+1 ) //we can photoionize, since we are not in the z+1th ionization state (bare)
-	  {
-	  if (mode == NEBULARMODE_MATRIX_BB)
-		{
-	  	pi_rates[mm]=calc_pi_rate (mm,xplasma,2); //PI rate for the BB model
-		}
-	  else if (mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
-		{
-	  	pi_rates[mm]=calc_pi_rate (mm,xplasma,1);  //PI rate for an explicit spectral model
-		}
-  	  else
-                {
-// If reached this point the program does not understand what type of spectral model to apply 
-                Error ("matrix_solv: Unknown mode %d\n", mode);
-                exit (0);
-                }
-	   }
-      for (nn=0;nn<nelements;nn++)
+	for (mm = 0; mm < nions; mm++)
 	{
-	if (ion[mm].z==ele[nn].z)
+		newden[mm] = xplasma->density[mm];	// newden is our local density array
+		xion[mm] = mm;							// xion is an array we use to track which ion is in which row of the matrix
+		if (ion[mm].istate != 1)		// We can recombine since we are not in the first ionization stage
 		{
-		xelem[mm]=nn;  /*xelem logs which element each ow in the arrays refers to. This is important
-because we need to know what the total density will be for a group of rows all representing the same element. */
+			rr_rates[mm] = total_rrate(mm, xplasma->t_e);	// radiative recombination rates
 		}
-	}
-    }
-
-/*This next line sets the partition function for each ion. This has always been the place here python calculates
-the partition funcions and sets the level densities for each ion. It needs to be done, or other parts of the code
-which rely on sensible level populations don't work properly. In the case of the dilute blackbody, the code
-works well, however we do not currently (v78) have a procedure to calucate the levels for a spectral model case.
-We therefore call partition functions with mode 4 - this is a special mode which forces the ions to be in the 
-ground state. This is reasonable for a radiation dominated plasma, since any excitations into higher states will
-quickly be followed by radative de-excitation. We should really do better though... */
-
-if (mode == NEBULARMODE_MATRIX_BB)
-	{
-  	partition_functions (xplasma, NEBULARMODE_ML93);	//We use t_r and the radiative weight
-	}
-else if (mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
-	{
-	partition_functions (xplasma, 4);			//Set to ground state	
-	}
-
-/*Next we need to obtain an initian guess for the electron density. In the past this has been done by calculating
-the hydrogen density directly from the Saha equation at the current electron temperature. In initial testing of 
-this mode - this seemed to be a little unstable. At the moment, we use the last ionization state to compute n_e.
-For the first iteraion, this will just be calculated in LTE from the initial temperature structure of the wind,
-which will give almost the same result as the original procedure, or for successive calculations, it should be 
-a better guess. I've leftin the original code, commented out...  */ 
-
-xne = xxne = xxxne = get_ne (newden);    //Set n_e to the current value. 
-
-/*xne is the current working number
-  xxne 
-
-
-/*These following commented out lines calculate the electron density from Saha given the current electron temperature*/
- //if (t_e < MIN_TEMP)
- //   t_e = MIN_TEMP;		/* fudge to prevent divide by zeros */
-//  xsaha = SAHA * pow (t_e, 1.5);
-//  theta = xsaha * exp (-ion[0].ip / (BOLTZMANN * t_e)) / nh;
-//  if (theta < THETAMAX)
-//    {
-//      x = (-theta + sqrt (theta * theta + 4 * theta)) / 2.;
-//      xne = xxne = xxxne = x * nh;
-//    }
-//  else
-//    xne = xxne = xxxne = nh;	/*xxne is just a store so the error can report the starting value of ne. */
-                             /*    xxxne is the shared variable so the temperature solver routine can access it */
- // if (xne < 1.e-6)
- //   xne = xxxne = 1.e-6;	/* Set a minimum ne to assure we can calculate
-	//			   xne the first time through the loop */
-
-
-
-/* We are now going to iterate on the electron density - MAXITERATIONS is set in python.h and is currently (78) 
-set to 200. We would normally expect to converge much fater than this */
-
-  niterate = 0;
-  while (niterate < MAXITERATIONS)
-{
-
-  populate_ion_rate_matrix(xplasma, rate_matrix, pi_rates, rr_rates, b_temp, xne, xelem);
-
-
-    /* The array is now fully populated, and we can begin the process of solving it */
-
-    nrows=nions; /*This is a placeholder, we may end up removing rows and columns that have no rates (or very low rates) connecting them to other rows. This may improve stability but will need to be done carefully */
-
-    /* The solver routine was taken largely wholesale from the matom routine. I have left in most of the original comments, and added a few of my own for clarification */
-
-
-
-	  /********************************************************************************/
-	  /* The block that follows (down to next line of ***s) is to do the
-	     matrix inversion. It uses LU decomposition - the code for doing this is 
-	     taken from the GSL manual with very few modifications. */
-	  /* here we solve the matrix equation M x = b, where x is our vector containing
-	     level populations as a fraction w.r.t the whole element */
-
-	  /* Replaced inline array allocaation with calloc, which will work with older version of c compilers */
-
-    /* This next line produces an array of the correct size to hold the rate matrix */
-	  a_data =
-	    (double *) calloc (sizeof (double), nrows * nrows);
-
-    /* We now copy our rate matrix into the prepared matrix */
-	  for (mm = 0; mm < nrows; mm++)
-	    {
-	      for (nn = 0; nn < nrows; nn++)
+		if (ion[mm].istate != ion[mm].z + 1)	// we can photoionize, since we are not in the z+1th ionization state (bare)
 		{
-		  a_data[mm * nrows + nn] = rate_matrix[mm][nn];
-		}
-	    }
-
-
-
-	  /* Replaced inline array allocaation with calloc, which will work with older version of c compilers 
-	     calloc also sets the elements to zero, which is required */
-
-	  b_data = (double *) calloc (sizeof (double), nrows);
-	  populations = (double *) calloc (sizeof (double), nrows);
-
-  /*This b_data column matrix is the total number density for each element, placed into the row which relates to
-  the neutral ion. This matches the row in the rate matrix which is just  1 1 1 1  for all stages. NB, we could have
-  chosen any line for this.*/
-
-    for (nn=0;nn<nrows;nn++)
-	  {
-	    b_data[nn]=b_temp[nn];
-	  }
-
-    ierr = solve_matrix(a_data, b_data, nrows, populations);
-
-    if (ierr != 0)
-	  Error("matrix_solve: bad return from solve_matrix\n");
-
-	/* free memory */
-    free (a_data);	
-    free (b_data);	
-
-    /* Calculate level populations for macro-atoms */
-    if (geo.macro_ioniz_mode == 1)
-	  {
-	    macro_pops (xplasma, xne);
-	  }
-
-  /*We now have the populations of all the ions stored in the matrix populations. We copy this data into the
-  newden array which will temperarily store all the populations. We wont copy this to the plasma structure 
-  until we are sure thatwe have made things better. We just loop over all ions, and copy. The complexity in the
-  loop is to future proof us against the possibility that there are some ions that are not included in the 
-  matrix scheme becuse there is no route into or out of it.*/
-
-  for (nn=0;nn<nions;nn++)
-	{
-	newden[nn]=0.0;  //initialise the arrayelement
-
-	/* if the ion is being treated by macro_pops then use the populations just computed */
-	if ((ion[nn].macro_info == 1) && (geo.macro_simple == 0)
-	      && (geo.macro_ioniz_mode == 1))
-	    {
-	      newden[nn] = xplasma->density[nn];
-	    }
-    
-	for (mm=0;mm<nrows;mm++) //inner loop over the elements of the population array
-		{
-		if (xion[mm]==nn) //if this element contains the population of the ion is question
+			if (mode == NEBULARMODE_MATRIX_BB)
 			{
-			newden[nn]= populations[mm]; //get the population
+				pi_rates[mm] = calc_pi_rate(mm, xplasma, 2);	// PI rate for the BB model
+			}
+			else if (mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
+			{
+				pi_rates[mm] = calc_pi_rate(mm, xplasma, 1);	// PI rate for an explicit spectral model
+			}
+			else
+			{
+				// If reached this point the program does not understand what type of spectral model to apply 
+				Error("matrix_ion_populations: Unknown mode %d\n", mode);
+				exit(0);
+			}
+		}
+		for (nn = 0; nn < nelements; nn++)
+		{
+			if (ion[mm].z == ele[nn].z)
+			{
+				xelem[mm] = nn;					/* xelem logs which element each ow in the arrays refers to. This is important because we need
+																   to know what the total density will be for a group of rows all representing the same
+																   element. */
+			}
+		}
+	}
+
+	/* This next line sets the partition function for each ion. This has always been the place here python calculates the
+	   partition funcions and sets the level densities for each ion. It needs to be done, or other parts of the code which rely
+	   on sensible level populations don't work properly. In the case of the dilute blackbody, the code works well, however we do 
+	   not currently (v78) have a procedure to calucate the levels for a spectral model case. We therefore call partition
+	   functions with mode 4 - this is a special mode which forces the ions to be in the ground state. This is reasonable for a
+	   radiation dominated plasma, since any excitations into higher states will quickly be followed by radative de-excitation.
+	   We should really do better though... */
+
+	if (mode == NEBULARMODE_MATRIX_BB)
+	{
+		partition_functions(xplasma, NEBULARMODE_ML93);	// We use t_r and the radiative weight
+	}
+	else if (mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
+	{
+		partition_functions(xplasma, 4);	// Set to ground state 
+	}
+
+	/* Next we need to obtain an initian guess for the electron density. In the past this has been done by calculating the
+	   hydrogen density directly from the Saha equation at the current electron temperature. In initial testing of this mode -
+	   this seemed to be a little unstable. At the moment, we use the last ionization state to compute n_e. For the first
+	   iteraion, this will just be calculated in LTE from the initial temperature structure of the wind, which will give almost
+	   the same result as the original procedure, or for successive calculations, it should be a better guess. I've leftin the
+	   original code, commented out...  */
+
+	xne = xxne = xxxne = get_ne(newden);	// Set n_e to the current value. 
+
+	/* xne is the current working number xxne
+
+
+	   /*These following commented out lines calculate the electron density from Saha given the current electron temperature */
+	// if (t_e < MIN_TEMP)
+	// t_e = MIN_TEMP; /* fudge to prevent divide by zeros */
+	// xsaha = SAHA * pow (t_e, 1.5);
+	// theta = xsaha * exp (-ion[0].ip / (BOLTZMANN * t_e)) / nh;
+	// if (theta < THETAMAX)
+	// {
+	// x = (-theta + sqrt (theta * theta + 4 * theta)) / 2.;
+	// xne = xxne = xxxne = x * nh;
+	// }
+	// else
+	// xne = xxne = xxxne = nh; /*xxne is just a store so the error can report the starting value of ne. */
+	/* xxxne is the shared variable so the temperature solver routine can access it */
+	// if (xne < 1.e-6)
+	// xne = xxxne = 1.e-6; /* Set a minimum ne to assure we can calculate
+	// xne the first time through the loop */
+
+
+
+	/* We are now going to iterate on the electron density - MAXITERATIONS is set in python.h and is currently (78) set to 200.
+	   We would normally expect to converge much fater than this */
+
+	niterate = 0;
+	while (niterate < MAXITERATIONS)
+	{
+
+
+		populate_ion_rate_matrix(xplasma, rate_matrix, pi_rates, rr_rates, b_temp, xne, xelem);
+
+
+		/* The array is now fully populated, and we can begin the process of solving it */
+
+		nrows = nions;							/* This is a placeholder, we may end up removing rows and columns that have no rates (or very
+																   low rates) connecting them to other rows. This may improve stability but will need to be
+																   done carefully */
+
+		/* The solver routine was taken largely wholesale from the matom routine. I have left in most of the original comments, and 
+		   added a few of my own for clarification */
+
+
+
+		/********************************************************************************/
+		/* The block that follows (down to next line of ***s) is to do the matrix inversion. It uses LU decomposition - the code
+		   for doing this is taken from the GSL manual with very few modifications. */
+		/* here we solve the matrix equation M x = b, where x is our vector containing level populations as a fraction w.r.t the
+		   whole element */
+		/* JM 1411 -- the actual LU decomposition- the process of obtaining a solution - is done by the routine solve_matrix() */
+
+		/* Replaced inline array allocaation with calloc, which will work with older version of c compilers */
+
+		/* This next line produces an array of the correct size to hold the rate matrix */
+		a_data = (double *)calloc(sizeof(double), nrows * nrows);
+
+		/* We now copy our rate matrix into the prepared matrix */
+		for (mm = 0; mm < nrows; mm++)
+		{
+			for (nn = 0; nn < nrows; nn++)
+			{
+				a_data[mm * nrows + nn] = rate_matrix[mm][nn];
 			}
 		}
 
 
-	if (newden[nn] < DENSITY_MIN)   //this wil also capture the case where population doesnt have a value for this ion
-		newden[nn] = DENSITY_MIN;
-	}
+
+		/* Replaced inline array allocaation with calloc, which will work with older version of c compilers calloc also sets the
+		   elements to zero, which is required */
+
+		b_data = (double *)calloc(sizeof(double), nrows);
+		populations = (double *)calloc(sizeof(double), nrows);
+
+		/* This b_data column matrix is the total number density for each element, placed into the row which relates to the neutral 
+		   ion. This matches the row in the rate matrix which is just 1 1 1 1 for all stages. NB, we could have chosen any line for 
+		   this. */
+
+		for (nn = 0; nn < nrows; nn++)
+		{
+			b_data[nn] = b_temp[nn];
+		}
+
+		ierr = solve_matrix(a_data, b_data, nrows, populations);
+
+		if (ierr != 0)
+			Error("matrix_ion_populations: bad return from solve_matrix\n");
+
+		/* free memory */
+		free(a_data);
+		free(b_data);
+
+		/* Calculate level populations for macro-atoms */
+		if (geo.macro_ioniz_mode == 1)
+		{
+			macro_pops(xplasma, xne);
+		}
+
+		/* We now have the populations of all the ions stored in the matrix populations. We copy this data into the newden array
+		   which will temperarily store all the populations. We wont copy this to the plasma structure until we are sure thatwe
+		   have made things better. We just loop over all ions, and copy. The complexity in the loop is to future proof us against
+		   the possibility that there are some ions that are not included in the matrix scheme becuse there is no route into or
+		   out of it. */
+
+		for (nn = 0; nn < nions; nn++)
+		{
+			newden[nn] = 0.0;					// initialise the arrayelement
+
+			/* if the ion is being treated by macro_pops then use the populations just computed */
+			if ((ion[nn].macro_info == 1) && (geo.macro_simple == 0) && (geo.macro_ioniz_mode == 1))
+			{
+				newden[nn] = xplasma->density[nn];
+			}
+
+			for (mm = 0; mm < nrows; mm++)	// inner loop over the elements of the population array
+			{
+				if (xion[mm] == nn)			// if this element contains the population of the ion is question
+				{
+					newden[nn] = populations[mm];	// get the population
+				}
+			}
 
 
-      xnew = get_ne (newden);	/* determine the electron density for this density distribution */
+			if (newden[nn] < DENSITY_MIN)	// this wil also capture the case where population doesnt have a value for this ion
+				newden[nn] = DENSITY_MIN;
+		}
 
 
-     if (xnew < DENSITY_MIN)
-	xnew = DENSITY_MIN;	/* fudge to keep a floor on ne */
+		xnew = get_ne(newden);			/* determine the electron density for this density distribution */
 
 
-      if (fabs ((xne - xnew) / (xnew)) < FRACTIONAL_ERROR || xnew < 1.e-6) /*We have converged, or have the situation where we have a neutral plasma */
+		if (xnew < DENSITY_MIN)
+			xnew = DENSITY_MIN;				/* fudge to keep a floor on ne */
+
+
+		if (fabs((xne - xnew) / (xnew)) < FRACTIONAL_ERROR || xnew < 1.e-6)	/* We have converged, or have the situation where we
+																																				   have a neutral plasma */
+		{
+			break;										/* Break out of the while loop - we have finished our iterations */
+		}
+		xne = xxxne = (xnew + xne) / 2.;	/* New value of ne */
+
+		niterate++;
+
+
+		if (niterate == MAXITERATIONS)
+		{
+			Error("matrix_ion_populations: failed to converge for cell %i t %e nh %e xnew %e\n", xplasma->nplasma, t_e, nh, xnew);
+
+
+			for (nn = 0; nn < geo.nxfreq; nn++)
+			{
+				Log
+					("numin= %e (%e) numax= %e (%e) Model= %2d PL_log_w= %e PL_alpha= %e Exp_w= %e EXP_temp= %e\n",
+					 xplasma->fmin_mod[nn], geo.xfreq[nn], xplasma->fmax_mod[nn],
+					 geo.xfreq[nn + 1], xplasma->spec_mod_type[nn],
+					 xplasma->pl_log_w[nn], xplasma->pl_alpha[nn], xplasma->exp_w[nn], xplasma->exp_temp[nn]);
+			}
+
+			Error("matrix_ion_populations: xxne %e theta %e\n", xxne, theta);
+
+			return (-1);							/* If we get to MAXITERATIONS, we return without copying the new populations into plasma */
+		}
+	}															/* This is the end of the iteration loop */
+
+
+	xplasma->ne = xnew;
+	for (nn = 0; nn < nions; nn++)
 	{
-	  break; /*Break out of the while loop - we have finished our iterations */
+		/* If statement added here to suppress interference with macro populations (SS Apr 04) */
+		if (ion[nn].macro_info == 0 || geo.macro_ioniz_mode == 0 || geo.macro_simple == 1)
+		{
+			xplasma->density[nn] = newden[nn];
+		}
 	}
-      xne = xxxne = (xnew + xne) / 2.;	/*New value of ne */
-
-      niterate++;
 
 
-      if (niterate == MAXITERATIONS)
-	{
-	  Error
-	    ("matrix_solv: failed to converge for cell %i t %e nh %e xnew %e\n",
-	     xplasma->nplasma, t_e, nh, xnew);
- 	for (nn = 0; nn < geo.nxfreq; nn++)
-    		{
-      		Log ("numin= %e (%e) numax= %e (%e) Model= %2d PL_log_w= %e PL_alpha= %e Exp_w= %e EXP_temp= %e\n",xplasma-> fmin_mod[nn],geo.xfreq[nn],xplasma->fmax_mod[nn],geo.xfreq[nn+1],xplasma->spec_mod_type[nn],xplasma->pl_log_w[nn],xplasma->pl_alpha[nn],xplasma->exp_w[nn],xplasma->exp_temp[nn]);
-		}    
-	Error ("matrix_solv: xxne %e theta %e\n", xxne, theta);
-	  return (-1); /*If we get to MAXITERATIONS, we return without copying the new populations into plasma*/
-	}
-    } /*This is the end of the iteration loop */
-
-
-  xplasma->ne = xnew;
-  for (nn = 0; nn < nions; nn++)
-    {
-      /* If statement added here to suppress interference with macro populations (SS Apr 04) */
-      if (ion[nn].macro_info == 0 || geo.macro_ioniz_mode == 0
-	  || geo.macro_simple == 1)
-	{
-	  xplasma->density[nn] = newden[nn];
-	}
-    }
-
-
-  partition_functions (xplasma, 4);	/*  WARNING fudge NSH 11/5/14 - this is as a test. 
-                                        We really need a better implementation of partition functions and levels
-                                        for a power law illuminating spectrum. We found that if we didnt make this call, 
-                                        we would end up with undefined levels - which did really crazy things */
+	partition_functions(xplasma, 4);	/* WARNING fudge NSH 11/5/14 - this is as a test. We really need a better implementation
+																		   of partition functions and levels for a power law illuminating spectrum. We found that
+																		   if we didnt make this call, we would end up with undefined levels - which did really
+																		   crazy things */
 
 
 
-  return(0);
+	return (0);
 }
 
 
@@ -355,8 +364,25 @@ set to 200. We would normally expect to converge much fater than this */
     with the pi_rates and rr_rates supplied at the density xne in question.
 
   
-  Arguments:		
+  Arguments:	
+    xplasma 
+      PlasmaPtr to the plasma cell for physical properties
 
+    pi_rates
+      PI rates for each ion
+
+    rr_rates 
+      radiative recombination rates for each ion
+
+    b_temp
+      array which is mostly zeros, but first element is set to abundances
+      so the equation is soluble
+
+    xne 
+      our guess of ne, which has not been copied to xplasma yet
+
+    xelem
+      array which stores the element corresponding to each ion in the matrix
 
   Returns:
 	
@@ -374,172 +400,169 @@ set to 200. We would normally expect to converge much fater than this */
 **************************************************************/
 
 int populate_ion_rate_matrix(xplasma, rate_matrix, pi_rates, rr_rates, b_temp, xne, xelem)
-    PlasmaPtr xplasma;
-    double rate_matrix[nions][nions];
-    double pi_rates[nions];
-    double rr_rates[nions];
-    double xne;
-    double b_temp[nions];
-    int xelem[nions];
+		 PlasmaPtr xplasma;
+		 double rate_matrix[nions][nions];
+		 double pi_rates[nions];
+		 double rr_rates[nions];
+		 double xne;
+		 double b_temp[nions];
+		 int xelem[nions];
 
 {
-  int nn, mm; 
-  double nh;
+	int nn, mm;
+	double nh;
 
-  nh = xplasma->rho * rho2nh;	//The number density of hydrogen ions - computed from density
+	nh = xplasma->rho * rho2nh;		// The number density of hydrogen ions - computed from density
 
-  /*First we initialise the matrix */
-  for (nn = 0; nn < nions; nn++)
+	/* First we initialise the matrix */
+	for (nn = 0; nn < nions; nn++)
 	{
-	  for (mm = 0; mm < nions; mm++)
-	    {
-	      rate_matrix[nn][mm] = 0.0;
-	    }
-	}
-
-
-  /*The next block of loops populate the matrix. For simplicity of reading the code each process has its own loop.
-  Some rates actually dont change during each iteration, but those that depend on n_e will. All are dealt with
-  together at the moment, but this could be streamlined if it turns out that there is a bottleneck.*/
-
-  /*Now we populate the elements relating to PI depopulating a state*/
-
-
-  for (mm = 0; mm<nions; mm++)
-	{
-	  if (ion[mm].istate != ion[mm].z+1) //we have electrons
+		for (mm = 0; mm < nions; mm++)
 		{
-		  rate_matrix[mm][mm] -= pi_rates[mm];
+			rate_matrix[nn][mm] = 0.0;
 		}
 	}
 
 
-  /*Now we populate the elements relating to PI populating a state */
+	/* The next block of loops populate the matrix. For simplicity of reading the code each process has its own loop. Some rates
+	   actually dont change during each iteration, but those that depend on n_e will. All are dealt with together at the moment,
+	   but this could be streamlined if it turns out that there is a bottleneck. */
 
-  for (mm =0; mm<nions; mm++)
+	/* Now we populate the elements relating to PI depopulating a state */
+
+
+	for (mm = 0; mm < nions; mm++)
 	{
-	for (nn=0;nn<nions;nn++)
+		if (ion[mm].istate != ion[mm].z + 1)	// we have electrons
+		{
+			rate_matrix[mm][mm] -= pi_rates[mm];
+		}
+	}
+
+
+	/* Now we populate the elements relating to PI populating a state */
+
+	for (mm = 0; mm < nions; mm++)
+	{
+		for (nn = 0; nn < nions; nn++)
 		{
 
-		if (mm==nn+1 && ion[nn].istate != ion[nn].z+1 && ion[mm].z==ion[nn].z) 
+			if (mm == nn + 1 && ion[nn].istate != ion[nn].z + 1 && ion[mm].z == ion[nn].z)
 			{
-			  rate_matrix[mm][nn] += pi_rates[nn];
+				rate_matrix[mm][nn] += pi_rates[nn];
 			}
 		}
 	}
 
-  /*Now we populate the elements relating to direct ionization depopulating a state*/
+	/* Now we populate the elements relating to direct ionization depopulating a state */
 
-  for (mm = 0; mm<nions; mm++)
+	for (mm = 0; mm < nions; mm++)
 	{
-	if (ion[mm].istate != ion[mm].z+1 && ion[mm].dere_di_flag > 0) //we have electrons and a DI rate
+		if (ion[mm].istate != ion[mm].z + 1 && ion[mm].dere_di_flag > 0)	// we have electrons and a DI rate
 		{
-		  rate_matrix[mm][mm]  -= (xne*di_coeffs[mm]);
+			rate_matrix[mm][mm] -= (xne * di_coeffs[mm]);
 		}
 	}
 
-  /*Now we populate the elements relating to direct ionization populating a state - this does depend on the electron 
-  density */
+	/* Now we populate the elements relating to direct ionization populating a state - this does depend on the electron density */
 
-  for (mm =0; mm<nions; mm++)
+	for (mm = 0; mm < nions; mm++)
 	{
-	for (nn=0;nn<nions;nn++)
+		for (nn = 0; nn < nions; nn++)
 		{
-		if (mm==nn+1 && ion[nn].istate != ion[nn].z+1 && ion[mm].z==ion[nn].z && ion[nn].dere_di_flag > 0) 
+			if (mm == nn + 1 && ion[nn].istate != ion[nn].z + 1 && ion[mm].z == ion[nn].z && ion[nn].dere_di_flag > 0)
 			{
-			rate_matrix[mm][nn]+=(xne*di_coeffs[nn]);
+				rate_matrix[mm][nn] += (xne * di_coeffs[nn]);
 			}
 		}
 	}
 
 
-  /*Now we populate the elements relating to radiative recomb depopulating a state*/
-		
-  for (mm = 0; mm<nions; mm++)
+	/* Now we populate the elements relating to radiative recomb depopulating a state */
+
+	for (mm = 0; mm < nions; mm++)
 	{
-	if (ion[mm].istate != 1) //we have space for electrons
+		if (ion[mm].istate != 1)		// we have space for electrons
 		{
-		rate_matrix[mm][mm]-=(xne*rr_rates[mm]);
+			rate_matrix[mm][mm] -= (xne * rr_rates[mm]);
 		}
 	}
 
 
-  /*Now we populate the elements relating to radiative recomb populating a state */
+	/* Now we populate the elements relating to radiative recomb populating a state */
 
-  for (mm =0; mm<nions; mm++)
+	for (mm = 0; mm < nions; mm++)
 	{
-	for (nn=0;nn<nions;nn++)
+		for (nn = 0; nn < nions; nn++)
 		{
-		if (mm==nn-1 && ion[nn].istate != 1 && ion[mm].z==ion[nn].z) 
+			if (mm == nn - 1 && ion[nn].istate != 1 && ion[mm].z == ion[nn].z)
 			{
-			rate_matrix[mm][nn]  +=  (xne*rr_rates[nn]);
+				rate_matrix[mm][nn] += (xne * rr_rates[nn]);
 			}
 		}
 	}
 
-  /* Now we populate the elements relating to dielectronic recombination depopulating a state */
-	
-  for (mm = 0; mm<nions; mm++)
+	/* Now we populate the elements relating to dielectronic recombination depopulating a state */
+
+	for (mm = 0; mm < nions; mm++)
 	{
-	if (ion[mm].istate != 1 && ion[mm].drflag > 0) //we have space for electrons
+		if (ion[mm].istate != 1 && ion[mm].drflag > 0)	// we have space for electrons
 		{
-		rate_matrix[mm][mm]  -=  (xne*dr_coeffs[mm]);
+			rate_matrix[mm][mm] -= (xne * dr_coeffs[mm]);
 		}
 	}
 
 
-  /* Now we populate the elements relating to dielectronic recombination populating a state */
+	/* Now we populate the elements relating to dielectronic recombination populating a state */
 
 
 
-  for (mm =0; mm<nions; mm++)
+	for (mm = 0; mm < nions; mm++)
 	{
-	for (nn=0;nn<nions;nn++)
+		for (nn = 0; nn < nions; nn++)
 		{
-		if (mm==nn-1 && ion[nn].istate != 1 && ion[mm].z==ion[nn].z && ion[mm].drflag > 0) 
+			if (mm == nn - 1 && ion[nn].istate != 1 && ion[mm].z == ion[nn].z && ion[mm].drflag > 0)
 			{
-			rate_matrix[mm][nn]+=(xne*dr_coeffs[nn]);
+				rate_matrix[mm][nn] += (xne * dr_coeffs[nn]);
 			}
 		}
 	}
 
-  /*Now, we replace the first line for each element with 1's and 0's. This is done because we actually have
-  more equations than unknowns. We replace the array elements relating to each ion stage in this element with
-  a 1, and all the other array elements (which relate to other elements (in the chemicalsense) with zeros. This
-  is equivalent to the equation 1*n1+1*n2+1*n3 = n_total - i.e. the sum of all the partial number densities
-  adds up to the total number density for that element.
-  This loop also produces the 'b matrix'. This is the right hand side of the matrix equation, and represents
-  the total number density for each element. This can be a series of 1's for each row in the matrix relating to 
-  the ground state of the repsective element, however one can just use the total number density for that elements
-  and then the densities which the solver computes are just the actual number densities for each ion. This does
-  mean that different rows are orders of magnitude different, so one can imagine numerical issues. However each
-  element is essentially solved for seperately.. Something to watch
-  */
+	/* Now, we replace the first line for each element with 1's and 0's. This is done because we actually have more equations
+	   than unknowns. We replace the array elements relating to each ion stage in this element with a 1, and all the other array
+	   elements (which relate to other elements (in the chemicalsense) with zeros. This is equivalent to the equation
+	   1*n1+1*n2+1*n3 = n_total - i.e. the sum of all the partial number densities adds up to the total number density for that
+	   element. This loop also produces the 'b matrix'. This is the right hand side of the matrix equation, and represents the
+	   total number density for each element. This can be a series of 1's for each row in the matrix relating to the ground
+	   state of the repsective element, however one can just use the total number density for that elements and then the
+	   densities which the solver computes are just the actual number densities for each ion. This does mean that different rows
+	   are orders of magnitude different, so one can imagine numerical issues. However each element is essentially solved for
+	   seperately.. Something to watch */
 
-for (nn=0;nn<nions;nn++)
+	for (nn = 0; nn < nions; nn++)
 	{
-	if (ion[nn].istate==1)
+		if (ion[nn].istate == 1)
 		{
-		b_temp[nn]=nh * ele[xelem[nn]].abun;
-		for (mm=0;mm<nions;mm++)
+			b_temp[nn] = nh * ele[xelem[nn]].abun;
+			for (mm = 0; mm < nions; mm++)
 			{
-			if (ion[mm].z==ion[nn].z)
+				if (ion[mm].z == ion[nn].z)
 				{
-				rate_matrix[nn][mm]=1.0;
+					rate_matrix[nn][mm] = 1.0;
 				}
-			else
+				else
 				{
-				rate_matrix[nn][mm]=0.0;
+					rate_matrix[nn][mm] = 0.0;
 				}
 			}
 		}
-	else
+		else
 		{
-		b_temp[nn]=0.0;
+			b_temp[nn] = 0.0;
 		}
 	}
-  
-  return (0);
+
+	return (0);
 }
 
 /***********************************************************
@@ -577,86 +600,83 @@ for (nn=0;nn<nions;nn++)
 **************************************************************/
 
 int solve_matrix(a_data, b_data, nrows, x)
-  double *a_data, *b_data;
-  int nrows;
-  double *x;
+		 double *a_data, *b_data;
+		 int nrows;
+		 double *x;
 {
-  int mm, ierr, s;
-  double test_val;
-  gsl_permutation *p;		//NEWKSL
-  gsl_matrix_view m;		//NEWKSL
-  gsl_vector_view b;		//NEWKSL
-  gsl_vector *test_vector, *populations;	//NEWKSL
-  gsl_matrix *test_matrix;
+	int mm, ierr, s;
+	double test_val;
+	gsl_permutation *p;						// NEWKSL
+	gsl_matrix_view m;						// NEWKSL
+	gsl_vector_view b;						// NEWKSL
+	gsl_vector *test_vector, *populations;	// NEWKSL
+	gsl_matrix *test_matrix;
 
-  ierr = 0;
-  test_val = 0.0;
+	ierr = 0;
+	test_val = 0.0;
 
-  /* create gsl matrix/vector views of the arrays of rates */
-  m = gsl_matrix_view_array (a_data, nrows, nrows);	//KSLNEW
+	/* create gsl matrix/vector views of the arrays of rates */
+	m = gsl_matrix_view_array(a_data, nrows, nrows);	// KSLNEW
 
-  /* these are used for testing the solution below */
-  test_matrix = gsl_matrix_alloc(nrows, nrows);
-  test_vector = gsl_vector_alloc (nrows);
+	/* these are used for testing the solution below */
+	test_matrix = gsl_matrix_alloc(nrows, nrows);
+	test_vector = gsl_vector_alloc(nrows);
 
-  gsl_matrix_memcpy(test_matrix, &m.matrix); 	// create copy for testing 
+	gsl_matrix_memcpy(test_matrix, &m.matrix);	// create copy for testing 
 
-  b = gsl_vector_view_array (b_data, nrows);	//KSLNEW
+	b = gsl_vector_view_array(b_data, nrows);	// KSLNEW
 
-  /* the populations vector will be a gsl vector which stores populations */
-  populations = gsl_vector_alloc (nrows);	//KSLNEW
+	/* the populations vector will be a gsl vector which stores populations */
+	populations = gsl_vector_alloc(nrows);	// KSLNEW
 
 
-  p = gsl_permutation_alloc (nrows);	//NEWKSL
+	p = gsl_permutation_alloc(nrows);	// NEWKSL
 
-  gsl_linalg_LU_decomp (&m.matrix, p, &s);
+	gsl_linalg_LU_decomp(&m.matrix, p, &s);
 
-  gsl_linalg_LU_solve (&m.matrix, p, &b.vector, populations);
+	gsl_linalg_LU_solve(&m.matrix, p, &b.vector, populations);
 
-  gsl_permutation_free (p);
+	gsl_permutation_free(p);
 
-  /* JM 140414 -- before we clean, we should check that the populations vector we 
-         have just created really is a solution to the matrix equation */
-      
-  /* gsl_blas_dgemv declaration contained in my_linalg.h, taken from gsl library */
-  /* The following line does the matrix multiplication 
-             test_vector = 1.0 * test_matrix * populations
-     The CblasNoTrans statement just says we do not do anything to test_matrix, 
-     and the 0.0 means we do not add a second matrix to the result 
-     If the solution has worked, then test_vector should be equal to b_temp */
+	/* JM 140414 -- before we clean, we should check that the populations vector we have just created really is a solution to
+	   the matrix equation */
 
-  ierr = gsl_blas_dgemv(CblasNoTrans, 1.0, test_matrix, populations, 0.0, test_vector);
+	/* gsl_blas_dgemv declaration contained in my_linalg.h, taken from gsl library */
+	/* The following line does the matrix multiplication test_vector = 1.0 * test_matrix * populations The CblasNoTrans
+	   statement just says we do not do anything to test_matrix, and the 0.0 means we do not add a second matrix to the result
+	   If the solution has worked, then test_vector should be equal to b_temp */
 
-  if (ierr != 0)
-    {
-  	  Error("solve_matrix: bad return when testing matrix solution to rate equations.\n");
-    }
+	ierr = gsl_blas_dgemv(CblasNoTrans, 1.0, test_matrix, populations, 0.0, test_vector);
 
-  /* now cycle through and check the solution to y = m * populations really is
-     (1, 0, 0 ... 0) */
+	if (ierr != 0)
+	{
+		Error("solve_matrix: bad return when testing matrix solution to rate equations.\n");
+	}
 
-  for (mm = 0; mm < nrows; mm++)
-    {
+	/* now cycle through and check the solution to y = m * populations really is (1, 0, 0 ... 0) */
 
-      /* get the element of the vector we want to check */
-      test_val = gsl_vector_get (test_vector, mm);
-      
-      if ( (fabs((test_val - b_data[mm]))/test_val) > EPSILON)
-        {
-      	  //Error("solve_matrix: test solution fails for row %i %e != %e\n",
-      	  //    	mm, test_val, b_data[mm]);
-      	  ierr = 1;
-      	}
-    }
+	for (mm = 0; mm < nrows; mm++)
+	{
 
-  /* copy the populations to a normal array */
-  for (mm = 0; mm < nrows; mm++)
-  	x[mm] = gsl_vector_get (populations, mm);
+		/* get the element of the vector we want to check */
+		test_val = gsl_vector_get(test_vector, mm);
 
-  /* free memory */
-  free (test_vector);
-  free (test_matrix);
-  gsl_vector_free (populations);
+		if ((fabs((test_val - b_data[mm])) / test_val) > EPSILON)
+		{
+			// Error("solve_matrix: test solution fails for row %i %e != %e\n",
+			// mm, test_val, b_data[mm]);
+			ierr = 1;
+		}
+	}
 
-  return (ierr);
+	/* copy the populations to a normal array */
+	for (mm = 0; mm < nrows; mm++)
+		x[mm] = gsl_vector_get(populations, mm);
+
+	/* free memory */
+	free(test_vector);
+	free(test_matrix);
+	gsl_vector_free(populations);
+
+	return (ierr);
 }

--- a/source/saha.c
+++ b/source/saha.c
@@ -188,11 +188,11 @@ nebular_concentrations (xplasma, mode)
 //NSH 1411 - two new modes for matrix ionization schemes
   else if (mode == NEBULARMODE_MATRIX_BB)
 	{
-	m=matrix_solv(xplasma,mode);
+	m=matrix_ion_populations(xplasma,mode);
 	}
   else if(mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
 	{
-	m=matrix_solv(xplasma,mode);
+	m=matrix_ion_populations(xplasma,mode);
 	}
 
   else

--- a/source/templates.h
+++ b/source/templates.h
@@ -463,6 +463,8 @@ double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
 int matrix_solv(PlasmaPtr xplasma, int mode);
+int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
+int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* py_wind_sub.c */
 int zoom(int direction);
 int overview(WindPtr w, char rootname[]);

--- a/source/templates.h
+++ b/source/templates.h
@@ -462,7 +462,7 @@ double tb_planck1(double freq);
 double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
-int matrix_solv(PlasmaPtr xplasma, int mode);
+int matrix_ion_populations(PlasmaPtr xplasma, int mode);
 int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
 int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* py_wind_sub.c */


### PR DESCRIPTION
This is a bit of reorganising of @Higginbottom 's rate matrix implementation, as discussed also with @kslong 
- rename matrix_solv to matrix_ion_populations
- move code which populates the rate matrix with rates into a subroutine populate_ion_rate_matrix
  - populate_ion_rate_matrix(xplasma, rate_matrix, pi_rates, rr_rates, b_temp, xne, xelem)
  - this populates the array rate_matrix with rates rr_rates and pi_rates in cell xplasma
  - it also uses the di and dr rates compited
- solve_matrix is a new, general routine, which solves the equation A x = b for x
  - it places the solution in an array populations
  - it takes a_data and b_data arrays as 1d versions of the matrix A and vector b
  - this routine is now also used by macro_pops

This is merging from a branch in my forked repository into the matrix_test branch in the main dev branch. I've verified that this produces identical results in the matrix ionization scheme, but need to test thoroughly for macro-atoms.  
