### PR TITLE
Implementation of log spectra

### DIFF
--- a/source/extract.c
+++ b/source/extract.c
@@ -427,6 +427,8 @@ the same resonance again */
 	  if ( pp->origin == PTYPE_WIND || pp->origin == PTYPE_WIND_MATOM || pp->nscat > 0) {
 
 	  	xxspec[nspec].f_wind[k] += pp->w * exp (-(tau));	//OK increment the spectrum in question
+	  	xxspec[nspec].lf_wind[k1] += pp->w * exp (-(tau));	//OK increment the spectrum in question
+
 	    }
 			    
 	

--- a/source/extract.c
+++ b/source/extract.c
@@ -236,6 +236,7 @@ History:
  	97sep28	ksl	Modified weightings of extracted photons to be those in Knigge's thesis for
 			Eddington approximation
 	02jan2	ksl	Adapted extract to use photon types
+	16jun22 NSH Added lines to produce a logarithmically binned spectrum
 
 **************************************************************/
 
@@ -252,12 +253,13 @@ extract_one (w, pp, itype, nspec)
   struct photon pstart;
   double weight_min;
   int icell;
-  int k;
+  int k,k1;
   double x[3];
   double tau;
   double zz;
   double dvds;
-  int ishell;
+  double lfreqmin,lfreqmax,ldfreq;
+    int ishell;
 
 
   weight_min = EPSILON * pp->w;
@@ -393,6 +395,24 @@ the same resonance again */
 	    k = 0;
 	  else if (k > NWAVE - 1)
 	    k = NWAVE - 1;
+	  
+	  
+	  lfreqmin = log10 (xxspec[nspec].freqmin);
+	  lfreqmax = log10 (xxspec[nspec].freqmax);
+	  ldfreq = (lfreqmax - lfreqmin) / NWAVE;
+	  
+	  
+	  
+    /* find out where we are in log space */
+      k1 = (log10 (pp->freq) - log10 (xxspec[nspec].freqmin)) / ldfreq;
+      if (k1 < 0)
+	{
+	  k1 = 0;
+	}
+      if (k1 > NWAVE-1)
+	{
+	  k1 = NWAVE-1;
+	}
 
 	  /* Increment the spectrum.  Note that the photon weight has not been diminished
 	   * by its passage through th wind, even though it may have encounterd a number
@@ -400,6 +420,8 @@ the same resonance again */
 	   */
 
 	  xxspec[nspec].f[k] += pp->w * exp (-(tau));	//OK increment the spectrum in question
+	  xxspec[nspec].lf[k1] += pp->w * exp (-(tau));  //And increment the log spectrum
+	  
 
 	  /* If this photon was a wind photon, then also increment the "reflected" spectrum */
 	  if ( pp->origin == PTYPE_WIND || pp->origin == PTYPE_WIND_MATOM || pp->nscat > 0) {

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -1525,8 +1525,8 @@ rdint ("Wind.array.element", &n);
        w[n].x[2], w[n].v[0], w[n].v[1], w[n].v[2]);
   Log ("r theta %12.6e %12.6e \n", w[n].rcen, w[n].thetacen/RADIAN);
 	   
-  Log ("nh %8.2e ne %8.2e t_r %8.2e t_e %8.2e w %8.2e vol %8.2e\n",
-       xplasma->rho * rho2nh, xplasma->ne, xplasma->t_r, xplasma->t_e,
+  Log ("rho %8.2e nh %8.2e ne %8.2e t_r %8.2e t_e %8.2e w %8.2e vol %8.2e\n",
+       xplasma->rho ,xplasma->rho * rho2nh, xplasma->ne, xplasma->t_r, xplasma->t_e,
        xplasma->w, w[n].vol);
 
   if (w[n].inwind < 0)
@@ -1565,7 +1565,7 @@ rdint ("Wind.array.element", &n);
   Log ("DR cooling        %8.2e is %8.2g of total cooling\n", xplasma->lum_dr_ioniz,
        xplasma->lum_dr_ioniz / (xplasma->lum_rad + xplasma->lum_adiabatic + xplasma->lum_comp_ioniz + xplasma->lum_dr_ioniz));
   Log ("Number of ionizing photons in cell nioniz %d\n", xplasma->nioniz);
-  Log ("Log Ionization parameter in this cell cell based %4.2f ferland %4.2f\n", log10 (xplasma->ip), log10 (xplasma->ferland_ip));	//70h NSH computed ionizaion parameter
+  Log ("Log Ionization parameter in this cell U %4.2f xi %4.2f\n", log10 (xplasma->ip), log10 (xplasma->xi));	//70h NSH computed ionizaion parameter
   Log ("ioniz %8.2e %8.2e %8.2e %8.2e %8.2e\n",
        xplasma->ioniz[0], xplasma->ioniz[1], xplasma->ioniz[2],
        xplasma->ioniz[3], xplasma->ioniz[4]);

--- a/source/python.h
+++ b/source/python.h
@@ -1264,9 +1264,9 @@ struct filenames
   char diagfolder[LINELENGTH];  // diag folder
   char old_windsave[LINELENGTH];// old windsave name
   char input[LINELENGTH];       // input name if creating new pf file
-  char lspec[LINELENGTH];       // log_spec_tot file name
+  char lwspec[LINELENGTH];       // log_spec_tot file name  
   char wspec[LINELENGTH];       // spectot file name
-  char lspec_wind[LINELENGTH];  // log_spec_tot filename for wind photons
+  char lwspec_wind[LINELENGTH];  // log_spec_tot filename for wind photons
   char wspec_wind[LINELENGTH];  // spectot filename for wind photons
   char disk[LINELENGTH];        // disk diag file name
   char tprofile[LINELENGTH];    // non standard tprofile fname
@@ -1274,6 +1274,8 @@ struct filenames
   char windrad[LINELENGTH];     // wind rad file
   char spec[LINELENGTH];        // .spec file
   char spec_wind[LINELENGTH];   // .spec file for wind photons
+  char lspec[LINELENGTH];        // .spec file
+  char lspec_wind[LINELENGTH];   // .spec file for wind photons
 }
 files;
 

