### PR TITLE
Add lamp post power law source to domain2

### DIFF
--- a/examples/agn_ss_2010_modela.pf
+++ b/examples/agn_ss_2010_modela.pf
@@ -28,6 +28,7 @@ Disk.temperature.profile(0=standard;1=readin)                    0
 disk.radmax(cm)                               5e16
 lum_agn(ergs/s)                               1e43
 agn_power_law_index                           -1.38
+geometry_for_pl_source(0=sphere,1=lamp_post)   0
 wind.radmax(cm)                               5e16
 wind.t.init                                   1e5
 wind.mdot(msol/yr)                            0.1

--- a/examples/lamp_post.pf
+++ b/examples/lamp_post.pf
@@ -25,7 +25,8 @@ Disk.temperature.profile(0=standard;1=readin)                    0
 disk.radmax(cm)                               1e17
 lum_agn(ergs/s)                               1e43
 agn_power_law_index                            -0.9
-geometry_for_pl_source(0=sphere,1=lamp_post)    0 
+geometry_for_pl_source(0=sphere,1=lamp_post)    1 
+lamp_post.height(r_g)							10
 wind.radmax(cm)                               1e19
 wind.t.init                                    1e5
 wind.mdot(msol/yr)                            5

--- a/source/agn.c
+++ b/source/agn.c
@@ -308,20 +308,20 @@ int
 photo_gen_agn (p, r, alpha, weight, f1, f2, spectype, istart, nphot)
      PhotPtr p;
      double r, alpha, weight;
-     double f1, f2;		/* The freqency mininimum and maximum if a uniform distribution is selected */
-     int spectype;		/*The spectrum type to generate: 0 is bb, 1 (or in fact anything but 0)
-				   is uniform in frequency space */
-     int istart, nphot;		/* Respecitively the starting point in p and the number of photons to generate */
+     double f1, f2;   /* The freqency mininimum and maximum if a uniform distribution is selected */
+     int spectype;    /*The spectrum type to generate: 0 is bb, 1 (or in fact anything but 0)
+           is uniform in frequency space */
+     int istart, nphot;   /* Respecitively the starting point in p and the number of photons to generate */
 {
   double freqmin, freqmax, dfreq, t;
   int i, iend;
   int n;
   double ftest;
 
-  t = alpha;			/* NSH 130605, this is a slightly odd statmenent, put in to avoid 03 compilation 
-				   errors, but stemming from the odd behaviour that one can give the AGN a 
-				   themal spectral type, and the alpha parameter is then used to transmit 
-				   the temperature. */
+  t = alpha;      /* NSH 130605, this is a slightly odd statmenent, put in to avoid 03 compilation 
+           errors, but stemming from the odd behaviour that one can give the AGN a 
+           themal spectral type, and the alpha parameter is then used to transmit 
+           the temperature. */
 
 
   if ((iend = istart + nphot) > NPHOT)
@@ -332,92 +332,113 @@ photo_gen_agn (p, r, alpha, weight, f1, f2, spectype, istart, nphot)
   if (f2 < f1)
     {
       Error
-	("photo_gen_agn: Cannot generate photons if freqmax %g < freqmin %g\n",
-	 f2, f1);
+  ("photo_gen_agn: Cannot generate photons if freqmax %g < freqmin %g\n",
+   f2, f1);
     }
   Log_silent ("photo_gen_agn creates nphot %5d photons from %5d to %5d \n",
-	      nphot, istart, iend);
+        nphot, istart, iend);
   freqmin = f1;
   freqmax = f2;
   dfreq = (freqmax - freqmin) / MAXRAND;
-  r = (1. + EPSILON) * r;	/* Generate photons just outside the photosphere unnecessary for the AGN perhaps? */
 
