### PR TITLE
Multiple bugfixes and improvements

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -113,7 +113,7 @@ LDFLAGS= -L$(LIB) -lm -lcfitsio -lgsl -lgslcblas
 #Note that version should be a single string without spaces. 
 
 
-VERSION = 80
+VERSION = 80a
 
 CHOICE=1             // Compress plasma as much as possible
 # CHOICE=0           //  Keep relation between plasma and wind identical

--- a/source/atomic.h
+++ b/source/atomic.h
@@ -30,7 +30,7 @@
 #define ANGSTROM                        1.e-8	/*Definition of an Angstrom in units of this code, e.g. cm */
 
 #define EV2ERGS   			1.602192e-12
-#define RADIAN				57.29578
+#define RADIAN				57.29577951308232
 #define RYD2ERGS                        2.1798741e-11	/* Rydberg in units of ergs */
 
 

--- a/source/brem.c
+++ b/source/brem.c
@@ -35,7 +35,7 @@ integ_brem (freq)
      double freq;
 {
   double answer;
-  answer = geo.const_agn * pow(freq,-0.2) * exp ((-1.0 * H * freq) / (BOLTZMANN * geo.brem_temp));
+  answer = geo.const_agn * pow(freq,geo.brem_alpha) * exp ((-1.0 * H * freq) / (BOLTZMANN * geo.brem_temp));
   return (answer);
 }
 
@@ -45,7 +45,7 @@ double
 		double alpha;
 {
 	double answer;
-	answer=pow(alpha,-0.2)*exp(-1.0*alpha);
+	answer=pow(alpha,geo.brem_alpha)*exp(-1.0*alpha);
 	return(answer);
 }
 
@@ -90,7 +90,7 @@ get_rand_brem (freqmin, freqmax)
   
   
 
-  /*First time through create the array containing the proper boundaries for the integral of the BB function,
+  /*First time through create the array containing the proper boundaries for the integral of the brem function,
      Note calling pdf_gen_from func also defines ylo and yhi */
 
   if (ninit_brem == 0)
@@ -102,7 +102,7 @@ get_rand_brem (freqmin, freqmax)
 	  Error ("get_rand_brem: on return from pdf_gen_from_func %d\n", echeck);
 	}
 	
-      /* We need the integral of the bb function outside of the regions of interest as well */
+      /* We need the integral of the brem function outside of the regions of interest as well */
 	
       cdf_brem_tot = (pow(BREM_ALPHAMIN/100.0,0.8))/0.8+qromb (brem_d, BREM_ALPHAMIN/100.0, BREM_ALPHABIG, 1e-8);
       cdf_brem_lo = (pow(BREM_ALPHAMIN/100.0,0.8))/0.8+qromb (brem_d, BREM_ALPHAMIN/100.0, BREM_ALPHAMIN, 1e-8) / cdf_brem_tot;	//position in the full cdf of low frequcny boundary
@@ -191,7 +191,7 @@ reset.  A careful review of them is warranted.
 
   if (y <= cdf_brem_lo || brem_alphamax < BREM_ALPHAMIN)
     {
-      alpha = get_rand_pow (brem_lo_freq_alphamin, brem_lo_freq_alphamax, -0.2);
+      alpha = get_rand_pow (brem_lo_freq_alphamin, brem_lo_freq_alphamax,geo.brem_alpha);
     }
   else if (y >= cdf_brem_hi || brem_alphamin > BREM_ALPHAMAX)
     {

--- a/source/diag.c
+++ b/source/diag.c
@@ -250,10 +250,10 @@ History:
 
 
 int
-save_photon_stats (one, p, ds)
+save_photon_stats (one, p, ds, w_ave)
      WindPtr one;
      PhotPtr p;
-     double ds;
+     double ds,w_ave;
 {
   int i;
 
@@ -267,8 +267,8 @@ save_photon_stats (one, p, ds)
       if (one->nplasma == ncell_stats[i])
 	{
 	  fprintf (pstatptr,
-		   "PHOTON_DETAILS %3d %8.3e %8.3e %8.3e cell%3d wind cell%3d\n",
-		   geo.wcycle, p->freq, p->w, ds, one->nplasma, one->nwind);
+   "PHOTON_DETAILS cycle %3d n_photon %d freq %8.3e  w %8.3e ave_w %8.3e ds %8.3e nscat %d plasma cell %3d wind cell %3d\n",
+   geo.wcycle, p->np, p->freq, p->w, w_ave,ds, p->nscat, one->nplasma, one->nwind);
 	}
     }
   return (0);