--- a/source/run.c
+++ b/source/run.c
@@ -330,9 +330,9 @@ calculate_ionization (restart_stat)
 #endif
 
 	  spectrum_summary (files.wspec, "w", 0, 6, 0, 1., 0, 0);
-	  spectrum_summary (files.lspec, "w", 0, 6, 0, 1., 1, 0);	/* output the log spectrum */
+	  spectrum_summary (files.lwspec, "w", 0, 6, 0, 1., 1, 0);	/* output the log spectrum */
 	  spectrum_summary (files.wspec_wind, "w", 0, 6, 0, 1., 0, 1);  /* These two are the spectra of wind photons */
-	  spectrum_summary (files.lspec_wind, "w", 0, 6, 0, 1., 1, 1);	/* output the log spectrum */
+	  spectrum_summary (files.lwspec_wind, "w", 0, 6, 0, 1., 1, 1);	/* output the log spectrum */
     phot_gen_sum (files.phot, "w"); /* Save info about the way photons are created and absorbed
              by the disk */
 #ifdef MPI_ON

--- a/source/run.c
+++ b/source/run.c
@@ -599,7 +599,7 @@ int make_spectra(restart_stat)
 	{
 #endif
 	  spectrum_summary (files.spec, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 0);
-	  spectrum_summary (files.lspec, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 1);
+	  spectrum_summary (files.lspec, "w", 0, nspectra - 1, geo.select_spectype, renorm, 1, 0);
 	  
 	  /* Next line is of spectrum just of the wind*/
 	  spectrum_summary (files.spec_wind, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 1);

--- a/source/run.c
+++ b/source/run.c
@@ -599,8 +599,12 @@ int make_spectra(restart_stat)
 	{
 #endif
 	  spectrum_summary (files.spec, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 0);
+	  spectrum_summary (files.lspec, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 1);
+	  
 	  /* Next line is of spectrum just of the wind*/
 	  spectrum_summary (files.spec_wind, "w", 0, nspectra - 1, geo.select_spectype, renorm, 0, 1);
+	  spectrum_summary (files.lspec_wind, "w", 0, nspectra - 1, geo.select_spectype, renorm, 1, 1);
+	  
 #ifdef MPI_ON
 	}
 #endif

--- a/source/setup.c
+++ b/source/setup.c
@@ -1443,10 +1443,10 @@ setup_created_files ()
   strcpy (basename, files.root);	//56d -- ksl --Added so filenames could be created by routines as necessary
 
   strcpy (files.wspec, files.root);  //generated photons
-  strcpy (files.lspec, files.root);  //generated photon in log space
+  strcpy (files.lwspec, files.root);  //generated photon in log space
   
   strcpy (files.wspec_wind, files.root);
-  strcpy (files.lspec_wind, files.root);
+  strcpy (files.lwspec_wind, files.root);
   
   strcpy (files.spec, files.root);  
   strcpy (files.lspec, files.root);  
@@ -1468,9 +1468,10 @@ setup_created_files ()
   strcat (files.disk, files.root);
 
   strcat (files.wspec, ".spec_tot");
-  strcat (files.lspec, ".log_spec_tot");
+  strcat (files.lwspec, ".log_spec_tot");
+  
   strcat (files.wspec_wind, ".spec_tot_wind");
-  strcat (files.lspec_wind, ".log_spec_tot_wind");
+  strcat (files.lwspec_wind, ".log_spec_tot_wind");
   
   
   strcat (files.spec, ".spec");

--- a/source/setup.c
+++ b/source/setup.c
@@ -1442,12 +1442,20 @@ setup_created_files ()
 
   strcpy (basename, files.root);	//56d -- ksl --Added so filenames could be created by routines as necessary
 
-  strcpy (files.wspec, files.root);
-  strcpy (files.lspec, files.root);
-  strcpy (files.spec, files.root);
+  strcpy (files.wspec, files.root);  //generated photons
+  strcpy (files.lspec, files.root);  //generated photon in log space
+  
   strcpy (files.wspec_wind, files.root);
   strcpy (files.lspec_wind, files.root);
-  strcpy (files.spec_wind, files.root);
+  
+  strcpy (files.spec, files.root);  
+  strcpy (files.lspec, files.root);  
+  
+  strcpy (files.spec_wind, files.root);  
+  strcpy (files.lspec_wind, files.root); 
+  
+  
+  
 
   strcpy (files.windrad, "python");
   strcpy (files.windsave, files.root);
@@ -1463,8 +1471,15 @@ setup_created_files ()
   strcat (files.lspec, ".log_spec_tot");
   strcat (files.wspec_wind, ".spec_tot_wind");
   strcat (files.lspec_wind, ".log_spec_tot_wind");
+  
+  
   strcat (files.spec, ".spec");
+  strcat (files.lspec, ".log_spec");
+
   strcat (files.spec_wind, ".spec_wind");
+  strcat (files.lspec_wind, ".log_spec_wind");
+  
+  
   strcat (files.windrad, ".wind_rad");
   strcat (files.windsave, ".wind_save");
   strcat (files.specsave, ".spec_save");

--- a/source/spectra.c
+++ b/source/spectra.c
@@ -795,11 +795,11 @@ spectrum_summary (filename, mode, nspecmin, nspecmax, select_spectype, renorm,
 	      else if (select_spectype == 2)
 		{		/*fnu */
 		  x /= (dfreq * dd);
-		}
+		}		
         else if (select_spectype == 0)
-  	{		/*fnu */
-  	  x /= (dfreq);  //With log spectra implemented, we should divide by nu, so log and lin spectra agree
-  	}
+		{		/*generated spectrum*/
+			x /= (dfreq);  //With log spectra implemented, we should divide by nu, so log and lin spectra agree
+  		}
 	      fprintf (fptr, " %8.3g", x * renorm);
 	    }
 
