### PR TITLE
Auger ionization

### DIFF
--- a/py_progs/py79_pl_loop.py
+++ b/py_progs/py79_pl_loop.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+
+
+'''
+                    UNLV
+
+Synopsis:  
+
+This routine carries out a series of thin shell python simulations.
+The wind mdot is set to produce a hydrogen density of 1e7 - to change
+this one had to change the wind_mdot parameter. The loop is carried out
+over the 2-10kev luminosity of the central source. A luminosity of
+1e21 give a mainly neutral plasma (IP=5e-10) whilst 1e37 is almost 
+totally ionized (IP=5e6). The code strips out ion densities and constructs 
+data files with the cloudy type ionization parameter as the first 
+line.
+If one wants a constant temperature file, then one needs to hack python
+to stop the temperature changing
+We currently write out H,He,C,N,O and Fe. We also output heating and cooling
+mechanisms.
+
+
+Command line usage (if any):
+
+	usage: python_pl_loop *optional file suffix*
+
+Description:  
+
+Primary routines:
+
+Notes:
+									   
+History:
+
+081214 nsh Commented
+
+'''
+
+
+if __name__ == "__main__":		# allows one to run from command line without running automatically with write_docs.py
+
+	import sys, subprocess
+	import numpy as np
+
+	#Use an optional suffix so file will be py_hydrogen_*suffix*.dat, 
+	#If nothing is supplied, default is PL.
+	
+	alpha=-0.9
+	npoints=101 			#this is the parameter which says how many runs to perform - we do 10 per order of magnitude in lum
+	python_ver="py"   	#This is where we define the version of python to use
+	atomic="data/standard78"
+	python_opts=" "
+	ncycles=20
+	nphot=1000000
+	t_e=10000
+	nh=1e7
+	lum_start=1e25
+	
+	
+	
+	
+	
+	
+	wind_mdot=4.72694719429145E-20*(nh/1e7)
+
+
+	if  len(sys.argv) > 1:
+		run_name=sys.argv[1]
+		inp=open(run_name+".param")
+		for line in inp.readlines():
+			data=line.split()
+			if len(data)!=2:
+				print ("Improperly structured param file - each line should be a param name and value seperated by a space")
+			else:
+				print data[0],data[1]
+				if data[0]=='alpha': 
+					alpha=data[1]
+				if data[0]=='npoints':
+					npoints=int(data[1])
+				if data[0]=='t_e':
+					t_e=float(data[1])
+				if data[0]=='python_ver':
+					python_ver=data[1]
+				if data[0]=='atomic':
+					atomic=data[1]
+				if data[0]=='python_opts':
+					python_opts=data[1]
+				if data[0]=='ncycles':
+					ncycles=int(data[1])
+				if data[0]=='nphot':
+					nphot=data[1]
+				if data[0]=='nh':
+					nh=data[1]
+				if data[0]=='lum_start':
+					lum_start=float(data[1])
+	else:
+		run_name='PL'
+
+
+		
+	
+
+	#Open empty files to contain data
+
+	Hout=open('py_hydrogen_'+run_name+'.dat','w')
+	Hout.write('IP H1 H2\n')
+	Heout=open('py_helium_'+run_name+'.dat','w')
+	Heout.write('IP He1 He2 He3\n')
+	Cout=open('py_carbon_'+run_name+'.dat','w')
+	Cout.write('IP C1 C2 C3 C4 C5 C6 C7\n')
+	Nout=open('py_nitrogen_'+run_name+'.dat','w')
+	Nout.write('IP N1 N2 N3 N4 N5 N6 N7 N8\n')
+	Oout=open('py_oxygen_'+run_name+'.dat','w')
+	Oout.write('IP O1 O2 O3 O4 O5 O6 O7 O8 O9\n')
+	Feout=open('py_iron_'+run_name+'.dat','w')
+	Feout.write('IP')
+	for i in range(27):
+			Feout.write(" Fe"+str(i+1))
+	Feout.write('\n')
+	Tout=open('py_temperature_'+run_name+'.dat','w')
+	Tout.write("Lum Sim_ip Cl_ip T_e N_e heat cool\n")
+	Heat=open('py_heat_'+run_name+'.dat','w')
+	Heat.write('IP total photo ff compton ind_comp lines auger\n')
+	Cool=open('py_cool_'+run_name+'.dat','w')
+	Cool.write('IP total recomb ff compton DR DI lines Adiabatic\n')
+
+
+
+	for i in range(npoints):
+		lum=10**((float(i)+np.log10(lum_start)*10.0)/10.0)   #The 210 means the first luminosity is 21.0
+		print 'Starting cycle '+str(i+1)+' of '+str(npoints)
+		print 'Lum= '+str(lum)
+		inp =open('input.pf','w')
+		inp.write("Wind_type() 9\n")
+		inp.write("Atomic_data "+atomic+"\n")
+		inp.write("write_atomicdata      0\n")
+		inp.write("photons_per_cycle "+str(nphot)+"\n")
+		inp.write("Ionization_cycles "+str(ncycles)+"\n")
+		inp.write("spectrum_cycles                                   0\n")
+		inp.write("Coord.system()                   0\n")
+		inp.write("Wind.dim.in.x_or_r.direction                     4\n")
+		inp.write("Wind_ionization()                   9\n")
+		inp.write("Line_transfer()                    3\n")
+		inp.write("Thermal_balance_options 		0\n")
+		inp.write("System_type()                   2\n")
+		inp.write("disk.type()             							0\n")
+		inp.write("Star_radiation(y=1)                              0\n")
+		inp.write("Disk_radiation(y=1)                              0\n")
+		inp.write("Wind_radiation(y=1)                              0\n")
+		inp.write("QSO_BH_radiation(y=1)                            1\n")
+		inp.write("Rad_type_for_star(0=bb,1=models)_to_make_wind                   0\n")
+		inp.write("Rad_type_for_agn()_to_make_wind                   4\n")
+		inp.write("mstar(msol)                                     0.8\n")
+		inp.write("rstar(cm)                                     1e10\n")
+		inp.write("tstar                                      1000000\n")
+		inp.write("disk.type()                   0\n")
+		inp.write("lum_agn(ergs/s) "+str(lum)+"\n")
+		inp.write("agn_power_law_index  "+str(alpha)+"\n")
+		inp.write("low_energy_break(ev)				0.136\n")
+		inp.write("high_energy_break(ev)			20000\n")
+		inp.write("Torus(0=no,1=yes) 				 0\n")
+		inp.write("wind.radmax(cm)                   1.00000000001e11\n")
+		inp.write("wind.t.init       "+str(t_e)+"\n")
+		inp.write("shell_wind_mdot(msol/yr)  "+str(wind_mdot)+"\n")
+		inp.write("shell.wind.radmin(cm)                       1e11\n")
+		inp.write("shell.wind_v_at_rmin(cm)                    1.00000\n")
+		inp.write("shell.wind.v_at_rmax(cm)                    1.000010\n")
+		inp.write("shell.wind.acceleration_exponent                   1\n")
+		inp.write("wind.filling_factor(1=smooth,<1=clumped) (1)       1\n")
+		inp.write("spec.type(flambda(1),fnu(2),basic(other)                    2\n")
+		inp.write("reverb.type()									0\n")
+		inp.write("Extra.diagnostics(0=no)                           0\n")
+		inp.write("Use.standard.care.factors(1=yes)                    1\n")
+		inp.write("Photon.sampling.approach()                   5\n")
+		inp.write("Num.of.frequency.bands                           3\n")
+		inp.write("Lowest_energy_to_be_considered(eV)                   0.0001\n")
+		inp.write("Highest_energy_to_be_considered(eV)           100000000   \n")
+		inp.write("Band.boundary(eV)                             2000\n")
+		inp.write("Band.boundary(eV)                            10000\n")
+		inp.write("Band.minimum_fraction)                         0.3\n")
+		inp.write("Band.minimum_fraction)                         0.4\n")
+		inp.write("Band.minimum_fraction)                         0.3\n")
+		inp.close()
+		subprocess.check_call("time "+python_ver+" "+python_opts+" input > output",shell=True)	   #This is where we define the version of python to use
+		subprocess.check_call("tail -n 60 output  | grep OUTPUT > temp",shell=True)#Strip the last 60 lines from the output
+		inp=open('temp','r')
+		for line in inp.readlines():
+			data=line.split()
+			if (data[1]=='Lum_agn='):       #This marks the start of the data we want. Field 14 is the cloudy ionization parameter
+				Hout.write(data[14])
+				Heout.write(data[14])
+				Cout.write(data[14])
+				Nout.write(data[14])
+				Oout.write(data[14])
+				Feout.write(data[14])
+				Heat.write(data[14])
+				Cool.write(data[14])
+				Tout.write(data[2]+' '+data[12]+' '+data[14]+' '+data[4]+' '+data[8]+' ')
+			if (data[1]=='Absorbed_flux(ergs-1cm-3)'):
+				Heat.write(' '+data[2]+' '+data[4]+' '+data[6]+' '+data[8]+' '+data[10]+' '+data[12]+' '+data[14]+'\n')
+				Tout.write(data[2]+' ')
+			if (data[1]=='Wind_cooling(ergs-1cm-3)'):
+				Cool.write(' '+data[2]+' '+data[4]+' '+data[6]+' '+data[8]+' '+data[10]+' '+data[12]+' '+data[16]+' '+data[14]+'\n')
+				Tout.write(data[2]+'\n')
+			if (data[1]=='H'):
+				for j in range(2):
+					Hout.write(' '+data[j+2])
+				Hout.write('\n')
+			if (data[1]=='He'):
+				for j in range(3):
+					Heout.write(' '+data[j+2])
+				Heout.write('\n')
+			if (data[1]=='C'):
+				for j in range(7):
+					Cout.write(' '+data[j+2])
+				Cout.write('\n')
+			if (data[1]=='N'):
+				for j in range(8):
+					Nout.write(' '+data[j+2])
+				Nout.write('\n')
+			if (data[1]=='O'):
+				for j in range(9):
+					Oout.write(' '+data[j+2])
+				Oout.write('\n')
+			if (data[1]=='Fe'):
+				for j in range(27):
+					Feout.write(' '+data[j+2])
+				Feout.write('\n')
+	#Flush the output files so one can see progress and if the loop crashes all is not lost
+		Hout.flush()
+		Heout.flush()
+		Cout.flush()
+		Nout.flush()
+		Oout.flush()
+		Feout.flush()
+		Tout.flush()
+		Heat.flush()
+		Cool.flush()	
+		print 'Finished cycle '+str(i+1)+' of '+str(npoints)
+	#Close the files.
+	Hout.close()
+	Heout.close()
+	Cout.close()
+	Nout.close()
+	Oout.close()
+	Feout.close()
+	Tout.close()
+	Heat.close()
+	Cool.close()
+

