### PR TITLE
Enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ compiler:
 # only want to run this test when we commit to dev
 branches:
   only:
-      dev
-      enum
+    - dev
+    - enum
 
 install:
     # first configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ compiler:
 branches:
   only:
       dev
+      enum
 
 install:
     # first configure

--- a/source/python.c
+++ b/source/python.c
@@ -585,6 +585,8 @@ main (argc, argv)
   	case 0: geo.system_type = SYSTEM_TYPE_STAR;
   	case 1: geo.system_type = SYSTEM_TYPE_BINARY;
   	case 2: geo.system_type = SYSTEM_TYPE_AGN;
+  	Error ("main: Unknown system type %d\n \
+  		Valid system types are 0=Star, 1=Binary, 2=AGN\n", n);
   }
 
 

--- a/source/python.c
+++ b/source/python.c
@@ -579,8 +579,14 @@ main (argc, argv)
   /*  Establish the overall system type  - Added for python_69 to allow qso's have different inputs
       Note - ksl - What happened to the possibility of a true single star with no disk - 110914 */
 
-  rdint ("System_type(0=star,1=binary,2=agn)", &n);	//SWM - Tweaked to read to int, then to enum
-  geo.system_type = (enum system_type_enum) n;
+  rdint ("System_type(0=star,1=binary,2=agn)", &n);	//SWM - Tweaked to read to enum
+  switch (n)
+  {
+  	case 0: geo.system_type = SYSTEM_TYPE_STAR;
+  	case 1: geo.system_type = SYSTEM_TYPE_BINARY;
+  	case 2: geo.system_type = SYSTEM_TYPE_AGN;
+  }
+
 
   /* specify if there is a disk and what type */
   /* JM 1502 -- moved disk type question here- previously it was just before

--- a/source/python.c
+++ b/source/python.c
@@ -582,10 +582,10 @@ main (argc, argv)
   rdint ("System_type(0=star,1=binary,2=agn)", &n);	//SWM - Tweaked to read to enum
   switch (n)
   {
-  	case 0: geo.system_type = SYSTEM_TYPE_STAR;
-  	case 1: geo.system_type = SYSTEM_TYPE_BINARY;
-  	case 2: geo.system_type = SYSTEM_TYPE_AGN;
-  	Error ("main: Unknown system type %d\n \
+  	case 0: geo.system_type = SYSTEM_TYPE_STAR; break;
+  	case 1: geo.system_type = SYSTEM_TYPE_BINARY; break;
+  	case 2: geo.system_type = SYSTEM_TYPE_AGN; break;
+  	default:Error ("main: Unknown system type %d\n \
   		Valid system types are 0=Star, 1=Binary, 2=AGN\n", n);
   }
 

--- a/source/python.c
+++ b/source/python.c
@@ -391,7 +391,6 @@ main (argc, argv)
 	("Wind_type(0=SV,1=Sphere,2=Previous,3=Proga,4=Corona,5=knigge,6=homologous,7=yso,8=elvis,9=shell)",
 	 &geo.wind_type);
 
-
       if (geo.wind_type == 2)
 	{
 	  /* This option is for the confusing case where we want to start with
@@ -580,7 +579,8 @@ main (argc, argv)
   /*  Establish the overall system type  - Added for python_69 to allow qso's have different inputs
       Note - ksl - What happened to the possibility of a true single star with no disk - 110914 */
 