--- a/source/direct_ion.c
+++ b/source/direct_ion.c
@@ -43,7 +43,6 @@ compute_di_coeffs (T)
     {
       if (ion[n].dere_di_flag == 0)
 	{
-    //printf ("NO COEFFS\n");
 	  di_coeffs[n] = 0.0;
 	}
 
@@ -96,7 +95,7 @@ compute_qrecomb_coeffs(T)
       if (ion[n].istate > 1)  //There is only any point doing this is we are not a neutral ion
     {
 
-      if (ion[n].dere_di_flag == 0)
+      if (ion[n-1].dere_di_flag == 0)
   {
     //printf ("NO COEFFS\n");
     qrecomb_coeffs[n] = 0.0;
@@ -129,6 +128,10 @@ compute_qrecomb_coeffs(T)
   }
 
     }   //End of if statement for neutral ions
+	else //We are a neutral ion - so there can be no recombination
+	{
+		qrecomb_coeffs[n] = 0.0;
+	}  
     }   //End of loop over ions
 
   return (0);

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -87,7 +87,7 @@ bf_estimators_increment (one, p, ds)
    */
   if (modes.save_cell_stats && ncstat > 0)
     {
-      save_photon_stats(one, p, ds);  // save photon statistics (extra diagnostics)
+      save_photon_stats(one, p, ds,p->w);  // save photon statistics (extra diagnostics)
     }
 
 

--- a/source/foo.h
+++ b/source/foo.h
@@ -560,6 +560,7 @@ int convergence_all(WindPtr w, char rootname[], int ochoice);
 int model_bands(WindPtr w, char rootname[], int ochoice);
 int heatcool_summary(WindPtr w, char rootname[], int ochoice);
 int complete_physical_summary(WindPtr w, char rootname[], int ochoice);
+int complete_ion_summary(WindPtr w, char rootname[], int ochoice);
 double get_density_or_frac(PlasmaPtr xplasma, int element, int istate, int frac_choice);
 int find_ion(int element, int istate);
 int find_element(int element);

--- a/source/foo.h
+++ b/source/foo.h
@@ -257,7 +257,7 @@ double gs_rrate(int nion, double T);
 /* diag.c */
 int open_diagfile(void);
 int get_extra_diagnostics(void);
-int save_photon_stats(WindPtr one, PhotPtr p, double ds);
+int save_photon_stats(WindPtr one, PhotPtr p, double ds, double w_ave);
 /* sv.c */
 int get_sv_wind_params(void);
 double sv_velocity(double x[], double v[]);
@@ -590,3 +590,4 @@ int main(int argc, char *argv[]);
 int one_choice(int choice, char *root, int ochoice);
 int py_wind_help(void);
 /* test_saha.c */
+int main(int argc, char *argv[]);

--- a/source/foo.h
+++ b/source/foo.h
@@ -193,6 +193,7 @@ int rtheta_make_hydro_grid(WindPtr w);
 int rtheta_hydro_volumes(WindPtr w);
 int hydro_frac(double coord, double coord_array[], int imax, int *cell1, int *cell2, double *frac);
 double hydro_interp_value(double array[], int im, int ii, int jm, int jj, double f1, double f2);
+int hydro_restart(void);
 /* corona.c */
 int get_corona_params(void);
 double corona_velocity(double x[], double v[]);