--- a/py_progs/py79_pl_loop.py
+++ b/py_progs/py79_pl_loop.py
@@ -181,7 +181,9 @@ if __name__ == "__main__":		# allows one to run from command line without runnin
 		inp.write("Band.minimum_fraction)                         0.4\n")
 		inp.write("Band.minimum_fraction)                         0.3\n")
 		inp.close()
-		subprocess.check_call("time "+python_ver+" "+python_opts+" input > output",shell=True)	   #This is where we define the version of python to use
+		cmd="time "+python_ver+" "+python_opts+" input > output"
+		print cmd
+		subprocess.check_call(cmd,shell=True)	   #This is where we define the version of python to use
 		subprocess.check_call("tail -n 60 output  | grep OUTPUT > temp",shell=True)#Strip the last 60 lines from the output
 		inp=open('temp','r')
 		for line in inp.readlines():

--- a/py_progs/py79_pl_loop.py
+++ b/py_progs/py79_pl_loop.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":		# allows one to run from command line without runnin
 	t_e=10000
 	nh=1e7
 	lum_start=1e25
+	nprocs=0
 	
 	
 	
@@ -75,6 +76,8 @@ if __name__ == "__main__":		# allows one to run from command line without runnin
 				print data[0],data[1]
 				if data[0]=='alpha': 
 					alpha=data[1]