-  rdint ("System_type(0=star,1=binary,2=agn)", &geo.system_type);
+  rdint ("System_type(0=star,1=binary,2=agn)", &n);	//SWM - Tweaked to read to int, then to enum
+  geo.system_type = (enum system_type_enum) n;
 
   /* specify if there is a disk and what type */
   /* JM 1502 -- moved disk type question here- previously it was just before

--- a/source/python.h
+++ b/source/python.h
@@ -118,12 +118,6 @@ int NPHOT;			/* As of python_40, NPHOT must be defined in the main program using
 #define NCOMPS 	10
 #define LINELENGTH 	160
 
-
-/* SWM - Reverb enums */
- #define REV_NONE 0
- #define REV_PHOTON 1
- #define REV_WIND 2
-
 struct geometry
 {
 /* 67 - ksl This section added to allow for restarting the program, and adds parameters used
@@ -374,8 +368,11 @@ struct geometry
   char atomic_filename[132];	/* 54e -- The masterfile for the atomic data */
   char fixed_con_file[132];	/* 54e -- For fixed concentrations, the file specifying concentrations */
 
-  //Added by SWM for reverberation mapping - 0=None, 1=Photon, 2=Wind
-  int reverb, reverb_path_bins, reverb_theta_bins; 
+  //Added by SWM for reverberation mapping
+  enum reverb_enum {
+    REV_NONE=0, REV_PHOTON=1, REV_WIND=2
+  } reverb;
+  int reverb_path_bins, reverb_theta_bins; 
 }
 geo;
 
@@ -534,8 +531,6 @@ typedef struct wind
   		W_ALL_INWIND=0, W_PART_INWIND=1, 
   		W_ALL_INTORUS=2, W_PART_INTORUS=3
   	}	inwind;			
-  int inwind;			/* 061104 -- 58b -- ksl -- Moved definitions of for whether a cell is or is not
-				   inwind to #define statements above */
   Wind_Paths_Ptr paths;         // SWM 6-2-15 Path data struct for each cell
 }
 wind_dummy, *WindPtr;

--- a/source/python.h
+++ b/source/python.h
@@ -147,9 +147,9 @@ struct geometry
   double twind;			/* temperature of wind */
   double tmax;			/*NSH 120817 the maximim temperature of any element of the model - used to help estimate things for an exponential representation of the spectrum in a cell */
   enum system_type_enum 
-  	{	SYSTEM_TYPE_STAR	=0, 
+  	{	SYSTEM_TYPE_STAR	  =0, 
   		SYSTEM_TYPE_BINARY	=1, 
-  		SYSTEM_TYPE_AGN		=2
+  		SYSTEM_TYPE_AGN		  =2
   	} 	system_type;
   int disk_type;		/*0 --> no disk, 
 				   1 --> a standard disk in xy plane, 
@@ -877,7 +877,8 @@ typedef struct photon
   double w,w_orig;		       /* current and original weight of this packet */
   double tau;
   enum istat_enum 
-  	{	P_INWIND           =0,	//in wind,
+  	{	
+    P_INWIND           =0,	//in wind,
 		P_SCAT             =1,	//in process of scattering,
 		P_ESCAPE           =2,	//Escaped to reach the universe,
 		P_HIT_STAR         =3,	//absorbed by photosphere of star,
@@ -887,7 +888,7 @@ typedef struct photon
 		P_ERROR            =5,	//Too many calls to translate without something happening
 		P_SEC              =8,	//Photon hit secondary
 		P_ADIABATIC        =9 	//records that a photon created a kpkt which was destroyed by adiabatic cooling
-  	} 	istat;					/*status of photon.*/
+  	} 	istat;					   /*status of photon.*/
 
   int nscat;			/*number of scatterings */
   int nres;			/*The line number in lin_ptr of last scatter or wind line creation */

--- a/source/setup.c
+++ b/source/setup.c
@@ -240,7 +240,7 @@ if (geo.wind_type != 2)
         case 2: geo.coord_type = RTHETA;
         case 3: geo.coord_type = CYLVAR;
         default:Error("Invalid parameter supplied for 'Coord_system'. Valid coordinate types are: \n\
-          0 = Spherical, 1 = Cylindrical, 2 = Spherical polar, 3 = Cylindrical (varying Z)")
+          0 = Spherical, 1 = Cylindrical, 2 = Spherical polar, 3 = Cylindrical (varying Z)");
       }
 
       rdint ("Wind.dim.in.x_or_r.direction", &geo.ndim);
@@ -978,7 +978,7 @@ get_meta_params (void)
   switch(meta_param)
   {
     case 0: geo.reverb = REV_NONE;
-    case 1: geo.reverb = REV_PHOT;
+    case 1: geo.reverb = REV_PHOTON;
     case 2: geo.reverb = REV_WIND;
     default:geo.reverb = REV_NONE;
   }