--- a/source/get_atomicdata.c
+++ b/source/get_atomicdata.c
@@ -2609,7 +2609,7 @@ ion[n].dere_di_flag=1;
 				if (inner_cross[n].n_fluor_yield==-1) /*This is the first yield data for this vacancy */
 				{
 					inner_fluor_yield[n_fluor_yield_tot].nion=n; /*This yield refers to this ion*/
-					inner_cross[n].n_elec_yield=n_fluor_yield_tot;
+					inner_cross[n].n_fluor_yield=n_fluor_yield_tot;
 					inner_fluor_yield[n_fluor_yield_tot].z=z;
 					inner_fluor_yield[n_fluor_yield_tot].istate=istate;
 					inner_fluor_yield[n_fluor_yield_tot].n=in;

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -107,6 +107,7 @@ communicate_estimators_para ()
   MPI_Reduce (minbandfreqhelper, minbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
   MPI_Reduce (maxbandfreqhelper, maxbandfreqhelper2, NPLASMA * NXBANDS, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
   MPI_Reduce (maxfreqhelper, maxfreqhelper2, NPLASMA, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Barrier (MPI_COMM_WORLD);  
   MPI_Reduce (redhelper, redhelper2, plasma_double_helpers, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   if (rank_global == 0)
     {
@@ -114,6 +115,7 @@ communicate_estimators_para ()
       Log_parallel ("Zeroth thread successfully received the normalised estimators. About to broadcast.\n");
     }
 
+  MPI_Barrier (MPI_COMM_WORLD);
   MPI_Bcast (redhelper2, plasma_double_helpers, MPI_DOUBLE, 0, MPI_COMM_WORLD);
   MPI_Bcast (maxfreqhelper2, NPLASMA, MPI_DOUBLE, 0, MPI_COMM_WORLD);
   /* 131213 NSH Send out the global min and max band limited frequencies to all threads */

--- a/source/py_wind.c
+++ b/source/py_wind.c
@@ -131,7 +131,8 @@ History:
  */
 
 char *choice_options = "\n\
-   1=onefile summary n=ne,  R=rho,  v=vel,        i=ion info, j=ave_tau, f=ave_freq, p=nphot, S=sim_alpha\n\
+    1=onefile summary 2=all ions in a given cell\n\
+ 	   n=ne,  R=rho,  v=vel,        i=ion info, j=ave_tau, f=ave_freq, p=nphot, S=sim_alpha\n\
    r=t_r, t=t_e,  w=rad_weight,  s=vol,     l=lum,     C=cooling/heating,  b=adiabatic cooling\n\
    a=abs, c=c4,   g=photo,       h=recomb,  k=tau H,   l=lum,     m=F_rad, x=total, y=mod_te,\n\
    o=overview,    e=everything, P=Partial emission meas, I=Ionisation parameter\n\
@@ -598,6 +599,9 @@ one_choice (choice, root, ochoice)
     case 'u':			/* Go back to full image */
       zoom (1);
       break;
+      case '2':
+      complete_ion_summary(wmain, root, ochoice);  //
+        break;
     case 'q':			/* quit */
       /* Write out a parameterfile that gives all of the commands used in this run */
       cpar ("py_wind.pf");

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -1502,6 +1502,8 @@ rdint ("Wind.array.element", &n);
      xplasma->nrad);
   Log ("xyz %8.2e %8.2e %8.2e vel %8.2e %8.2e %8.2e\n", w[n].x[0], w[n].x[1],
        w[n].x[2], w[n].v[0], w[n].v[1], w[n].v[2]);
+  Log ("r theta %12.6e %12.6e \n", w[n].rcen, w[n].thetacen/RADIAN);
+	   
   Log ("nh %8.2e ne %8.2e t_r %8.2e t_e %8.2e w %8.2e vol %8.2e\n",
        xplasma->rho * rho2nh, xplasma->ne, xplasma->t_r, xplasma->t_e,
        xplasma->w, w[n].vol);
@@ -1515,9 +1517,9 @@ rdint ("Wind.array.element", &n);
     ("t_e %8.2e cool_tot %8.2e lum_lines  %8.2e lum_ff  %8.2e lum_fb     %8.2e cool_comp %8.2e cool_adiab %8.2e cool_DR %8.2e \n",
      xplasma->t_e, xplasma->lum_rad_ioniz+xplasma->lum_comp_ioniz+xplasma->lum_adiabatic_ioniz+xplasma->lum_dr_ioniz, xplasma->lum_lines_ioniz, xplasma->lum_ff_ioniz, xplasma->lum_fb_ioniz, xplasma->lum_comp_ioniz, xplasma->lum_adiabatic_ioniz, xplasma->lum_dr_ioniz);
   Log
-    ("t_r %8.2e heat_tot %8.2e heat_lines %8.2e heat_ff %8.2e heat_photo %8.2e heat_comp %8.2e heat_icomp %8.2e\n",
+    ("t_r %8.2e heat_tot %8.2e heat_lines %8.2e heat_ff %8.2e heat_photo %8.2e heat_auger %8.2e heat_comp %8.2e heat_icomp %8.2e\n",
      xplasma->t_r, xplasma->heat_tot, xplasma->heat_lines, xplasma->heat_ff,
-     xplasma->heat_photo, xplasma->heat_comp,xplasma->heat_ind_comp);
+     xplasma->heat_photo, xplasma->heat_auger,xplasma->heat_comp,xplasma->heat_ind_comp);
 
 
 
@@ -3235,14 +3237,14 @@ complete_physical_summary (w, rootname, ochoice)
   printf("n\tnplasma\tinwind\ti\tj\tx\tz\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
 rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tconv\tconv_tr\tconv_te\tconv_hc\t \
 lum_tot\tlum_rad\tlum_fb\tlum_ff\tlum_lines\tlum_adiabatic\tlum_comp\tlum_dr\t \
-heat_tot\theat_photo\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
+heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
   if (ochoice)
-    fprintf(fptr, "n\tnplasma\tinwind\ti\tj\tx\tz\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
-rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tconv\tconv_tr\tconv_te\tconv_hc\t \
+    fprintf(fptr, "n\tnplasma\tinwind\ti\tj\tx\tz\tr\ttheta\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
+rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tXi\tconv\tconv_tr\tconv_te\tconv_hc\t \
 lum_tot\tlum_rad\tlum_fb\tlum_ff\tlum_lines\tlum_adiabatic\tlum_comp\tlum_dr\t \
-heat_tot\theat_photo\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
+heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
 
@@ -3272,7 +3274,7 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
     o6den =  get_density_or_frac(xplasma,8,6, frac_choice);
     si4den =  get_density_or_frac(xplasma,14,4, frac_choice);
 
-    /* printf("%i %i %i %i %i %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
+    /* printf("%i %i %i %i %i %8.4e %8.4e %8.4e %8.4e %8.4e  %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
@@ -3289,22 +3291,23 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
     */
     
     if (ochoice)
-      fprintf(fptr, "%i %i %i %i %i %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
-            %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e \
-            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
+      fprintf(fptr, "%i %i %i %i %i %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
+            %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e \
+            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\n",
-            n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2], vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol,
+            n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2],w[n].rcen,w[n].thetacen/RADIAN, vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol,
             plasmamain[np].rho, plasmamain[np].ne, plasmamain[np].t_e, plasmamain[np].t_r, plasmamain[np].ntot,
-            plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].converge_whole, 
+            plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].xi, plasmamain[np].converge_whole, 
             plasmamain[np].converge_t_r, plasmamain[np].converge_t_e, plasmamain[np].converge_hc, 
-            plasmamain[np].lum_ioniz, plasmamain[np].lum_rad, plasmamain[np].lum_fb, 
+			plasmamain[np].lum_rad+plasmamain[np].lum_comp+plasmamain[np].lum_adiabatic+plasmamain[np].lum_dr,
+            plasmamain[np].lum_rad, plasmamain[np].lum_fb, 
             plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].lum_adiabatic, 
-            plasmamain[np].lum_comp, plasmamain[np].lum_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, 
+            plasmamain[np].lum_comp, plasmamain[np].lum_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, plasmamain[np].heat_auger,
             plasmamain[np].heat_lines , plasmamain[np].heat_ff , plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp,
             h1den, h2den, he1den, he2den, he3den, c3den, c4den, c5den, n5den, o6den, si4den);
   }
-    else
+   else
   {
       /* if we aren't inwind then print out a load of zeroes */
 
@@ -3315,29 +3318,108 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0\n",
             n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2]);
       */
-
+	  
       if (ochoice)
-        fprintf(fptr, "%i %i %i %i %i %8.4e %8.4e 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
-            0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
+        fprintf(fptr, "%i %i %i %i %i %8.4e %8.4e 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
+            0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
-            0.0 0.0 0.0 0.0 0.0 0.0 \
+            0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0\n",
-            n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2]);
+            n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2]); 
   }
     }
   
 
   if (ochoice)
   {
-
     fclose (fptr);
     printf("\nSaved summary of physical quantites in %s, use py_read_output.py to read\n",
           filename);
   }
 
   return (0);