@@ -836,10 +836,10 @@ spectrum_summary (filename, mode, nspecmin, nspecmax, select_spectype, renorm,
 		  x /= (dfreq * dd);
 		}
         else if (select_spectype == 0)  
-  	{		/*fnu */
-  	  x /= (dfreq); 
-  	}
-	      fprintf (fptr, " %8.3g", x * renorm);	/* this really shouldn't get called if we are outputting log data */
+  		{		/*generated spectrum*/
+  	  	  x /= (dfreq); 
+  		}
+	      fprintf (fptr, " %8.3g", x * renorm);
 	    }
 
 

--- a/source/spectra.c
+++ b/source/spectra.c
@@ -796,6 +796,10 @@ spectrum_summary (filename, mode, nspecmin, nspecmax, select_spectype, renorm,
 		{		/*fnu */
 		  x /= (dfreq * dd);
 		}
+        else if (select_spectype == 0)
+  	{		/*fnu */
+  	  x /= (dfreq);  //With log spectra implemented, we should divide by nu, so log and lin spectra agree
+  	}
 	      fprintf (fptr, " %8.3g", x * renorm);
 	    }
 
@@ -831,6 +835,10 @@ spectrum_summary (filename, mode, nspecmin, nspecmax, select_spectype, renorm,
 		{		/*fnu */
 		  x /= (dfreq * dd);
 		}
+        else if (select_spectype == 0)  
+  	{		/*fnu */
+  	  x /= (dfreq); 
+  	}
 	      fprintf (fptr, " %8.3g", x * renorm);	/* this really shouldn't get called if we are outputting log data */
 	    }
 


### PR DESCRIPTION
This pull request is for bug report #170.
log_spec is output as the logarithmic spectrum equivalent of spec
log_spec_wind is the log equivalent of spec_wind.

The spec_tot file is also slightly modified. It is now divided by dfreq so that the log_spec_tot file looks the same as the log_spec file. Both now show L_nu rather than L_nudnu