--- a/source/setup.c
+++ b/source/setup.c
@@ -226,20 +226,20 @@ History:
 int get_grid_params()
 
 {
-  int grid_param;
+  int input_int;
 if (geo.wind_type != 2)
     {
       /* Define the coordinate system for the grid and allocate memory for the wind structure */
       rdint
   ("Coord.system(0=spherical,1=cylindrical,2=spherical_polar,3=cyl_var)",
-   &grid_param);
-      switch(grid_param)
+   &input_int);
+      switch(input_int)
       {
-        case 0: geo.coord_type = SPHERICAL;
-        case 1: geo.coord_type = CYLIND;
-        case 2: geo.coord_type = RTHETA;
-        case 3: geo.coord_type = CYLVAR;
-        default:Error("Invalid parameter supplied for 'Coord_system'. Valid coordinate types are: \n\
+        case 0: geo.coord_type = SPHERICAL; break;
+        case 1: geo.coord_type = CYLIND; break;
+        case 2: geo.coord_type = RTHETA; break;
+        case 3: geo.coord_type = CYLVAR; break;
+        default: Error("Invalid parameter supplied for 'Coord_system'. Valid coordinate types are: \n\
           0 = Spherical, 1 = Cylindrical, 2 = Spherical polar, 3 = Cylindrical (varying Z)");
       }
 
@@ -977,10 +977,10 @@ get_meta_params (void)
   rdint("reverb.type", &meta_param);
   switch(meta_param)
   {
-    case 0: geo.reverb = REV_NONE;
-    case 1: geo.reverb = REV_PHOTON;
-    case 2: geo.reverb = REV_WIND;
-    default:geo.reverb = REV_NONE;
+    case 0: geo.reverb = REV_NONE; break;
+    case 1: geo.reverb = REV_PHOTON; break;
+    case 2: geo.reverb = REV_WIND; break;
+    default:geo.reverb = REV_NONE; break;
   }
 
   if (geo.reverb == REV_WIND)

--- a/source/setup.c
+++ b/source/setup.c
@@ -226,12 +226,22 @@ History:
 int get_grid_params()
 
 {
+  int grid_param;
 if (geo.wind_type != 2)
     {
       /* Define the coordinate system for the grid and allocate memory for the wind structure */
       rdint
   ("Coord.system(0=spherical,1=cylindrical,2=spherical_polar,3=cyl_var)",
-   &geo.coord_type);
+   &grid_param);
+      switch(grid_param)
+      {
+        case 0: geo.coord_type = SPHERICAL;
+        case 1: geo.coord_type = CYLIND;
+        case 2: geo.coord_type = RTHETA;
+        case 3: geo.coord_type = CYLVAR;
+        default:Error("Invalid parameter supplied for 'Coord_system'. Valid coordinate types are: \n\
+          0 = Spherical, 1 = Cylindrical, 2 = Spherical polar, 3 = Cylindrical (varying Z)")
+      }
 
       rdint ("Wind.dim.in.x_or_r.direction", &geo.ndim);
       if (geo.coord_type)
@@ -962,8 +972,17 @@ History:
 int 
 get_meta_params (void)
 {
-  geo.reverb = REV_NONE;
-  rdint("reverb.type", &geo.reverb);
+  int meta_param;
+
+  rdint("reverb.type", &meta_param);
+  switch(meta_param)
+  {
+    case 0: geo.reverb = REV_NONE;
+    case 1: geo.reverb = REV_PHOT;
+    case 2: geo.reverb = REV_WIND;
+    default:geo.reverb = REV_NONE;
+  }
+
   if (geo.reverb == REV_WIND)
   {
     geo.reverb_path_bins = 30;


### PR DESCRIPTION
This is the switch to enums made for discussion #148. The enum-likes not switched to enum are SPECTYPE, IONMODE and NEBULARMODE. 

Spectype readin is unmodified as the get_spectype/get_models chain is convoluted- switching from int to enum will have no impact on readability or maintenance. IONMODE and NEBULARMODE currently depend on modes sharing integer values and switching to enums would slightly obfusciate that (unless a new comparison function was added).