+  
+  
+}
+
+/**************************************************************************
+
+
+  Synopsis:  
+  complete_ion_summary outputs a file with all of the ion fractions for a given cell
+
+
+  History:
+  1602 NSH coded
+
+************************************************************************/
+
+
+
+  int
+  complete_ion_summary (w, rootname, ochoice)
+       WindPtr w;
+  char rootname[];
+  int ochoice;
+  
+  {
+	  char cell[5];
+    PlasmaPtr xplasma;
+    FILE *fptr, *fopen ();
+    char filename[LINELENGTH];
+	
+	
+    int  n, mm;
+    n = 50;
+  a: printf("There are %i wind elements in this model\n",NDIM2);
+  rdint ("Wind.array.element", &n);
+
+    if (n < 0)
+      goto b;
+    else if (n > NDIM2)
+  	{
+  	printf("No, there are %i wind elements, not %i\n",NDIM2,n);
+  	goto a;
+  	}
+	printf ("OK, using cell %i\n",n);
+    xplasma = &plasmamain[w[n].nplasma];
+	
+    if (ochoice)
+    {
+      strcpy (filename, rootname);
+	  strcat (filename,"_cell_");
+	  sprintf(cell,"%04d",n);
+	strcat (filename,cell);
+  printf ("opening file %s\n",filename);
+	
+      strcat (filename, ".ions");
+	  printf ("opening file %s\n",filename);
+      fptr = fopen (filename, "w");
+    }
+	
+	printf ("ion z n(ion) n(ion)/n(H)\n");
+	
+	
+    if (ochoice)
+      fprintf(fptr, "ion z n(ion) n(ion)/n(H)\n");
+	
+
+    for (mm = 0; mm < nions; mm++)
+      {
+        
+		  printf ("%i %i %e %e\n",mm,ion[mm].z,xplasma->density[mm],xplasma->density[mm]/(xplasma->rho*rho2nh));
+		  if (ochoice)
+		  {
+			  fprintf (fptr,"%i %i %e %e\n",mm,ion[mm].z,xplasma->density[mm],xplasma->density[mm]/(xplasma->rho*rho2nh));
+		  }
+		
+      }
+	  goto a;
+
+	b:return (0);
 
 }
