### PR TITLE
Communicate matom estimators between threads

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -140,7 +140,7 @@ python_objects = bb.o get_atomicdata.o photon2d.o photon_gen.o \
 		cylind_var.o bilinear.o gridwind.o partition.o signal.o auger_ionization.o \
 		agn.o shell_wind.o compton.o torus.o zeta.o dielectronic.o \
 		spectral_estimators.o variable_temperature.o matom_diag.o \
-		log.o lineio.o rdpar.o direct_ion.o
+		log.o lineio.o rdpar.o direct_ion.o para_update.o
 
 
 python_source= bb.c get_atomicdata.c python.c photon2d.c photon_gen.c \
@@ -155,7 +155,7 @@ python_source= bb.c get_atomicdata.c python.c photon2d.c photon_gen.c \
 		cylind_var.c bilinear.c gridwind.c partition.c signal.c auger_ionization.c \
 		agn.c shell_wind.c compton.c torus.c zeta.c dielectronic.c \
 		spectral_estimators.c variable_temperature.c matom_diag.c \
-		direct_ion.c
+		direct_ion.c para_update.c
 
 # kpar_source is now declared seaprately from python_source so that the file log.h 
 # can be made using cproto

--- a/source/foo.h
+++ b/source/foo.h
@@ -461,6 +461,10 @@ int matom_emiss_report(void);
 /* direct_ion.c */
 int compute_di_coeffs(double T);
 double total_di(WindPtr one, double t_e);
+/* para_update.c */
+int communicate_estimators_para(void);
+int gather_spectra_para(int nspec_helper, int nspecs);
+int communicate_matom_estimators_para(void);
 /* py_wind_sub.c */
 int zoom(int direction);
 int overview(WindPtr w, char rootname[]);

--- a/source/matom.c
+++ b/source/matom.c
@@ -2244,8 +2244,12 @@ get_matom_f (mode)
       for (m = 0; m < nlevels_macro; m++)
 	{
 	  norm += macromain[n].matom_abs[m];
+	  if (sane_check(macromain[n].matom_abs[m]))
+	  	Error("matom_abs is %8.4e in matom %i level %i\n",macromain[n].matom_abs[m], n, m);
 	}
       norm += plasmamain[n].kpkt_abs;
+      if (sane_check(plasmamain[n].kpkt_abs))
+        Error("kpkt_abs is %8.4e in matom %i\n",plasmamain[n].kpkt_abs, n);
     }
 
 

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -1,7 +1,13 @@
 /***********************************************************
                         University of Southampton
 
-Synopsis: communicate_estimators_para
+Synopsis:   
+  communicate_estimators_para averages the spectral
+  estimators between tasks using MPI_Reduce. 
+  It should only be called if the MPI_ON flag was present 
+  in compilation. It communicates all the information
+  required for the spectral model ionization scheme, and 
+  also heating and cooling quantities in cells.
 
 Arguments:		
 
@@ -197,7 +203,13 @@ communicate_estimators_para ()
 
 Synopsis: gather_spectra_para
 
-Arguments:		
+Arguments:	
+  int nspec_helper
+    size of the helper arrays used by the MPI_Reduce and Broadcast routines
+
+  int nspecs
+    the number of spectra computed. This is longer for the spectral cycles than
+    the ionization cycles 	
 
 Returns:
  
@@ -260,7 +272,13 @@ gather_spectra_para (nspec_helper, nspecs)
 /***********************************************************
                         University of Southampton
 
-Synopsis: communicate_matom_estimators_para
+Synopsis: 
+  communicate_matom_estimators_para averages the macro-atom 
+  estimators between tasks using MPI_Reduce. 
+  It should only be called if the MPI_ON flag was present 
+  in compilation, and returns 0 immediately if no macro atom levels.
+  This should probably be improved by working out exactly
+  what is needed in simple-ion only mode. 
 
 Arguments:		
 
@@ -407,13 +425,14 @@ communicate_matom_estimators_para ()
 
   for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
     {
-
+      /* one kpkt_abs quantity per cell */
       plasmamain[mpi_i].kpkt_abs = cell_helper[mpi_i];
 
+      /* each of the cooling sums and normalisations also have one quantity per cell */
       macromain[mpi_i].cooling_normalisation = cell_helper[mpi_i + NPLASMA];
       macromain[mpi_i].cooling_bftot = cell_helper[mpi_i + 2 * NPLASMA];
       macromain[mpi_i].cooling_bf_coltot = cell_helper[mpi_i + 3 * NPLASMA];
-      macromain[mpi_i].cooling_bbtot = cell_helper[mpi_i + 4 * NPLASMA];
+      macromain[mpi_i].cooling_bbtot = cell_helper[mpi_i + 4 * NPLASMA];lslt 
       macromain[mpi_i].cooling_ff = cell_helper[mpi_i + 5 * NPLASMA];
       macromain[mpi_i].cooling_adiabatic = cell_helper[mpi_i + 6 * NPLASMA];
 
@@ -454,6 +473,8 @@ communicate_matom_estimators_para ()
   }
     }
 