+				if data[0]=='nprocs': 
+					nprocs=int(data[1])
 				if data[0]=='npoints':
 					npoints=int(data[1])
 				if data[0]=='t_e':
@@ -181,7 +184,10 @@ if __name__ == "__main__":		# allows one to run from command line without runnin
 		inp.write("Band.minimum_fraction)                         0.4\n")
 		inp.write("Band.minimum_fraction)                         0.3\n")
 		inp.close()
-		cmd="time "+python_ver+" "+python_opts+" input > output"
+		if nprocs==0:
+			cmd="time "+python_ver+" "+python_opts+" input > output"
+		else:
+			cmd="time mpirun -n "+str(nprocs)+" "+python_ver+" "+python_opts+" input > output"
 		print cmd
 		subprocess.check_call(cmd,shell=True)	   #This is where we define the version of python to use
 		subprocess.check_call("tail -n 60 output  | grep OUTPUT > temp",shell=True)#Strip the last 60 lines from the output

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -112,12 +112,12 @@ bf_estimators_increment (one, p, ds)
       n = xplasma->kbf_use[nn];
       ft = phot_top[n].freq[0];	//This is the edge frequency (SS)
 
-      if (ion[phot_top[n].nion].phot_info == 1)   //topbase 
+      if (ion[phot_top[n].nion].phot_info > 0)   //topbase or hybrid
       {
         llvl = phot_top[n].nlev;	//Returning lower level = correct (SS)
         density = den_config (xplasma, llvl);
       }