+
 
 /**************************************************************************
 

--- a/source/python.c
+++ b/source/python.c
@@ -217,6 +217,7 @@ History:
 #include <string.h>
 #include <math.h>
 #include "atomic.h"
+#include <sys/time.h>  //To allow the used of the clock command without errors!!
 
 
 #include "python.h"
@@ -674,6 +675,11 @@ main (argc, argv)
 		}
 	    }
 	}
+	if (modes.zeus_connect==1) /* We are in rad-hydro mode, we want the new density and temperature*/
+		{
+			Log ("We are going to read in the density and temperature from a zeus file\n");
+			get_hydro ();  //This line just populates the hydro structures  
+		}
     }
 
   /* 121219 NSH Set up DFUDGE to be a value that makes some kind of sense
@@ -998,6 +1004,11 @@ main (argc, argv)
 }
   // Do not reinit if you want to use old windfile
 
+else if (modes.zeus_connect==1) //We have restarted, but are in zeus connect mode, so we want to update density, temp and velocities
+{
+	hydro_restart();
+}
+
   w = wmain;
 
   if (modes.save_cell_stats)
@@ -1008,8 +1019,17 @@ main (argc, argv)
 
   /* initialize the random number generator */
   //      srand( (n=(unsigned int) clock()));  
+	
+	
+	if (modes.zeus_connect==1) //We don't want to run the same photons each cycle in zeus mode!
+	{
+		n=(unsigned int) clock()*(rank_global+1);
+      srand(n);  
+  }
+  else
+  {
   srand (1084515760+(13*rank_global));
-
+}
   /* 68b - 0902 - ksl - Start with photon history off */
 
   phot_hist_on = 0;
@@ -1253,7 +1273,17 @@ main (argc, argv)
 
 
       /* Calculate and store the amount of heating of the disk due to radiation impinging on the disk */
+	/* We only want one process to write to the file */
+#ifdef MPI_ON
+      if (rank_global == 0)
+      {
+#endif
       qdisk_save (files.disk, ztot);
+	  
+#ifdef MPI_ON
+      }
+      MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
 /* Completed writing file describing disk heating */
 
@@ -1305,13 +1335,13 @@ main (argc, argv)
 #endif
       spectrum_summary (files.wspec, "w", 0, 6, 0, 1., 0);
       spectrum_summary (files.lspec, "w", 0, 6, 0, 1., 1);	/* output the log spectrum */
-
+      phot_gen_sum (files.phot, "w");	/* Save info about the way photons are created and absorbed
+					   by the disk */
 #ifdef MPI_ON
       }
       MPI_Barrier(MPI_COMM_WORLD);
 #endif
-      phot_gen_sum (files.phot, "w");	/* Save info about the way photons are created and absorbed
-					   by the disk */
+
 
       /* Save everything after each cycle and prepare for the next cycle 
          JM1304: moved geo.wcycle++ after xsignal to record cycles correctly. First cycle is cycle 0. */
@@ -1333,6 +1363,17 @@ main (argc, argv)
       wind_save (files.windsave);
       Log_silent ("Saved wind structure in %s after cycle %d\n", files.windsave,
 	   geo.wcycle);