+
+  /* at this stage each thread should have the correctly averaged estimators */
   Log_parallel ("Thread %d happy after broadcast.\n", rank_global);
 
 

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -410,7 +410,7 @@ communicate_matom_estimators_para ()
   MPI_Reduce (gamma_helper, gamma_helper2, NPLASMA * 4 * size_gamma_est, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   MPI_Reduce (alpha_helper, alpha_helper2, NPLASMA * 2 * size_alpha_est, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   MPI_Reduce (cooling_bf_helper, cooling_bf_helper2, NPLASMA * 2 * ntop_phot, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-  MPI_Reduce (cooling_bb_helper, alpha_helper2, NPLASMA * nlines, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce (cooling_bb_helper, cooling_bb_helper2, NPLASMA * nlines, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 
 
   if (rank_global == 0)

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -288,10 +288,18 @@ communicate_matom_estimators_para ()
   double *cooling_bf_helper, *cooling_bb_helper; 
   double *cooling_bf_helper2, *cooling_bb_helper2;
 
+  if (nlevels_macro == 0 && geo.nmacro == 0)
+  {
+    /* in this case no space would have been allocated for macro-atom estimators */
+    Log("No need to communicate matom estimators as no macro-atoms!\n");
+    return (0);
+  }
+
   /* allocate helper arrays for the estimators we want to communicate */
   /* the sizes of these arrays should match the allocation in calloc_estimators in gridwind.c */
   /* we need two arrays for each set of variables. Note that we stick all estimators of
      the same size in the same helper array */
+  /* could put some error conditions here to check memory allocation worked */
   jbar_helper = calloc (sizeof (double), NPLASMA * size_Jbar_est);
   gamma_helper = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
   alpha_helper = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -35,7 +35,7 @@ int
 communicate_estimators_para ()
 {
 #ifdef MPI_ON   // these routines should only be called anyway in parallel but we need these to compile
-  
+
   int mpi_i, mpi_j;
   double *maxfreqhelper, *maxfreqhelper2;
   /*NSH 131213 the next line introduces new helper arrays for the max and min frequencies in bands */
@@ -172,12 +172,12 @@ communicate_estimators_para ()
   MPI_Bcast (iredhelper2, plasma_int_helpers, MPI_INT, 0, MPI_COMM_WORLD);
   for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
     {
-      plasmamain[mpi_i].ntot = iredhelper[mpi_i];
-      plasmamain[mpi_i].ntot_star = iredhelper[mpi_i + NPLASMA];
-      plasmamain[mpi_i].ntot_bl = iredhelper[mpi_i + 2 * NPLASMA];
-      plasmamain[mpi_i].ntot_disk = iredhelper[mpi_i + 3 * NPLASMA];
-      plasmamain[mpi_i].ntot_wind = iredhelper[mpi_i + 4 * NPLASMA];
-      plasmamain[mpi_i].ntot_agn = iredhelper[mpi_i + 5 * NPLASMA];
+      plasmamain[mpi_i].ntot = iredhelper2[mpi_i];
+      plasmamain[mpi_i].ntot_star = iredhelper2[mpi_i + NPLASMA];
+      plasmamain[mpi_i].ntot_bl = iredhelper2[mpi_i + 2 * NPLASMA];
+      plasmamain[mpi_i].ntot_disk = iredhelper2[mpi_i + 3 * NPLASMA];
+      plasmamain[mpi_i].ntot_wind = iredhelper2[mpi_i + 4 * NPLASMA];
+      plasmamain[mpi_i].ntot_agn = iredhelper2[mpi_i + 5 * NPLASMA];
       for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
 	{
 	  plasmamain[mpi_i].nxtot[mpi_j] = iredhelper2[mpi_i + (6 + mpi_j) * NPLASMA];
@@ -435,50 +435,50 @@ communicate_matom_estimators_para ()
   for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
     {
       /* one kpkt_abs quantity per cell */
-      plasmamain[mpi_i].kpkt_abs = cell_helper[mpi_i];
+      plasmamain[mpi_i].kpkt_abs = cell_helper2[mpi_i];
 
       /* each of the cooling sums and normalisations also have one quantity per cell */
-      macromain[mpi_i].cooling_normalisation = cell_helper[mpi_i + NPLASMA];
-      macromain[mpi_i].cooling_bftot = cell_helper[mpi_i + 2 * NPLASMA];
-      macromain[mpi_i].cooling_bf_coltot = cell_helper[mpi_i + 3 * NPLASMA];
-      macromain[mpi_i].cooling_bbtot = cell_helper[mpi_i + 4 * NPLASMA];
-      macromain[mpi_i].cooling_ff = cell_helper[mpi_i + 5 * NPLASMA];
-      macromain[mpi_i].cooling_adiabatic = cell_helper[mpi_i + 6 * NPLASMA];
+      macromain[mpi_i].cooling_normalisation = cell_helper2[mpi_i + NPLASMA];
+      macromain[mpi_i].cooling_bftot = cell_helper2[mpi_i + 2 * NPLASMA];
+      macromain[mpi_i].cooling_bf_coltot = cell_helper2[mpi_i + 3 * NPLASMA];
+      macromain[mpi_i].cooling_bbtot = cell_helper2[mpi_i + 4 * NPLASMA];
+      macromain[mpi_i].cooling_ff = cell_helper2[mpi_i + 5 * NPLASMA];
+      macromain[mpi_i].cooling_adiabatic = cell_helper2[mpi_i + 6 * NPLASMA];
 
 
       for (n = 0; n < nlevels_macro; n++)
 	{
-	  macromain[mpi_i].matom_abs[n] = level_helper[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].matom_abs[n] = level_helper2[mpi_i + (n * NPLASMA)];
 	}
 
       for (n = 0; n < size_Jbar_est; n++)
 	{
-	  macromain[mpi_i].jbar[n] = jbar_helper[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].jbar[n] = jbar_helper2[mpi_i + (n * NPLASMA)];
 	}
 
       for (n = 0; n < size_gamma_est; n++)
 	{
-	  macromain[mpi_i].alpha_st[n] = gamma_helper[mpi_i + (n * NPLASMA)];
-	  macromain[mpi_i].alpha_st_e[n] = gamma_helper[mpi_i + ((n + size_gamma_est) * NPLASMA)] / np_mpi_global;
-	  macromain[mpi_i].gamma[n] = gamma_helper[mpi_i + ((n + 2 * size_gamma_est) * NPLASMA)];
-	  macromain[mpi_i].gamma_e[n] = gamma_helper[mpi_i + ((n + 3 * size_gamma_est) * NPLASMA)];
+	  macromain[mpi_i].alpha_st[n] = gamma_helper2[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].alpha_st_e[n] = gamma_helper2[mpi_i + ((n + size_gamma_est) * NPLASMA)] / np_mpi_global;
+	  macromain[mpi_i].gamma[n] = gamma_helper2[mpi_i + ((n + 2 * size_gamma_est) * NPLASMA)];
+	  macromain[mpi_i].gamma_e[n] = gamma_helper2[mpi_i + ((n + 3 * size_gamma_est) * NPLASMA)];
 	}
 
       for (n = 0; n < size_alpha_est; n++)
 	{
-	  macromain[mpi_i].recomb_sp[n] = alpha_helper[mpi_i + (n * NPLASMA)];
-	  macromain[mpi_i].recomb_sp_e[n] = alpha_helper[mpi_i + ((n + size_alpha_est) * NPLASMA)];
+	  macromain[mpi_i].recomb_sp[n] = alpha_helper2[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].recomb_sp_e[n] = alpha_helper2[mpi_i + ((n + size_alpha_est) * NPLASMA)];
 	}
 
       for (n = 0; n < ntop_phot; n++)
   {
-    macromain[mpi_i].cooling_bf[n] = cooling_bf_helper[mpi_i + (n * NPLASMA)];
-    macromain[mpi_i].cooling_bf_col[n] = cooling_bf_helper[mpi_i + ((n + ntop_phot) * NPLASMA)];
+    macromain[mpi_i].cooling_bf[n] = cooling_bf_helper2[mpi_i + (n * NPLASMA)];
+    macromain[mpi_i].cooling_bf_col[n] = cooling_bf_helper2[mpi_i + ((n + ntop_phot) * NPLASMA)];
   }
 
       for (n = 0; n < nlines; n++)
   {
-    macromain[mpi_i].cooling_bb[n] = cooling_bb_helper[mpi_i + (n * NPLASMA)];
+    macromain[mpi_i].cooling_bb[n] = cooling_bb_helper2[mpi_i + (n * NPLASMA)];
   }
     }
 

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -34,6 +34,8 @@ History:
 int
 communicate_estimators_para ()
 {
+#ifdef MPI_ON   // these routines should only be called anyway in parallel but we need these to compile
+  
   int mpi_i, mpi_j;
   double *maxfreqhelper, *maxfreqhelper2;
   /*NSH 131213 the next line introduces new helper arrays for the max and min frequencies in bands */
@@ -50,7 +52,6 @@ communicate_estimators_para ()
   /* The size of the helper array for integers. We transmit 6 numbers 
      for each cell, plus one array of length NXBANDS */
   plasma_int_helpers = (6 + NXBANDS) * NPLASMA;
-
 
 
   maxfreqhelper = calloc (sizeof (double), NPLASMA);
@@ -194,6 +195,7 @@ communicate_estimators_para ()
   free (iredhelper);
   free (iredhelper2);
 
+#endif
   return (0);
 }
 
@@ -228,6 +230,8 @@ gather_spectra_para (nspec_helper, nspecs)
      int nspec_helper;
      int nspecs;
 {
+#ifdef MPI_ON   // these routines should only be called anyway in parallel but we need these to compile
+
   double *redhelper, *redhelper2;
   int mpi_i, mpi_j;
 
@@ -263,6 +267,7 @@ gather_spectra_para (nspec_helper, nspecs)
 
   free (redhelper);
   free (redhelper2);
+#endif
 
   return (0);
 }
@@ -298,6 +303,8 @@ History:
 int
 communicate_matom_estimators_para ()
 {
+#ifdef MPI_ON   // these routines should only be called anyway in parallel but we need these to compile
+
   int n, mpi_i;
   double *gamma_helper, *alpha_helper;
   double *level_helper, *cell_helper, *jbar_helper;
@@ -312,6 +319,8 @@ communicate_matom_estimators_para ()
     Log("No need to communicate matom estimators as no macro-atoms!\n");
     return (0);
   }
+
+
 
   /* allocate helper arrays for the estimators we want to communicate */
   /* the sizes of these arrays should match the allocation in calloc_estimators in gridwind.c */
@@ -432,7 +441,7 @@ communicate_matom_estimators_para ()
       macromain[mpi_i].cooling_normalisation = cell_helper[mpi_i + NPLASMA];
       macromain[mpi_i].cooling_bftot = cell_helper[mpi_i + 2 * NPLASMA];
       macromain[mpi_i].cooling_bf_coltot = cell_helper[mpi_i + 3 * NPLASMA];
-      macromain[mpi_i].cooling_bbtot = cell_helper[mpi_i + 4 * NPLASMA];lslt 
+      macromain[mpi_i].cooling_bbtot = cell_helper[mpi_i + 4 * NPLASMA];
       macromain[mpi_i].cooling_ff = cell_helper[mpi_i + 5 * NPLASMA];
       macromain[mpi_i].cooling_adiabatic = cell_helper[mpi_i + 6 * NPLASMA];
 
@@ -498,6 +507,8 @@ communicate_matom_estimators_para ()
   free (alpha_helper2);
   free (cooling_bf_helper2);
   free (cooling_bb_helper2);
+#endif
+
 
   return (0);
 }

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -1,0 +1,402 @@
+/***********************************************************
+                        University of Southampton
+
+Synopsis: communicate_estimators_para
+
+Arguments:		
+
+Returns:
+ 
+Description:	
+	
+Notes:
+  This was originally done in python.c but I've moved here for more readable code.
+
+History:
+    JM Coded as part of fix to #132
+
+
+
+**************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "atomic.h"
+#include "python.h"
+
+int
+communicate_estimators_para ()
+{
+  int mpi_i, mpi_j;
+  double *maxfreqhelper, *maxfreqhelper2;
+  /*NSH 131213 the next line introduces new helper arrays for the max and min frequencies in bands */
+  double *maxbandfreqhelper, *maxbandfreqhelper2, *minbandfreqhelper, *minbandfreqhelper2;
+  double *redhelper, *redhelper2;
+  int *iredhelper, *iredhelper2;
+  // int size_of_helpers;
+  int plasma_double_helpers, plasma_int_helpers;
+
+  /* The size of the helper array for doubles. We transmit 10 numbers 
+     for each cell, plus three arrays, each of length NXBANDS */
+  plasma_double_helpers = (14 + 3 * NXBANDS) * NPLASMA;
+
+  /* The size of the helper array for integers. We transmit 6 numbers 
+     for each cell, plus one array of length NXBANDS */
+  plasma_int_helpers = (6 + NXBANDS) * NPLASMA;
+
+
+
+  maxfreqhelper = calloc (sizeof (double), NPLASMA);
+  maxfreqhelper2 = calloc (sizeof (double), NPLASMA);
+  /* NSH 131213 - allocate memory for the band limited max and min frequencies */
+  maxbandfreqhelper = calloc (sizeof (double), NPLASMA * NXBANDS);
+  maxbandfreqhelper2 = calloc (sizeof (double), NPLASMA * NXBANDS);
+  minbandfreqhelper = calloc (sizeof (double), NPLASMA * NXBANDS);
+  minbandfreqhelper2 = calloc (sizeof (double), NPLASMA * NXBANDS);
+  redhelper = calloc (sizeof (double), plasma_double_helpers);
+  redhelper2 = calloc (sizeof (double), plasma_double_helpers);
+  iredhelper = calloc (sizeof (int), plasma_int_helpers);
+  iredhelper2 = calloc (sizeof (int), plasma_int_helpers);
+
+
+  MPI_Barrier (MPI_COMM_WORLD);
+  // the following blocks gather all the estimators to the zeroth (Master) thread
+
+
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+      maxfreqhelper[mpi_i] = plasmamain[mpi_i].max_freq;
+      redhelper[mpi_i] = plasmamain[mpi_i].j / np_mpi_global;
+      redhelper[mpi_i + NPLASMA] = plasmamain[mpi_i].ave_freq / np_mpi_global;
+      redhelper[mpi_i + 2 * NPLASMA] = plasmamain[mpi_i].lum / np_mpi_global;
+      redhelper[mpi_i + 3 * NPLASMA] = plasmamain[mpi_i].heat_tot / np_mpi_global;
+      redhelper[mpi_i + 4 * NPLASMA] = plasmamain[mpi_i].heat_lines / np_mpi_global;
+      redhelper[mpi_i + 5 * NPLASMA] = plasmamain[mpi_i].heat_ff / np_mpi_global;
+      redhelper[mpi_i + 6 * NPLASMA] = plasmamain[mpi_i].heat_comp / np_mpi_global;
+      redhelper[mpi_i + 7 * NPLASMA] = plasmamain[mpi_i].heat_ind_comp / np_mpi_global;
+      redhelper[mpi_i + 8 * NPLASMA] = plasmamain[mpi_i].heat_photo / np_mpi_global;
+      redhelper[mpi_i + 9 * NPLASMA] = plasmamain[mpi_i].ip / np_mpi_global;
+      redhelper[mpi_i + 10 * NPLASMA] = plasmamain[mpi_i].j_direct / np_mpi_global;
+      redhelper[mpi_i + 11 * NPLASMA] = plasmamain[mpi_i].j_scatt / np_mpi_global;
+      redhelper[mpi_i + 12 * NPLASMA] = plasmamain[mpi_i].ip_direct / np_mpi_global;
+      redhelper[mpi_i + 13 * NPLASMA] = plasmamain[mpi_i].ip_scatt / np_mpi_global;
+      for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
+	{
+	  redhelper[mpi_i + (14 + mpi_j) * NPLASMA] = plasmamain[mpi_i].xj[mpi_j] / np_mpi_global;
+	  redhelper[mpi_i + (14 + NXBANDS + mpi_j) * NPLASMA] = plasmamain[mpi_i].xave_freq[mpi_j] / np_mpi_global;
+	  redhelper[mpi_i + (14 + 2 * NXBANDS + mpi_j) * NPLASMA] = plasmamain[mpi_i].xsd_freq[mpi_j] / np_mpi_global;
+
+	  /* 131213 NSH populate the band limited min and max frequency arrays */
+	  maxbandfreqhelper[mpi_i * NXBANDS + mpi_j] = plasmamain[mpi_i].fmax[mpi_j];
+	  minbandfreqhelper[mpi_i * NXBANDS + mpi_j] = plasmamain[mpi_i].fmin[mpi_j];
+
+	}
+    }
+  /* 131213 NSH communiate the min and max band frequencies these use MPI_MIN or MPI_MAX */
+  MPI_Reduce (minbandfreqhelper, minbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+  MPI_Reduce (maxbandfreqhelper, maxbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Reduce (maxfreqhelper, maxfreqhelper2, NPLASMA, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Reduce (redhelper, redhelper2, plasma_double_helpers, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  if (rank_global == 0)
+    {
+
+      Log_parallel ("Zeroth thread successfully received the normalised estimators. About to broadcast.\n");
+    }
+
+  MPI_Bcast (redhelper2, plasma_double_helpers, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (maxfreqhelper2, NPLASMA, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  /* 131213 NSH Send out the global min and max band limited frequencies to all threads */
+  MPI_Bcast (minbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (maxbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+      plasmamain[mpi_i].max_freq = maxfreqhelper2[mpi_i];
+      plasmamain[mpi_i].j = redhelper2[mpi_i];
+      plasmamain[mpi_i].ave_freq = redhelper2[mpi_i + NPLASMA];
+      plasmamain[mpi_i].lum = redhelper2[mpi_i + 2 * NPLASMA];
+      plasmamain[mpi_i].heat_tot = redhelper2[mpi_i + 3 * NPLASMA];
+      plasmamain[mpi_i].heat_lines = redhelper2[mpi_i + 4 * NPLASMA];
+      plasmamain[mpi_i].heat_ff = redhelper2[mpi_i + 5 * NPLASMA];
+      plasmamain[mpi_i].heat_comp = redhelper2[mpi_i + 6 * NPLASMA];
+      plasmamain[mpi_i].heat_ind_comp = redhelper2[mpi_i + 7 * NPLASMA];
+      plasmamain[mpi_i].heat_photo = redhelper2[mpi_i + 8 * NPLASMA];
+      plasmamain[mpi_i].ip = redhelper2[mpi_i + 9 * NPLASMA];
+      plasmamain[mpi_i].j_direct = redhelper2[mpi_i + 10 * NPLASMA];
+      plasmamain[mpi_i].j_scatt = redhelper2[mpi_i + 11 * NPLASMA];
+      plasmamain[mpi_i].ip_direct = redhelper2[mpi_i + 12 * NPLASMA];
+      plasmamain[mpi_i].ip_scatt = redhelper2[mpi_i + 13 * NPLASMA];
+      for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
+	{
+	  plasmamain[mpi_i].xj[mpi_j] = redhelper2[mpi_i + (14 + mpi_j) * NPLASMA];
+	  plasmamain[mpi_i].xave_freq[mpi_j] = redhelper2[mpi_i + (14 + NXBANDS + mpi_j) * NPLASMA];
+	  plasmamain[mpi_i].xsd_freq[mpi_j] = redhelper2[mpi_i + (14 + NXBANDS * 2 + mpi_j) * NPLASMA];
+
+	  /* 131213 NSH And unpack the min and max banded frequencies to the plasma array */
+	  plasmamain[mpi_i].fmax[mpi_j] = maxbandfreqhelper2[mpi_i * NXBANDS + mpi_j];
+	  plasmamain[mpi_i].fmin[mpi_j] = minbandfreqhelper2[mpi_i * NXBANDS + mpi_j];
+	}
+    }
+  Log_parallel ("Thread %d happy after broadcast.\n", rank_global);
+
+  MPI_Barrier (MPI_COMM_WORLD);
+
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+      iredhelper[mpi_i] = plasmamain[mpi_i].ntot;
+      iredhelper[mpi_i + NPLASMA] = plasmamain[mpi_i].ntot_star;
+      iredhelper[mpi_i + 2 * NPLASMA] = plasmamain[mpi_i].ntot_bl;
+      iredhelper[mpi_i + 3 * NPLASMA] = plasmamain[mpi_i].ntot_disk;
+      iredhelper[mpi_i + 4 * NPLASMA] = plasmamain[mpi_i].ntot_wind;
+      iredhelper[mpi_i + 5 * NPLASMA] = plasmamain[mpi_i].ntot_agn;
+      for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
+	{
+	  iredhelper[mpi_i + (6 + mpi_j) * NPLASMA] = plasmamain[mpi_i].nxtot[mpi_j];
+	}
+    }
+  MPI_Reduce (iredhelper, iredhelper2, plasma_int_helpers, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  if (rank_global == 0)
+    {
+      Log_parallel ("Zeroth thread successfully received the integer sum. About to broadcast.\n");
+    }
+
+  MPI_Bcast (iredhelper2, plasma_int_helpers, MPI_INT, 0, MPI_COMM_WORLD);
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+      plasmamain[mpi_i].ntot = iredhelper[mpi_i];
+      plasmamain[mpi_i].ntot_star = iredhelper[mpi_i + NPLASMA];
+      plasmamain[mpi_i].ntot_bl = iredhelper[mpi_i + 2 * NPLASMA];
+      plasmamain[mpi_i].ntot_disk = iredhelper[mpi_i + 3 * NPLASMA];
+      plasmamain[mpi_i].ntot_wind = iredhelper[mpi_i + 4 * NPLASMA];
+      plasmamain[mpi_i].ntot_agn = iredhelper[mpi_i + 5 * NPLASMA];
+      for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
+	{
+	  plasmamain[mpi_i].nxtot[mpi_j] = iredhelper2[mpi_i + (6 + mpi_j) * NPLASMA];
+	}
+    }
+
+  free (maxfreqhelper);
+  free (maxfreqhelper2);
+  free (maxbandfreqhelper);
+  free (maxbandfreqhelper2);
+  free (minbandfreqhelper);
+  free (minbandfreqhelper2);
+  free (redhelper);
+  free (redhelper2);
+  free (iredhelper);
+  free (iredhelper2);
+
+  return (0);
+}
+
+
+/***********************************************************
+                        University of Southampton
+
+Synopsis: gather_spectra_para
+
+Arguments:		
+
+Returns:
+ 
+Description:	
+	
+Notes:
+
+History:
+    JM Coded as part of fix to #132
+
+**************************************************************/
+
+
+int
+gather_spectra_para (nspec_helper, nspecs)
+     int nspec_helper;
+     int nspecs;
+{
+  double *redhelper, *redhelper2;
+  int mpi_i, mpi_j;
+
+  redhelper = calloc (sizeof (double), nspec_helper);
+  redhelper2 = calloc (sizeof (double), nspec_helper);
+
+
+  for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
+    {
+      for (mpi_j = 0; mpi_j < nspecs; mpi_j++)
+	{
+	  redhelper[mpi_i * nspecs + mpi_j] = xxspec[mpi_j].f[mpi_i] / np_mpi_global;
+
+	  if (geo.ioniz_or_extract)	// this is True in ionization cycles only, when we also have a log_spec_tot file
+	    redhelper[mpi_i * nspecs + mpi_j + (NWAVE * nspecs)] = xxspec[mpi_j].lf[mpi_i] / np_mpi_global;
+	}
+    }
+
+  MPI_Reduce (redhelper, redhelper2, nspec_helper, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Bcast (redhelper2, nspec_helper, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
+    {
+      for (mpi_j = 0; mpi_j < nspecs; mpi_j++)
+	{
+	  xxspec[mpi_j].f[mpi_i] = redhelper2[mpi_i * nspecs + mpi_j];
+
+	  if (geo.ioniz_or_extract)	// this is True in ionization cycles only, when we also have a log_spec_tot file
+	    xxspec[mpi_j].lf[mpi_i] = redhelper2[mpi_i * nspecs + mpi_j + (NWAVE * nspecs)];
+	}
+    }
+  MPI_Barrier (MPI_COMM_WORLD);
+
+  free (redhelper);
+  free (redhelper2);
+
+  return (0);
+}
+
+
+
+/***********************************************************
+                        University of Southampton
+
+Synopsis: communicate_matom_estimators_para
+
+Arguments:		
+
+Returns:
+ 
+Description:	
+	
+Notes:
+
+History:
+    JM Coded as part of fix to #132
+
+
+**************************************************************/
+
+
+int
+communicate_matom_estimators_para ()
+{
+  int n, mpi_i;
+  double *gamma_helper, *alpha_helper;
+  double *level_helper, *kpkt_helper, *jbar_helper;
+  double *gamma_helper2, *alpha_helper2;
+  double *level_helper2, *kpkt_helper2, *jbar_helper2;
+
+  /* allocate helper arrays for the estimators we want to communicate */
+  /* the sizes of these arrays should match the allocation in calloc_estimators in gridwind.c */
+  jbar_helper = calloc (sizeof (double), NPLASMA * size_Jbar_est);
+  gamma_helper = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
+  alpha_helper = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);
+  level_helper = calloc (sizeof (double), NPLASMA * nlevels_macro);
+  kpkt_helper = calloc (sizeof (double), NPLASMA);
+  jbar_helper2 = calloc (sizeof (double), NPLASMA * size_Jbar_est);
+  gamma_helper2 = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
+  alpha_helper2 = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);
+  level_helper2 = calloc (sizeof (double), NPLASMA * nlevels_macro);
+  kpkt_helper2 = calloc (sizeof (double), NPLASMA);
+
+
+  MPI_Barrier (MPI_COMM_WORLD);
+
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+
+      kpkt_helper[mpi_i] = plasmamain[mpi_i].kpkt_abs / np_mpi_global;
+
+      for (n = 0; n < nlevels_macro; n++)
+	{
+	  level_helper[mpi_i + (n * NPLASMA)] = macromain[mpi_i].matom_abs[n] / np_mpi_global;
+	}
+
+      for (n = 0; n < size_Jbar_est; n++)
+	{
+	  jbar_helper[mpi_i + (n * NPLASMA)] = macromain[mpi_i].jbar[n] / np_mpi_global;
+	}
+
+      for (n = 0; n < size_gamma_est; n++)
+	{
+	  gamma_helper[mpi_i + (n * NPLASMA)] = macromain[mpi_i].alpha_st[n] / np_mpi_global;
+	  gamma_helper[mpi_i + ((n + size_gamma_est) * NPLASMA)] = macromain[mpi_i].alpha_st_e[n] / np_mpi_global;
+	  gamma_helper[mpi_i + ((n + 2 * size_gamma_est) * NPLASMA)] = macromain[mpi_i].gamma[n] / np_mpi_global;
+	  gamma_helper[mpi_i + ((n + 3 * size_gamma_est) * NPLASMA)] = macromain[mpi_i].gamma_e[n] / np_mpi_global;
+	}
+
+      for (n = 0; n < size_alpha_est; n++)
+	{
+	  alpha_helper[mpi_i + (n * NPLASMA)] = macromain[mpi_i].recomb_sp[n] / np_mpi_global;
+	  alpha_helper[mpi_i + ((n + size_alpha_est) * NPLASMA)] = macromain[mpi_i].recomb_sp_e[n] / np_mpi_global;
+	}
+    }
+
+  /* because in the above loop we have already divided by number of processes, we can now do a sum
+     with MPI_Reduce, passing it MPI_SUM as an argument. This will give us the mean across threads */
+  MPI_Reduce (kpkt_helper, kpkt_helper2, NPLASMA, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce (level_helper, level_helper2, NPLASMA * nlevels_macro, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce (jbar_helper, jbar_helper2, NPLASMA * size_Jbar_est, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce (gamma_helper, gamma_helper2, NPLASMA * 4 * size_gamma_est, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce (alpha_helper, alpha_helper2, NPLASMA * 2 * size_alpha_est, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+  if (rank_global == 0)
+    {
+      Log_parallel ("Zeroth thread successfully received the macro-atom estimators. About to broadcast.\n");
+    }
+
+  MPI_Bcast (kpkt_helper2, NPLASMA, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (level_helper2, NPLASMA * nlevels_macro, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (jbar_helper2, NPLASMA * size_Jbar_est, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (gamma_helper2, NPLASMA * 4 * size_gamma_est, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast (alpha_helper2, NPLASMA * 2 * size_alpha_est, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  /* We now need to copy these reduced variables to the plasma structure in each thread */
+  for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
+    {
+
+      plasmamain[mpi_i].kpkt_abs = kpkt_helper[mpi_i];
+
+      for (n = 0; n < nlevels_macro; n++)
+	{
+	  macromain[mpi_i].matom_abs[n] = level_helper[mpi_i + (n * NPLASMA)];
+	}
+
+      for (n = 0; n < size_Jbar_est; n++)
+	{
+	  macromain[mpi_i].jbar[n] = jbar_helper[mpi_i + (n * NPLASMA)];
+	}
+
+      for (n = 0; n < size_gamma_est; n++)
+	{
+	  macromain[mpi_i].alpha_st[n] = gamma_helper[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].alpha_st_e[n] = gamma_helper[mpi_i + ((n + size_gamma_est) * NPLASMA)] / np_mpi_global;
+	  macromain[mpi_i].gamma[n] = gamma_helper[mpi_i + ((n + 2 * size_gamma_est) * NPLASMA)];
+	  macromain[mpi_i].gamma_e[n] = gamma_helper[mpi_i + ((n + 3 * size_gamma_est) * NPLASMA)];
+	}
+
+      for (n = 0; n < size_alpha_est; n++)
+	{
+	  macromain[mpi_i].recomb_sp[n] = alpha_helper[mpi_i + (n * NPLASMA)];
+	  macromain[mpi_i].recomb_sp_e[n] = alpha_helper[mpi_i + ((n + size_alpha_est) * NPLASMA)];
+	}
+    }
+
+  Log_parallel ("Thread %d happy after broadcast.\n", rank_global);
+
+  MPI_Barrier (MPI_COMM_WORLD);
+
+  free (kpkt_helper);
+  free (level_helper);
+  free (jbar_helper);
+  free (gamma_helper);
+  free (alpha_helper);
+
+  free (kpkt_helper2);
+  free (level_helper2);
+  free (jbar_helper2);
+  free (gamma_helper2);
+  free (alpha_helper2);
+
+  return (0);
+}

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -285,8 +285,8 @@ communicate_matom_estimators_para ()
   double *level_helper, *cell_helper, *jbar_helper;
   double *gamma_helper2, *alpha_helper2;
   double *level_helper2, *cell_helper2, *jbar_helper2;
-  double *cooling_bf_helper, cooling_bb_helper; 
-  double *cooling_bf_helper2, cooling_bb_helper2;
+  double *cooling_bf_helper, *cooling_bb_helper; 
+  double *cooling_bf_helper2, *cooling_bb_helper2;
 
   /* allocate helper arrays for the estimators we want to communicate */
   /* the sizes of these arrays should match the allocation in calloc_estimators in gridwind.c */
@@ -454,7 +454,7 @@ communicate_matom_estimators_para ()
 
   MPI_Barrier (MPI_COMM_WORLD);
 
-  free (kpkt_helper);
+  free (cell_helper);
   free (level_helper);
   free (jbar_helper);
   free (gamma_helper);
@@ -462,7 +462,7 @@ communicate_matom_estimators_para ()
   free (cooling_bf_helper);
   free (cooling_bb_helper);
 
-  free (kpkt_helper2);
+  free (cell_helper2);
   free (level_helper2);
   free (jbar_helper2);
   free (gamma_helper2);

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -288,6 +288,8 @@ communicate_matom_estimators_para ()
 
   /* allocate helper arrays for the estimators we want to communicate */
   /* the sizes of these arrays should match the allocation in calloc_estimators in gridwind.c */
+  /* we need two arrays for each set of variables. Note that we stick all estimators of
+     the same size in the same helper array */
   jbar_helper = calloc (sizeof (double), NPLASMA * size_Jbar_est);
   gamma_helper = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
   alpha_helper = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);
@@ -299,12 +301,14 @@ communicate_matom_estimators_para ()
   level_helper2 = calloc (sizeof (double), NPLASMA * nlevels_macro);
   kpkt_helper2 = calloc (sizeof (double), NPLASMA);
 
-
+  /* set an mpi barrier before we start */
   MPI_Barrier (MPI_COMM_WORLD);
 
+  /* now we loop through each cell and copy the values of our variables 
+     into our helper arrays */
   for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
     {
-
+      /* one kpkt_abs quantity per cell */
       kpkt_helper[mpi_i] = plasmamain[mpi_i].kpkt_abs / np_mpi_global;
 
       for (n = 0; n < nlevels_macro; n++)

--- a/source/python.c
+++ b/source/python.c
@@ -1913,7 +1913,7 @@ run -- 07jul -- ksl
 
     communicate_estimators_para ();
 
-    //communicate_matom_estimators_para (); 
+    communicate_matom_estimators_para (); 
 #endif
 
 

--- a/source/python.c
+++ b/source/python.c
@@ -194,6 +194,10 @@ History:
 			Also some modifications to the parallel communiactions to deal with some new
 			plasma variabales, and the min and max frequency photons seen in bands.
 	1409	ksl	Added new switch -d to enable use of a new Debug logging feature
+	1411 	JM removed photons per cycle in favour of NPHOT. subcycles are now eliminated
+	1501 	JM moved some parallelization stuff to subroutines in para_update.c
+			functions are communicate_estimators_para, communicate_matom_estimators_para,
+			and gather_spectra_para
  	
  	Look in Readme.c for more text concerning the early history of the program.
 
@@ -1914,7 +1918,7 @@ run -- 07jul -- ksl
 
     communicate_estimators_para ();
 
-    communicate_matom_estimators_para (); 
+    communicate_matom_estimators_para (); // this will return 0 if nlevels_macro == 0
 #endif
 
 
@@ -2148,7 +2152,7 @@ run -- 07jul -- ksl
 
       /* Do an MPI reduce to get the spectra all gathered to the master thread */
 #ifdef MPI_ON
-      gather_spectra_para(spec_spec_helpers, MSPEC);
+      gather_spectra_para(spec_spec_helpers, nspectra);
 #endif
 
 

--- a/source/python.c
+++ b/source/python.c
@@ -267,22 +267,11 @@ should allocate the space for the spectra to avoid all this nonsense.  02feb ksl
   int np_mpi;		// rank and number of processes, 0 and 1 in non-parallel
   int time_to_quit;
 
-#ifdef MPI_ON
-  int mpi_i, mpi_j;
-
-
-  double *maxfreqhelper,*maxfreqhelper2; 
-/*NSH 131213 the next line introduces new helper arrays for the max and min frequencies in bands */
-  double *maxbandfreqhelper,*maxbandfreqhelper2,*minbandfreqhelper,*minbandfreqhelper2;
-  double *redhelper, *redhelper2;
-  int *iredhelper, *iredhelper2;
- // int size_of_helpers;
-  int plasma_double_helpers,plasma_int_helpers,ioniz_spec_helpers,spec_spec_helpers;
-#endif
-
   int mkdir();
 
   #ifdef MPI_ON
+    int ioniz_spec_helpers, spec_spec_helpers;
+
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &np_mpi);
@@ -1746,12 +1735,9 @@ run -- 07jul -- ksl
   check_time (root);
 
 #ifdef MPI_ON
-  // Since the wind is now set up can allocate sufficiently big arrays to help with the MPI reductions 
-
-  plasma_double_helpers = (14+3*NXBANDS)*NPLASMA; //The size of the helper array for doubles. We transmit 10 numbers for each cell, plus three arrays, each of length NXBANDS
-  plasma_int_helpers = (6+NXBANDS)*NPLASMA; //The size of the helper array for integers. We transmit 6 numbers for each cell, plus one array of length NXBANDS
+  /* Since the wind is now set up can work out the length big arrays to help with the MPI reductions of the spectra
+     the variables for the estimator arrays are set up in the subroutines themselves */
   ioniz_spec_helpers = 2*MSPEC*NWAVE; //we need space for log and lin spectra for MSPEC XNWAVE
-
   spec_spec_helpers = (NWAVE*(MSPEC+nangles)); //We need space for NWAVE wavelengths for nspectra, which will eventually equal nangles + MSPEC
 
 #endif
@@ -1924,148 +1910,10 @@ run -- 07jul -- ksl
       that has been accummulated on differenet MPI tasks */
 
 #ifdef MPI_ON
- 
-    maxfreqhelper = calloc (sizeof(double),NPLASMA); 
-    maxfreqhelper2 = calloc (sizeof(double),NPLASMA);
-    /* NSH 131213 - allocate memory for the band limited max and min frequencies */
-    maxbandfreqhelper = calloc (sizeof(double),NPLASMA*NXBANDS); 
-    maxbandfreqhelper2 = calloc (sizeof(double),NPLASMA*NXBANDS);
-    minbandfreqhelper = calloc (sizeof(double),NPLASMA*NXBANDS); 
-    minbandfreqhelper2 = calloc (sizeof(double),NPLASMA*NXBANDS);
-    redhelper = calloc (sizeof (double), plasma_double_helpers); 
-    redhelper2 = calloc (sizeof (double), plasma_double_helpers); 
-    iredhelper = calloc (sizeof (int), plasma_int_helpers); 
-    iredhelper2 = calloc (sizeof (int), plasma_int_helpers); 
 
+    communicate_estimators_para ();
 
-    MPI_Barrier(MPI_COMM_WORLD);
-    // the following blocks gather all the estimators to the zeroth (Master) thread
-
-      
-      for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
-	{
- 	  maxfreqhelper[mpi_i] = plasmamain[mpi_i].max_freq;
-	  redhelper[mpi_i] = plasmamain[mpi_i].j/ np_mpi_global;
-	  redhelper[mpi_i+NPLASMA] = plasmamain[mpi_i].ave_freq/ np_mpi_global;
-	  redhelper[mpi_i+2*NPLASMA] = plasmamain[mpi_i].lum/ np_mpi_global;
-	  redhelper[mpi_i+3*NPLASMA] = plasmamain[mpi_i].heat_tot/ np_mpi_global;
-	  redhelper[mpi_i+4*NPLASMA] = plasmamain[mpi_i].heat_lines/ np_mpi_global;
-	  redhelper[mpi_i+5*NPLASMA] = plasmamain[mpi_i].heat_ff/ np_mpi_global;
-	  redhelper[mpi_i+6*NPLASMA] = plasmamain[mpi_i].heat_comp/ np_mpi_global;
-	  redhelper[mpi_i+7*NPLASMA] = plasmamain[mpi_i].heat_ind_comp/ np_mpi_global;
-	  redhelper[mpi_i+8*NPLASMA] = plasmamain[mpi_i].heat_photo/ np_mpi_global;
-      redhelper[mpi_i+9*NPLASMA] = plasmamain[mpi_i].ip / np_mpi_global;
-      redhelper[mpi_i+10*NPLASMA] = plasmamain[mpi_i].j_direct / np_mpi_global;
-      redhelper[mpi_i+11*NPLASMA] = plasmamain[mpi_i].j_scatt / np_mpi_global;
-      redhelper[mpi_i+12*NPLASMA] = plasmamain[mpi_i].ip_direct / np_mpi_global;
-      redhelper[mpi_i+13*NPLASMA] = plasmamain[mpi_i].ip_scatt / np_mpi_global;
-	  for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
-	    {
-	      redhelper[mpi_i+(14+mpi_j)*NPLASMA] = plasmamain[mpi_i].xj[mpi_j]/ np_mpi_global;
-	      redhelper[mpi_i+(14+NXBANDS+mpi_j)*NPLASMA] = plasmamain[mpi_i].xave_freq[mpi_j]/ np_mpi_global;
-	      redhelper[mpi_i+(14+2*NXBANDS+mpi_j)*NPLASMA] = plasmamain[mpi_i].xsd_freq[mpi_j]/ np_mpi_global;
-          
-          /* 131213 NSH populate the band limited min and max frequency arrays */
-	      maxbandfreqhelper[mpi_i*NXBANDS+mpi_j] = plasmamain[mpi_i].fmax[mpi_j];
-	      minbandfreqhelper[mpi_i*NXBANDS+mpi_j] = plasmamain[mpi_i].fmin[mpi_j];
-
-	    }
-	}
-      /* 131213 NSH communiate the min and max band frequencies these use MPI_MIN or MPI_MAX */ 
-      MPI_Reduce(minbandfreqhelper, minbandfreqhelper2, NPLASMA*NXBANDS, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
-      MPI_Reduce(maxbandfreqhelper, maxbandfreqhelper2, NPLASMA*NXBANDS, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
-      MPI_Reduce(maxfreqhelper, maxfreqhelper2, NPLASMA, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
-      MPI_Reduce(redhelper, redhelper2, plasma_double_helpers, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-      if (rank_global == 0)
-	{
-
-	  Log_parallel("Zeroth thread successfully received the normalised estimators. About to broadcast.\n");
-	}
-      
-      MPI_Bcast(redhelper2, plasma_double_helpers, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-      MPI_Bcast(maxfreqhelper2, NPLASMA, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-      /* 131213 NSH Send out the global min and max band limited frequencies to all threads */
-      MPI_Bcast(minbandfreqhelper2, NPLASMA*NXBANDS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-      MPI_Bcast(maxbandfreqhelper2, NPLASMA*NXBANDS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-
-      for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
-	{
-  	  plasmamain[mpi_i].max_freq = maxfreqhelper2[mpi_i];
-	  plasmamain[mpi_i].j = redhelper2[mpi_i];
-	  plasmamain[mpi_i].ave_freq = redhelper2[mpi_i+NPLASMA];
-	  plasmamain[mpi_i].lum = redhelper2[mpi_i+2*NPLASMA];
-	  plasmamain[mpi_i].heat_tot = redhelper2[mpi_i+3*NPLASMA];
-	  plasmamain[mpi_i].heat_lines = redhelper2[mpi_i+4*NPLASMA];
-	  plasmamain[mpi_i].heat_ff = redhelper2[mpi_i+5*NPLASMA];
-	  plasmamain[mpi_i].heat_comp = redhelper2[mpi_i+6*NPLASMA];
-	  plasmamain[mpi_i].heat_ind_comp = redhelper2[mpi_i+7*NPLASMA];
-	  plasmamain[mpi_i].heat_photo = redhelper2[mpi_i+8*NPLASMA];
-      plasmamain[mpi_i].ip = redhelper2[mpi_i+9*NPLASMA];
-      plasmamain[mpi_i].j_direct = redhelper2[mpi_i+10*NPLASMA];
-      plasmamain[mpi_i].j_scatt = redhelper2[mpi_i+11*NPLASMA];
-      plasmamain[mpi_i].ip_direct = redhelper2[mpi_i+12*NPLASMA];
-      plasmamain[mpi_i].ip_scatt = redhelper2[mpi_i+13*NPLASMA];
-	  for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
-	    {
-	      plasmamain[mpi_i].xj[mpi_j]=redhelper2[mpi_i+(14+mpi_j)*NPLASMA];
-	      plasmamain[mpi_i].xave_freq[mpi_j]=redhelper2[mpi_i+(14+NXBANDS+mpi_j)*NPLASMA];
-	      plasmamain[mpi_i].xsd_freq[mpi_j]=redhelper2[mpi_i+(14+NXBANDS*2+mpi_j)*NPLASMA];
-
-          /* 131213 NSH And unpack the min and max banded frequencies to the plasma array */ 
-	      plasmamain[mpi_i].fmax[mpi_j] = maxbandfreqhelper2[mpi_i*NXBANDS+mpi_j];
-	      plasmamain[mpi_i].fmin[mpi_j] = minbandfreqhelper2[mpi_i*NXBANDS+mpi_j];
-	    }
-	}
-      Log_parallel("Thread %d happy after broadcast.\n", rank_global);
-
-      MPI_Barrier(MPI_COMM_WORLD);
-
-      for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
-	{
-	  iredhelper[mpi_i] = plasmamain[mpi_i].ntot;
-	  iredhelper[mpi_i+NPLASMA] = plasmamain[mpi_i].ntot_star;
-	  iredhelper[mpi_i+2*NPLASMA] = plasmamain[mpi_i].ntot_bl;
-	  iredhelper[mpi_i+3*NPLASMA] = plasmamain[mpi_i].ntot_disk;
-	  iredhelper[mpi_i+4*NPLASMA] = plasmamain[mpi_i].ntot_wind;
-	  iredhelper[mpi_i+5*NPLASMA] = plasmamain[mpi_i].ntot_agn;
-	  for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
-	    {
-	      iredhelper[mpi_i+(6+mpi_j)*NPLASMA] = plasmamain[mpi_i].nxtot[mpi_j];
-	    }
-	}
-      MPI_Reduce(iredhelper, iredhelper2, plasma_int_helpers, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-      if (rank_global == 0)
-	{
-	  Log_parallel("Zeroth thread successfully received the integer sum. About to broadcast.\n");
-	}
-      
-      MPI_Bcast(iredhelper2, plasma_int_helpers, MPI_INT, 0, MPI_COMM_WORLD);
-      for (mpi_i = 0; mpi_i < NPLASMA; mpi_i++)
-	{
-	  plasmamain[mpi_i].ntot = iredhelper[mpi_i];
-	  plasmamain[mpi_i].ntot_star = iredhelper[mpi_i+NPLASMA]; 
-	  plasmamain[mpi_i].ntot_bl = iredhelper[mpi_i+2*NPLASMA];
-	  plasmamain[mpi_i].ntot_disk = iredhelper[mpi_i+3*NPLASMA]; 
-	  plasmamain[mpi_i].ntot_wind = iredhelper[mpi_i+4*NPLASMA];
-	  plasmamain[mpi_i].ntot_agn = iredhelper[mpi_i+5*NPLASMA];
-	  for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
-	    {
-	      plasmamain[mpi_i].nxtot[mpi_j] = iredhelper2[mpi_i+(6+mpi_j)*NPLASMA];
-	    }
-	}
-  
-	free (maxfreqhelper);
-    free (maxfreqhelper2);
- 	free (maxbandfreqhelper);
- 	free (maxbandfreqhelper2);
- 	free (minbandfreqhelper);
- 	free (minbandfreqhelper2);
-    free (redhelper);
-    free (redhelper2); 
-    free (iredhelper);
-    free (iredhelper2);
-
+    //communicate_matom_estimators_para (); 
 #endif
 
 
@@ -2116,36 +1964,11 @@ run -- 07jul -- ksl
 
 #ifdef MPI_ON
 
-    redhelper = calloc (sizeof (double), ioniz_spec_helpers); 
-    redhelper2 = calloc (sizeof (double), ioniz_spec_helpers); 
-    
-
-      for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
-	{
-	  for (mpi_j=0; mpi_j < MSPEC; mpi_j++)
-	    {
-	      redhelper[mpi_i*MSPEC + mpi_j]=xxspec[mpi_j].f[mpi_i]/ np_mpi_global;
-	      redhelper[mpi_i*MSPEC + mpi_j + (NWAVE*MSPEC)]=xxspec[mpi_j].lf[mpi_i]/ np_mpi_global;
-	    }
-	}
-
-      MPI_Reduce(redhelper, redhelper2, ioniz_spec_helpers, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-      MPI_Bcast(redhelper2, ioniz_spec_helpers, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-      for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
-	{
-	  for (mpi_j=0; mpi_j < MSPEC; mpi_j++)
-	    {
-	      xxspec[mpi_j].f[mpi_i] = redhelper2[mpi_i*MSPEC + mpi_j];
-	      xxspec[mpi_j].lf[mpi_i] = redhelper2[mpi_i*MSPEC + mpi_j + (NWAVE*MSPEC)];
-	    }
-	}
-      MPI_Barrier(MPI_COMM_WORLD);
-
-	free(redhelper);
-	free(redhelper2);
+    gather_spectra_para (ioniz_spec_helpers, MSPEC);
 
 #endif
+
+
 
 #ifdef MPI_ON
       if (rank_global == 0)
@@ -2324,34 +2147,12 @@ run -- 07jul -- ksl
 
       /* Do an MPI reduce to get the spectra all gathered to the master thread */
 #ifdef MPI_ON
-
-    redhelper = calloc (sizeof (double), spec_spec_helpers); 
-    redhelper2 = calloc (sizeof (double), spec_spec_helpers); 
-
-
-      for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
-	{
-	  for (mpi_j=0; mpi_j < nspectra; mpi_j++)
-	    {
-	      redhelper[mpi_i*nspectra + mpi_j]=xxspec[mpi_j].f[mpi_i]/ np_mpi_global;
-	    }
-	}
-
-      MPI_Reduce(redhelper, redhelper2, spec_spec_helpers, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-      MPI_Bcast(redhelper2, spec_spec_helpers, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-      for (mpi_i = 0; mpi_i < NWAVE; mpi_i++)
-	{
-	  for (mpi_j=0; mpi_j < nspectra; mpi_j++)
-	    {
-	      xxspec[mpi_j].f[mpi_i] = redhelper2[mpi_i*nspectra + mpi_j];
-	    }
-	}
-      MPI_Barrier(MPI_COMM_WORLD);
-
-	free(redhelper);
-	free(redhelper2);
+      gather_spectra_para(spec_spec_helpers, MSPEC);
 #endif
+
+
+
+
 
 #ifdef MPI_ON
       if (rank_global == 0)

--- a/source/templates.h
+++ b/source/templates.h
@@ -461,6 +461,10 @@ int matom_emiss_report(void);
 /* direct_ion.c */
 int compute_di_coeffs(double T);
 double total_di(WindPtr one, double t_e);
+/* para_update.c */
+int communicate_estimators_para(void);
+int gather_spectra_para(int nspec_helper, int nspecs);
+int communicate_matom_estimators_para(void);
 /* py_wind_sub.c */
 int zoom(int direction);
 int overview(WindPtr w, char rootname[]);

--- a/source/version.h
+++ b/source/version.h
@@ -1,2 +1,2 @@
-#define VERSION  "78c_dev"
+#define VERSION  "parafix"
 #define CHOICE 1 // Compress plasma as much as possible


### PR DESCRIPTION
This fixes #132 - see discussion and test results there.
- New functions in para_update.c
- int communicate_estimators_para(void) - moved communication of non-matom estimators from python.c to subroutine (checked produces identical results with fiducial model)
- int gather_spectra_para(int nspec_helper, int nspecs) - moved averaging of spectra from python.c to subroutine
- int communicate_matom_estimators_para(void) new function which averages matom estimators between threads, using MPI_Reduce and MPI_Bcast. 