-  if (spectype == SPECTYPE_CL_TAB)	/*If we have a broken PL, we need to work out which alpha to use */
+  /* Generate photons just outside the photosphere unnecessary for the AGN perhaps? */
+  /* note this is only used in the spherical source */
+
+  if (spectype == SPECTYPE_CL_TAB)  /* If we have a broken PL, we need to work out which alpha to use */
     {
       ftest = (freqmin + freqmax) / 2.0;
-      for (n = 0; n < xband.nbands; n++)	/* work out what alpha and constant to use */
-	{
-	  if (xband.f1[n] < ftest && xband.f2[n] > ftest)
-	    {
-	      alpha = xband.alpha[n];
-	    }
-	}
+      for (n = 0; n < xband.nbands; n++)  /* work out what alpha and constant to use */
+  {
+    if (xband.f1[n] < ftest && xband.f2[n] > ftest)
+      {
+        alpha = xband.alpha[n];
+      }
+  }
     }
 
 
   for (i = istart; i < iend; i++)
     {
-      p[i].origin = PTYPE_AGN;	// For BL photons this is corrected in photon_gen 
+      p[i].origin = PTYPE_AGN;  // For BL photons this is corrected in photon_gen 
       p[i].w = weight;
       p[i].istat = p[i].nscat = p[i].nrscat = 0;
       p[i].grid = 0;
       p[i].tau = 0.0;
-      p[i].nres = -1;		// It's a continuum photon
+      p[i].nres = -1;   // It's a continuum photon
       p[i].nnscat = 1;
 
       if (spectype == SPECTYPE_BB)
-	{
-	  p[i].freq = planck (t, freqmin, freqmax);
-	}
+  {
+    p[i].freq = planck (t, freqmin, freqmax);
+  }
       else if (spectype == SPECTYPE_UNIFORM)
-	{			/* Kurucz spectrum */
-	  /*Produce a uniform distribution of frequencies */
-	  p[i].freq = freqmin + rand () * dfreq;
-	}
-      else if (spectype == SPECTYPE_POW)	/* this is the call to the powerlaw routine 
-						   we are most interested in */
-	{
-	  p[i].freq = get_rand_pow (freqmin, freqmax, alpha);
-	}
+  {     /* Kurucz spectrum */
+    /*Produce a uniform distribution of frequencies */
+    p[i].freq = freqmin + rand () * dfreq;
+  }
+      else if (spectype == SPECTYPE_POW)  /* this is the call to the powerlaw routine 
+               we are most interested in */
+  {
+    p[i].freq = get_rand_pow (freqmin, freqmax, alpha);
+  }
       else if (spectype == SPECTYPE_CL_TAB)
-	{
-	  p[i].freq = get_rand_pow (freqmin, freqmax, alpha);
-	}
+  {
+    p[i].freq = get_rand_pow (freqmin, freqmax, alpha);
+  }
       else
-	{
-	  p[i].freq =
-	    one_continuum (spectype, t, geo.gstar, freqmin, freqmax);
-	}
+  {
+    p[i].freq =
+      one_continuum (spectype, t, geo.gstar, freqmin, freqmax);
+  }
 
       if (p[i].freq < freqmin || freqmax < p[i].freq)
-	{
-	  Error_silent
-	    ("photo_gen_agn: phot no. %d freq %g out of range %g %g\n",
-	     i, p[i].freq, freqmin, freqmax);
-	}
+  {
+    Error_silent
+      ("photo_gen_agn: phot no. %d freq %g out of range %g %g\n",
+       i, p[i].freq, freqmin, freqmax);
+  }
 
+
+    /* first option is for the original spherical X-ray source as used in e.g. Higginbottom+ 2013 */
+
+      if (geo.pl_geometry == PL_GEOMETRY_SPHERE)
+  {
+    randvec (p[i].x, r);
+
+    /* Added by SS August 2004 for finite disk. */
+    if (geo.disk_type == DISK_VERTICALLY_EXTENDED)
+      {
+        /* JM XXX -- is this bit right? it seems to be that zdisk should use the x coordinate rather than
+           magnitude of vector (r) */
+        while (fabs (p[i].x[2]) < zdisk (r))
+    {
       randvec (p[i].x, r);
-
-      /* Added by SS August 2004 for finite disk. */
-      if (geo.disk_type == DISK_VERTICALLY_EXTENDED)
-	{
-	  while (fabs (p[i].x[2]) < zdisk (r))
-	    {
-	      randvec (p[i].x, r);
-	    }
+    }
 
 
-	  if (fabs (p[i].x[2]) < zdisk (r))
-	    {
-	      Error ("Photon_agn: agn photon %d in disk %g %g %g %g %g\n",
-		     i, p[i].x[0], p[i].x[1], p[i].x[2], zdisk (r), r);
-	      exit (0);
-	    }
-	}
+        if (fabs (p[i].x[2]) < zdisk (r))
+    {
+      Error ("Photon_agn: agn photon %d in disk %g %g %g %g %g\n",
+       i, p[i].x[0], p[i].x[1], p[i].x[2], zdisk (r), r);
+      exit (0);
+    }
+      }
+    /* this last bit is the direction, might need a change */
+    randvcos (p[i].lmn, p[i].x);
+  }
 
 
-      /* this last bit is the direction, might need a change */
-      randvcos (p[i].lmn, p[i].x);
+
+      /* if we have a lamp post geometry then we should generate isotropic photons at a height
+         above the disk plane */
+      else if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
+  {
+    p[i].x[0] = p[i].x[1] = 0.0;
+    p[i].x[2] = geo.lamp_post_height;
+
+    randvec (p[i].lmn, 1.0);  // lamp-post geometry is isotropic, so completely random vector
+  }
+
     }
   return (0);
 }