+ /* In a diagnostic mode save the wind file for each cycle (from thread 0) */
+
+       if (modes.keep_ioncycle_windsaves)
+ 	{
+ 	  strcpy (dummy, "");
+ 	  sprintf (dummy, "python%02d.wind_save", geo.wcycle);
+	  wind_save (dummy);
+       Log ("Saved wind structure in %s\n", dummy);
+ 	}
+	   
+	   
 #ifdef MPI_ON
       }
       MPI_Barrier(MPI_COMM_WORLD);
@@ -1537,9 +1578,14 @@ main (argc, argv)
 
 
 /* XXXX -- END CYCLE TO CALCULATE DETAILED SPECTRUM */
-
+#ifdef MPI_ON    
+      if (rank_global == 0)
+      {
+#endif
   phot_gen_sum (files.phot, "a");
-
+#ifdef MPI_ON
+      }
+#endif
 /* 57h - 07jul -- ksl -- Write out the freebound information */
 
 #ifdef MPI_ON

--- a/source/python.c
+++ b/source/python.c
@@ -217,7 +217,7 @@ History:
 #include <string.h>
 #include <math.h>
 #include "atomic.h"
-#include <sys/time.h>  //To allow the used of the clock command without errors!!
+#include <time.h>  //To allow the used of the clock command without errors!!
 
 
 #include "python.h"

--- a/source/python.h
+++ b/source/python.h
@@ -343,6 +343,8 @@ struct geometry
 
 // The next set of parameters relate to the central source of an AGN
   double brem_temp;       /*The temperature of a bremsstrahlung source */
+  double brem_alpha;       /*The exponent of the nu term for a bremstrahlung source */
+
   double pl_low_cutoff;  /* accessible only in advanced mode- see #34. default to zero */
 
   double alpha_agn;		/*The power law index of a BH at the center of an AGN.  Note that the luminosity

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -462,7 +462,7 @@ if (freq > phot_freq_min)
    */
   if (modes.save_cell_stats && ncstat > 0)
     {
-      save_photon_stats (one, p, ds);	// save photon statistics (extra diagnostics)
+      save_photon_stats (one, p, ds, w_ave);	// save photon statistics (extra diagnostics)
     }
 
 

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -172,8 +172,11 @@ fb_topbase_partial (freq)
   else if (ion[nion].phot_info == 0)	// it's a VFKY record, so shouldn't really use levels
   	gn = ion[nion].g;
   else
+  {
   	Error("fb_topbase_partial: Did not understand cross-section type %i for ion %i. Setting multiplicity to zero!\n",
   		   ion[nion].phot_info, nion);
+		gn = 0.0;   
+	   }
 
 
   gion = ion[nion + 1].g;	// Want the g factor of the next ion up