-      else if (ion[phot_top[n].nion].phot_info == 0)   //cfky
+      else if (ion[phot_top[n].nion].phot_info == 0)   //vfky
       {
         density = xplasma->density[phot_top[n].nion];
         llvl = 0;   // shouldn't ever be used 

--- a/source/foo.h
+++ b/source/foo.h
@@ -11,6 +11,7 @@ double check_fmax(double fmin, double fmax, double temp);
 int get_atomic_data(char masterfile[]);
 int index_lines(void);
 int index_phot_top(void);
+int index_inner_cross(void);
 int index_collisions(void);
 void indexx(int n, float arrin[], int indx[]);
 int limit_lines(double freqmin, double freqmax);
@@ -450,13 +451,13 @@ int matom_emiss_report(void);
 int compute_di_coeffs(double T);
 double total_di(WindPtr one, double t_e);
 /* pi_rates.c */
-double calc_pi_rate(int nion, PlasmaPtr xplasma, int mode);
+double calc_pi_rate(int nion, PlasmaPtr xplasma, int mode, int type);
 double tb_planck1(double freq);
 double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
 int matrix_ion_populations(PlasmaPtr xplasma, int mode);
-int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
+int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double inner_rates[n_inner_tot], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
 int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* para_update.c */
 int communicate_estimators_para(void);

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -413,9 +413,10 @@ History:
 	98	ksl	Coded as part of python effort
 	02jul	ksl	Added mode variable so could try detailed balance
 	06may	ksl	57+ -- Switched to use plasma structue
+    15aug   nsh 79 -- added a mode to leave t_e fixed
 
 **************************************************************/
-
+\
 
 
 int
@@ -432,10 +433,25 @@ one_shot (xplasma, mode)
   gain = xplasma->gain;
 
 
-  te_old = xplasma->t_e;
-  te_new = calc_te (xplasma, 0.7 * te_old, 1.3 * te_old);
+  
+  
+  
+     if (modes.fixed_temp==0)      //If we are not in fixed temp mode (the normal state of affairs)
+    {
+	  te_old = xplasma->t_e;    //Store the old electron tmperature
+	  te_new = calc_te (xplasma, 0.7 * te_old, 1.3 * te_old);  //compute the new t_e - no limits on where it can go
+  	  xplasma->t_e = (1 - gain) * te_old + gain * te_new;  //Allow the temperature to move by a fraction gain towards the equilibrium temperature
+	}
+	else
+	{
+	    compute_dr_coeffs (xplasma->t_e);
+	     xplasma->lum_dr = total_dr (&wmain[xplasma->nwind], xplasma->t_e);
+	     xplasma->lum_di = total_di (&wmain[xplasma->nwind], xplasma->t_e);
+	     xplasma->lum_comp = total_comp (&wmain[xplasma->nwind], xplasma->t_e);
+	     total_emission (&wmain[xplasma->nwind], 0., VERY_BIG);
+	}
+  
 
-  xplasma->t_e = (1 - gain) * te_old + gain * te_new;
 
 /* NSH 130722 - NOTE - at this stage, the cooling terms are still those computed from the 'ideal' t_e, not the new t_e - this may be worth investigatiing. */
   if (xplasma->t_e > TMAX)

--- a/source/python.c
+++ b/source/python.c
@@ -10,7 +10,7 @@
  
 Arguments:		
 
-	Usage:  py [-h] [-r] [-d] [-t time_max] xxx  or simply py
+	Usage:  py [-h] [-r] [-d] [-f] [-t time_max] xxx  or simply py
 
 	where xxx is the rootname or full name of a parameter file, e. g. test.pf
 
@@ -30,6 +30,7 @@ Arguments:
 		and Error_silent
 	-d	Enters detailed or advanced mode. Allows one to access extra diagnositics and some
 	    other advanced commands
+    -f  Fixed temperature mode - does not attempt to chenge the temperature of cells.
 	-e  Alter the maximum number of errors before the program quits
 	-i  Diagnostic mode which quits after reading in inputs. Used for Travis test suite.
 
@@ -2126,6 +2127,7 @@ int init_advanced_modes()
   modes.print_dvds_info = 0;          // print out information on velocity gradients
   write_atomicdata = 0;               // print out summary of atomic data 
   modes.quit_after_inputs = 0;		  // testing mode which quits after reading in inputs
+  modes.fixed_temp = 0;               // do not attempt to change temperature - used for testing
   //note this is defined in atomic.h, rather than the modes structure 
 
 

--- a/source/python.h
+++ b/source/python.h
@@ -611,6 +611,7 @@ typedef struct plasma
   double heat_lines_macro, heat_photo_macro;	/* bb and bf heating due to macro atoms. Subset of heat_lines 
 						   and heat_photo. SS June 04. */
   double heat_photo, heat_z;	/*photoionization heating total and of metals */
+  double heat_auger;       /* photoionization heating due to inner shell ionizations */  
   double w;			/*The dilution factor of the wind */
   int ntot;			/*Total number of photon passages */
 
@@ -1161,6 +1162,7 @@ struct advanced_modes
   int print_dvds_info;          // print out information on the velocity gradients
   int keep_photoabs;            // keep photoabsorption in final spectrum
   int quit_after_inputs;        // quit after inputs read in, testing mode
+  int fixed_temp;               // do not alter temperature from that set in the parameter file
 }
 modes;
 

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -692,7 +692,7 @@ fb (xplasma, t, freq, ion_choice, fb_choice)
 
   for (nion = nion_min; nion < nion_max; nion++)
     {
-      if (ion[nion].phot_info == 1) // topbase
+      if (ion[nion].phot_info > 0) // topbase or VFKY+topbase
         {
           nmin = ion[nion].ntop_first;
           nmax = nmin + ion[nion].ntop;
@@ -1010,7 +1010,7 @@ xinteg_fb (t, f1, f2, nion, fb_choice)
 
   if (-1 < nion && nion < nions)	//Get emissivity for this specific ion_number
     {
-      if (ion[nion].phot_info == 1) // topbase
+      if (ion[nion].phot_info > 0) // topbase or hybrid
         {
           nmin = ion[nion].ntop_first;
           nmax = nmin + ion[nion].ntop;
@@ -1501,7 +1501,7 @@ gs_rrate (nion, T)
     fbt = T;
     fbfr = 2;
 
-    if (ion[nion-1].phot_info == 1)	//topbase
+    if (ion[nion-1].phot_info > 0)	//topbase or hybrid
       {
         ntmin = ion[nion-1].ntop_ground;
         fb_xtop = &phot_top[ntmin];

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -758,7 +758,7 @@ kbf_need (fmin, fmax)
         {
           density = xplasma->density[nion];
         }
-        else if (ion[nion].phot_info == 1)  // topbases
+        else if (ion[nion].phot_info > 0)  // topbase or hybrid
         {
 	        nconf = phot_top[n].nlev;	//Returning lower level = correct (SS)
 	        density = den_config (xplasma, nconf);

--- a/source/setup.c
+++ b/source/setup.c
@@ -101,6 +101,11 @@ int parse_command_line(argc, argv)
       modes.iadvanced = 1;
       i++;
     }
+    else if (strcmp (argv[i], "-f") == 0)
+    {
+      modes.fixed_temp = 1;
+      i++;
+    }
 
     else if (strcmp (argv[i], "-i") == 0)
       {

--- a/source/summarize_atomic.c
+++ b/source/summarize_atomic.c
@@ -34,8 +34,10 @@ main (argc, argv)
 {
 
   char atomic_filename[LINELENGTH];
-  int n, m;
+  int n, m,i;
   int xlines;
+  FILE *fptr, *fopen ();
+  
 
   write_atomicdata = 1;
   strcat (atomic_filename, argv[1]);
@@ -43,7 +45,77 @@ main (argc, argv)
   get_atomic_data (atomic_filename);
 
   Log ("The number of elements is %d\n", nelements);
-  Log ("The number of ions is %d", nions);
+  Log ("The number of ions is %d\n", nions);
+
+  fptr = fopen ("ele.adat", "w");
+  fprintf(fptr,"name\tz\tfirstion\tnions\tabun\t\n");
+  for (i=0;i<nelements;i++)
+  {
+	  fprintf(fptr,"%s\t%i\t%i\t%i\t%e\n",ele[i].name,ele[i].z,ele[i].firstion,ele[i].nions,ele[i].abun);
+  }
+  fclose(fptr);
+  
+  
+  fptr = fopen ("ion.adat", "w");
+  fprintf(fptr,"z\tistate\tip\tg\tnmax\tn_lte_max\tfirstlevel\tnlevels\tfirst_nlte_level\tfirst_levden\t\
+	  nlte\tphot_info\tmacro_info\tntop_first\tntop_ground\tntop\tnxphot\tlev_type\tdrflag\tnxdrecomb\tcpartflag\t\
+	  nxcpart\ttotal_rrflag\tnxtotalrr\tbad_gs_rr_t_flag\tbad_gs_rr_r_flag\tnxbadgsrr\tdere_di_flag\tnxderedi\n");
+  for (i=0;i<nions;i++)
+  {
+	  fprintf(fptr,"%i\t%i\t%e\t%e\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\n",
+	  ion[i].z,ion[i].istate,ion[i].ip,ion[i].g,ion[i].nmax,ion[i].n_lte_max,ion[i].firstlevel,ion[i].nlevels,ion[i].first_nlte_level,
+	  ion[i].first_levden,ion[i].nlte,ion[i].phot_info,ion[i].macro_info,ion[i].ntop_first,ion[i].ntop_ground,ion[i].ntop,ion[i].nxphot,
+	  ion[i].lev_type,ion[i].drflag,ion[i].nxdrecomb,ion[i].cpartflag,ion[i].nxcpart,ion[i].total_rrflag,ion[i].nxtotalrr,ion[i].bad_gs_rr_t_flag,
+	  ion[i].bad_gs_rr_r_flag,ion[i].nxbadgsrr,ion[i].dere_di_flag,ion[i].nxderedi);
+  }
+  fclose(fptr);
+  
+  
+  fptr = fopen ("config.adat","w");
+	  fprintf(fptr,"z\tistate\tnion\tnden\tisp\tilv\tmacro_info\tn_bbu_jump\tn_bbd_jump\tn_bfu_jump\tn_bfd_jump\tg\tq_num\tex\trad_rate\t\
+		  bbu_indx_first\tbfu_indx_first\tbfd_indx_first\n");
+  for (i=0;i<nlevels;i++)
+  {
+	  fprintf(fptr,"%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%e\t%e\t%e\t%e\t%i\t%i\t%i\n",config[i].z,config[i].istate,config[i].nion,
+  	  config[i].nden,config[i].isp,config[i].ilv,config[i].macro_info,config[i].n_bbu_jump,config[i].n_bbd_jump,config[i].n_bfu_jump,
+	  config[i].n_bfd_jump,config[i].g,config[i].q_num,config[i].ex,config[i].rad_rate,config[i].bbu_indx_first,config[i].bfu_indx_first,
+	  config[i].bfd_indx_first);
+  }
+  fclose(fptr);
+  
+  fptr=fopen("lines.adat","w");
+  fprintf(fptr,"nion\tz\tistate\tgl\tgu\tnconfigl\tnconfigu\tlevl\tlevu\tmacro_info\tfreq\tf\tel\teu\tpow\twhere_in_list\tdown_index\tup_index\n");
+  for (i=0;i<nlines;i++)
+  {
+	  fprintf(fptr,"%i\t%i\t%i\t%e\t%e\t%i\t%i\t%i\t%i\t%i\t%e\t%e\t%e\t%e\t%e\t%i\t%i\t%i\n",
+      line[i].nion,line[i].z,line[i].istate,line[i].gl,line[i].gu,line[i].nconfigl,line[i].nconfigu,line[i].levl,line[i].levu,
+	  line[i].macro_info,line[i].freq,line[i].f,line[i].el,line[i].eu,line[i].pow,line[i].where_in_list,line[i].down_index,line[i].up_index);
+  }
+  fclose(fptr);
+  
+  fptr=fopen("topbase_phot.adat","w");
+  fprintf(fptr,"nlev\tuplev\tnion\tz\tistate\tnp\tnlast\tmacro_info\tdown_index\tup_index\tf0\tsigma0\tf\tsigma\n");
+  for (i=0;i<nlevels;i++)
+  {
+	  fprintf(fptr,"%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%e\t%e\t%e\t%e\n",phot_top[i].nlev,phot_top[i].uplev,
+	  phot_top[i].nion,phot_top[i].z,phot_top[i].istate,phot_top[i].np,phot_top[i].nlast,phot_top[i].macro_info,
+	  phot_top[i].down_index,phot_top[i].up_index,phot_top[i].freq[0],phot_top[i].x[0],phot_top[i].f,phot_top[i].sigma);
+  }
+  fclose(fptr);
+
+  fptr=fopen("xphot_tab.adat","w");
+  fprintf(fptr,"nlev\tuplev\tnion\tz\tistate\tnp\tnlast\tmacro_info\tdown_index\tup_index\tf0\tsigma0\tf\tsigma\n");
+  for (i=0;i<nions;i++)
+  {
+	  fprintf(fptr,"%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%i\t%e\t%e\t%e\t%e\n",xphot_tab[i].nlev,xphot_tab[i].uplev,
+	  xphot_tab[i].nion,xphot_tab[i].z,xphot_tab[i].istate,xphot_tab[i].np,xphot_tab[i].nlast,xphot_tab[i].macro_info,
+	  xphot_tab[i].down_index,xphot_tab[i].up_index,xphot_tab[i].freq[0],xphot_tab[i].x[0],xphot_tab[i].f,xphot_tab[i].sigma);
+  }
+  fclose(fptr);
+
+
+
+
 
   n = 0;
   while (n < nions)
@@ -52,10 +124,15 @@ main (argc, argv)
       m=0;
       while (m < nlines)
 	{
-	  if (line[m].nion == n)
+		
+		if (line[m].nion == n)
 	    {
 	      xlines++;
 	    }
+		if (line[m].nion ==176)
+		{
+			printf ("Line data %i %i %e\n",line[m].nconfigl,line[m].nconfigu,line[m].freq);
+		}
 	  m++;
 	}
 	  Log ("ion %3d %2d %2d %4d  %4d\n", n, ion[n].z, ion[n].istate,

--- a/source/templates.h
+++ b/source/templates.h
@@ -11,6 +11,7 @@ double check_fmax(double fmin, double fmax, double temp);
 int get_atomic_data(char masterfile[]);
 int index_lines(void);
 int index_phot_top(void);
+int index_inner_cross(void);
 int index_collisions(void);
 void indexx(int n, float arrin[], int indx[]);
 int limit_lines(double freqmin, double freqmax);
@@ -450,13 +451,13 @@ int matom_emiss_report(void);
 int compute_di_coeffs(double T);
 double total_di(WindPtr one, double t_e);
 /* pi_rates.c */
-double calc_pi_rate(int nion, PlasmaPtr xplasma, int mode);
+double calc_pi_rate(int nion, PlasmaPtr xplasma, int mode, int type);
 double tb_planck1(double freq);
 double tb_logpow1(double freq);
 double tb_exp1(double freq);
 /* matrix_ion.c */
 int matrix_ion_populations(PlasmaPtr xplasma, int mode);
-int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
+int populate_ion_rate_matrix(PlasmaPtr xplasma, double rate_matrix[nions][nions], double pi_rates[nions], double inner_rates[n_inner_tot], double rr_rates[nions], double b_temp[nions], double xne, int xelem[nions]);
 int solve_matrix(double *a_data, double *b_data, int nrows, double *x);
 /* para_update.c */
 int communicate_estimators_para(void);

--- a/source/variable_temperature.c
+++ b/source/variable_temperature.c
@@ -467,11 +467,11 @@ numerator=denominator=0.0;
     	{
 	if (mode==6)
 		{
-      		numerator = calc_pi_rate(ion_lower,xplasma,2);	/*Call calc_pi_rate with mode 2, which returns the PI rate coeficient*/
+      		numerator = calc_pi_rate(ion_lower,xplasma,2, 1);	/*Call calc_pi_rate with mode 2, which returns the PI rate coeficient*/
 		}
 	else if (mode==7)  /*The mean intensity is modelled as a series of power laws and/or exponentials */
 		{
-		numerator=calc_pi_rate (ion_lower,xplasma,1); /*NSH 0814 - the PI rate is now calculated by an external subroutine. Mode 1 means calulate using a PL/exp model of the mean intensity*/
+		numerator=calc_pi_rate (ion_lower,xplasma,1, 1); /*NSH 0814 - the PI rate is now calculated by an external subroutine. Mode 1 means calulate using a PL/exp model of the mean intensity*/
 		}
 	xplasma->PWnumer[ion_lower] = numerator;	/* Store the calculated numerator for this cell - it wont change during one ionization cycle*/
     	}				//End of if statement to decide if this is the first iteration
@@ -491,7 +491,7 @@ numerator=denominator=0.0;
       w_store=xplasma->w;   
       xplasma->t_r=xtemp;
       xplasma->w=1.0;
-      denominator = calc_pi_rate(ion_lower,xplasma,2); /*Now we can call calc_pi_rate, which will now calulate an LTE rate coefficient at our guess temperature */
+      denominator = calc_pi_rate(ion_lower,xplasma,2, 1); /*Now we can call calc_pi_rate, which will now calulate an LTE rate coefficient at our guess temperature */
       xplasma->t_r=t_r_store; /*Put things back the way they were */
       xplasma->w=w_store;
       xplasma->PWdenom[ion_lower] = denominator;  /*Store the LTE rate coefficient for next time*/

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -73,6 +73,8 @@ History:
 			also initialise the min and max frequencies seen in a band.
 	14jul	nsh	added call to calloc_dyn_plasma to allocate space for arrays of variable size - currently
 			those with length nion.
+	15jul	nsh added a mode for fixed temperature, which does not multiply wind temp by 0.9 so you get what you ask for
+
 
 **************************************************************/
 
@@ -377,7 +379,14 @@ be optional which variables beyond here are moved to structures othere than Wind
       plasmamain[n].gain = 0.5;
       plasmamain[n].dt_e_old = 0.0;
       plasmamain[n].dt_e = 0.0;
-      plasmamain[n].t_e = plasmamain[n].t_e_old = 0.9 * plasmamain[n].t_r;	//Lucy guess
+/* The next lines set the electrom temperature to 0.9 times the radiation temperature (which is a bit
+	  odd since the input is the wind temperature, but is taken to be the radiation temperature). If we have
+	  a fixed temprature calculation,then the wind temperature is set to be the wind temperature so the
+	  user gets what they are expecting */
+      if (modes.fixed_temp==0)
+		  plasmamain[n].t_e = plasmamain[n].t_e_old = 0.9 * plasmamain[n].t_r;	//Lucy guess
+	  else
+		  plasmamain[n].t_e = plasmamain[n].t_e_old = plasmamain[n].t_r; //If we want to fix the temperature, we set it to tr which has previously been set to twind.
 
 
 /* Calculate an initial guess for the weight of the PL spectrum (constant / area of a sphere / 4pi) */


### PR DESCRIPTION
This pull will implement auger ionization into python. 

There are three new import loops in get_atomicdata - for the inner shell cross sections, the electron yields and the fluorescent photon yields (nothing is currently done with the latter).

pi_rates.c has been modified to allow the same code to be used to compute normal PI rates and also inner shell rates.

matrix_ion.c has the code to put inner shell rates into the matrix

radiation.c has innershell opacity included

some changes to atomic.h and python.h

There is also a new mode, py -f will use the wind temperature supplied in the .pf file for t_e, and will not change it. 

I've also included an updated version of python_pl_loop.py - the loop python script in py_progs. It deals with auger now, and also allows you to make a param file which supplies various quantities for the run like what version of python to use etc. This means you no longer need to change the script to change the type of run.