--- a/source/agn.c
+++ b/source/agn.c
@@ -434,7 +434,17 @@ photo_gen_agn (p, r, alpha, weight, f1, f2, spectype, istart, nphot)
       else if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
   {
     p[i].x[0] = p[i].x[1] = 0.0;
-    p[i].x[2] = geo.lamp_post_height;
+
+    if (rand () > MAXRAND / 2)
+      {     /* Then the photon emerges in the upper hemisphere */
+        p[i].x[2] = geo.lamp_post_height;
+      }
+    else
+      {
+        p[i].x[2] = -geo.lamp_post_height;
+      }
+
+    randvec (p[i].lmn, 1.0);  // lamp-post geometry is isotropic, so completely random vector
 
     randvec (p[i].lmn, 1.0);  // lamp-post geometry is isotropic, so completely random vector
   }

--- a/source/python.h
+++ b/source/python.h
@@ -454,7 +454,7 @@ int wind_type;		/*Basic prescription for wind(0=SV,1=speherical , 2 can imply ol
   double lum_tot, lum_star, lum_disk, lum_bl, lum_wind;	/* The total luminosities of the disk, star, bl, & wind 
 							   are actually not used in a fundamental way in the program */
   double lum_agn;		/*The total luminosity of the AGN or point source at the center */
-  double pl_geometry;      /* geometry of X-ray point source */
+  int pl_geometry;      /* geometry of X-ray point source */
 #define PL_GEOMETRY_SPHERE 0
 #define PL_GEOMETRY_LAMP_POST 1
   double lamp_post_height; /* height of X-ray point source if lamp post */

--- a/source/python.h
+++ b/source/python.h
@@ -453,6 +453,10 @@ int wind_type;		/*Basic prescription for wind(0=SV,1=speherical , 2 can imply ol
   double lum_tot, lum_star, lum_disk, lum_bl, lum_wind;	/* The total luminosities of the disk, star, bl, & wind 
 							   are actually not used in a fundamental way in the program */
   double lum_agn;		/*The total luminosity of the AGN or point source at the center */
+  double pl_geometry;      /* geometry of X-ray point source */
+#define PL_GEOMETRY_SPHERE 0
+#define PL_GEOMETRY_LAMP_POST 1
+  double lamp_post_height; /* height of X-ray point source if lamp post */
 
 /* The next four variables added by nsh Apr 2012 to allow broken power law to match the cloudy table command */
   double agn_cltab_low;		//break at which the low frequency power law ends

--- a/source/setup.c
+++ b/source/setup.c
@@ -896,6 +896,20 @@ get_bl_and_agn_params (lstar)
       if (modes.iadvanced)
 	rddoub ("agn_power_law_cutoff", &geo.pl_low_cutoff);
 
+      rddoub("geometry_for_pl_source(0=sphere,1=lamp_post)", &geo.pl_geometry);
+
+      if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
+        {
+          rddoub("lamp_post.height(r_g)", &geo.lamp_post_height);
+          geo.lamp_post_height *= G * geo.mstar / C / C;  //get it in CGS units 
+        }
+      else if (geo.pl_geometry != PL_GEOMETRY_SPHERE) // only two options at the moment
+        {
+          Error("Did not understand power law geometry %i. Fatal.\n", geo.pl_geometry);
+          exit(0);
+        }
+
+
 
       /* Computes the constant for the power law spectrum from the input alpha and 2-10 luminosity. 
          This is only used in the sim correction factor for the first time through. 

--- a/source/setup.c
+++ b/source/setup.c
@@ -919,7 +919,7 @@ get_bl_and_agn_params (lstar)
       if (modes.iadvanced)
 	rddoub ("agn_power_law_cutoff", &geo.pl_low_cutoff);
 
-      rddoub("geometry_for_pl_source(0=sphere,1=lamp_post)", &geo.pl_geometry);
+      rdint("geometry_for_pl_source(0=sphere,1=lamp_post)", &geo.pl_geometry);
 
       if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
         {

--- a/source/setup2.c
+++ b/source/setup2.c
@@ -196,6 +196,9 @@ init_geo ()
 
   geo.t_bl = 100000.;
 
+  geo.pl_geometry = PL_GEOMETRY_SPHERE;   // default to spherical geometry
+  geo.lamp_post_height = 0.0;   // should only be used if geo.pl_geometry is PL_GEOMETRY_LAMP_POST
+
 
   strcpy (geo.atomic_filename, "data/standard78");
   strcpy (geo.fixed_con_file, "none");


### PR DESCRIPTION
This is code to include a power law source with a lamp post like geometry. The user now specifies a geometry for the lamp post source and a height above the disk if they select the lamp post option.

In that case then photons are generated isotropically at a height geo.lamp_post_height above the disk. There is an even chance of being above and below the disk plane. Not yet fully tested although I've verified that plausible X-ray spectra are generated and provided a file $PYTHON/examples/lamp_post.pf.