@@ -1355,7 +1358,7 @@ total_rrate (nion, T)
   else if (total_rr[ion[nion].nxtotalrr].type == RRTYPE_SHULL)
     {
       rate =
-	total_rr[ion[nion].nxtotalrr].params[0] * pow ((T / 1.0e4),
+	total_rr[ion[nion].nxtotalrr].params[0] * pow ((T / 1.0e4),-1.0*
 						       total_rr[ion
 								[nion].
 								nxtotalrr].

--- a/source/setup.c
+++ b/source/setup.c
@@ -481,7 +481,6 @@ int get_radiation_sources()
     "Rad_type_for_agn(0=bb,1=models,3=power_law,4=cloudy_table,5=bremsstrahlung)_to_make_wind",
     &geo.agn_ion_spectype);
 
-	 printf ("NSH %i\n",geo.agn_ion_spectype);
   /* 130621 - ksl - This is a kluge to add a power law to stellar systems.  What id done
      is to remove the bl emission, which we always assume to some kind of temperature
      driven source, and replace it with a power law source
@@ -845,8 +844,10 @@ int get_bl_and_agn_params (lstar)
 	else if (geo.agn_ion_spectype == SPECTYPE_BREM)
 	{
 		geo.brem_temp=1.16e8; //10kev
+		geo.brem_alpha=-0.2; //This is the cloudy form of bremstrahlung
 		geo.const_agn=1.0;
-		rddoub ("agn_bremsstrahung_temp(K)",&geo.brem_temp);
+		rddoub ("agn_bremsstrahlung_temp(K)",&geo.brem_temp);
+		rddoub ("agn_bremsstrahlung_alpha",&geo.brem_alpha);
 		temp_const_agn = geo.lum_agn / qromb(integ_brem,4.84e17,2.42e18,1e-4);
 		geo.const_agn=temp_const_agn;
       Log ("AGN Input parameters give a Bremsstrahlung constant of %e\n", temp_const_agn);

--- a/source/templates.h
+++ b/source/templates.h
@@ -560,6 +560,7 @@ int convergence_all(WindPtr w, char rootname[], int ochoice);
 int model_bands(WindPtr w, char rootname[], int ochoice);
 int heatcool_summary(WindPtr w, char rootname[], int ochoice);
 int complete_physical_summary(WindPtr w, char rootname[], int ochoice);
+int complete_ion_summary(WindPtr w, char rootname[], int ochoice);
 double get_density_or_frac(PlasmaPtr xplasma, int element, int istate, int frac_choice);
 int find_ion(int element, int istate);
 int find_element(int element);

--- a/source/templates.h
+++ b/source/templates.h
@@ -257,7 +257,7 @@ double gs_rrate(int nion, double T);
 /* diag.c */
 int open_diagfile(void);
 int get_extra_diagnostics(void);
-int save_photon_stats(WindPtr one, PhotPtr p, double ds);
+int save_photon_stats(WindPtr one, PhotPtr p, double ds, double w_ave);
 /* sv.c */
 int get_sv_wind_params(void);
 double sv_velocity(double x[], double v[]);
@@ -590,3 +590,4 @@ int main(int argc, char *argv[]);
 int one_choice(int choice, char *root, int ochoice);
 int py_wind_help(void);
 /* test_saha.c */
+int main(int argc, char *argv[]);

--- a/source/templates.h
+++ b/source/templates.h
@@ -193,6 +193,7 @@ int rtheta_make_hydro_grid(WindPtr w);
 int rtheta_hydro_volumes(WindPtr w);
 int hydro_frac(double coord, double coord_array[], int imax, int *cell1, int *cell2, double *frac);
 double hydro_interp_value(double array[], int im, int ii, int jm, int jj, double f1, double f2);
+int hydro_restart(void);
 /* corona.c */
 int get_corona_params(void);
 double corona_velocity(double x[], double v[]);

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -665,7 +665,7 @@ free (commbuffer);
   {
 	  Log("Outputting heatcool file for connecting to zeus\n");
       fptr = fopen ("py_heatcool.dat", "w");
- 	 fprintf(fptr,"i j rcen thetacen vol temp xi ne heat_xray heat_comp heat_lines heat_ff cool_comp cool_lines cool_ff\n");
+  	 fprintf(fptr,"i j rcen thetacen vol temp xi ne heat_xray heat_comp heat_lines heat_ff cool_comp cool_lines cool_ff rho n_h\n");
 	  
   }
 
@@ -729,20 +729,7 @@ free (commbuffer);
 
 
 
-	  if (modes.zeus_connect==1) //If we are running in zeus connect mode, we output heating and cooling rates.
-	  {
-	 		 wind_n_to_ij (plasmamain[nplasma].nwind, &i, &j);
-			 vol=w[plasmamain[nplasma].nwind].vol;
-   		  fprintf(fptr,"%d %d %e %e %e ",i,j,w[plasmamain[nplasma].nwind].rcen,w[plasmamain[nplasma].nwind].thetacen/RADIAN,vol); //output geometric things
-   		  fprintf(fptr,"%e %e %e ",plasmamain[nplasma].t_e,plasmamain[nplasma].xi,plasmamain[nplasma].ne); //output temp, xi and ne to ease plotting of heating rates
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_photo+plasmamain[nplasma].heat_auger)/vol); //Xray heating - or photoionization
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_comp)/vol); //Compton heating
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_lines)/vol); //Line heating 28/10/15 - not currently used in zeus
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_ff)/vol); //FF heating 28/10/15 - not currently used in zeus
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_comp)/vol); //Compton cooling
-   		  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_lines+plasmamain[nplasma].lum_fb+plasmamain[nplasma].lum_dr)/vol); //Line cooling must include all recombinatiobs cooling
-   		  fprintf(fptr,"%e\n",(plasmamain[nplasma].lum_ff)/vol); //ff cooling
-	   }
+
     }
 	
     if (modes.zeus_connect==1) 
@@ -781,6 +768,28 @@ free (commbuffer);
 
   asum = wind_luminosity (0.0, VERY_BIG);  /*We call wind_luminosity here to obtain an up to date set of cooling rates*/
 
+
+  if (modes.zeus_connect==1) //If we are running in zeus connect mode, we output heating and cooling rates.
+  {
+	  for (nplasma = 0; nplasma < NPLASMA; nplasma++)
+	  {
+	  
+ 		 wind_n_to_ij (plasmamain[nplasma].nwind, &i, &j);
+		 vol=w[plasmamain[nplasma].nwind].vol;
+	  fprintf(fptr,"%d %d %e %e %e ",i,j,w[plasmamain[nplasma].nwind].rcen,w[plasmamain[nplasma].nwind].thetacen/RADIAN,vol); //output geometric things
+	  fprintf(fptr,"%e %e %e ",plasmamain[nplasma].t_e,plasmamain[nplasma].xi,plasmamain[nplasma].ne); //output temp, xi and ne to ease plotting of heating rates
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_photo+plasmamain[nplasma].heat_auger)/vol); //Xray heating - or photoionization
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_comp)/vol); //Compton heating
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_lines)/vol); //Line heating 28/10/15 - not currently used in zeus
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_ff)/vol); //FF heating 28/10/15 - not currently used in zeus
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_comp)/vol); //Compton cooling
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_lines+plasmamain[nplasma].lum_fb+plasmamain[nplasma].lum_dr)/vol); //Line cooling must include all recombinatiobs cooling
+	  fprintf(fptr,"%e",(plasmamain[nplasma].lum_ff)/vol); //ff cooling
+	  fprintf(fptr,"%e ",plasmamain[nplasma].rho); //density
+	  fprintf(fptr,"%e\n",plasmamain[nplasma].rho*rho2nh); //hydrogen number density
+   }
+    fclose(fptr);
+}
 
   /* 1108 NSH Added commands to report compton heating */
   Log ("!!wind_update: Absorbed flux    %8.2e  (photo %8.2e ff %8.2e compton %8.2e auger %8.2e induced_compton %8.2e lines %8.2e)\n", 

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -732,8 +732,7 @@ free (commbuffer);
 
     }
 	
-    if (modes.zeus_connect==1) 
-        fclose(fptr);
+
 
   /* JM130621- bugfix for windsave bug- needed so that we have the luminosities from ionization
      cycles in the windsavefile even if the spectral cycles are run */

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -783,7 +783,7 @@ free (commbuffer);
 	  fprintf(fptr,"%e ",(plasmamain[nplasma].heat_ff)/vol); //FF heating 28/10/15 - not currently used in zeus
 	  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_comp)/vol); //Compton cooling
 	  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_lines+plasmamain[nplasma].lum_fb+plasmamain[nplasma].lum_dr)/vol); //Line cooling must include all recombinatiobs cooling
-	  fprintf(fptr,"%e",(plasmamain[nplasma].lum_ff)/vol); //ff cooling
+	  fprintf(fptr,"%e ",(plasmamain[nplasma].lum_ff)/vol); //ff cooling
 	  fprintf(fptr,"%e ",plasmamain[nplasma].rho); //density
 	  fprintf(fptr,"%e\n",plasmamain[nplasma].rho*rho2nh); //hydrogen number density
    }


### PR DESCRIPTION
There are a few modifications to python in this pull, each in a separate commit (more or less). The headlines are:
1: Changed the value of RADIAN to increased precision. This was to cope with some problems arising in finely gridded hydro models. This gave some differences in an spectrum - but within random photon errors.
2: Modified the bremstrahlung central source spectrum to allow a user defined alpha (the exponent of the nu term) to permit matching either cloudy or xstar. - no change in fiducial AGN spectrum
3: Made a small change to the direct ion calculations. The check to see if coffee were available was pointing at the wrong record. Also, if another check proved incorrect, the error message said it was setting the coeff to zero - but it didn't. Small changes to fiducial AGN, but within random photon noise
4: Small change to photon stat output. We now save the mean weight of a photon to the output file - this allows us to properly reconstruct the in cell spectrum. Again, photon noise changes to fiducial an run
5: Fixed bug in electron yield input - no change to spectra
6: Fixed error in calculation of schull type recommit data. Some changes to fiducial spectra, but within noise
7: Added some blocks in para_update to try and prevent iridis hangs. May still not be fixed! - no change to spectra
8: Also changes to hydro to allow restarts to use a past wind_save file to inform ionization state, added auger heating to mode 1 in py_wind, and added a mode 2 to output all ions for a given cell in ascii read-in style. Also a couple more bug fixes. None of these changed the AGN fiducial spectrum.
9: Added the correct library to python.c to allow the clock call in python to set a new random number seed.
