### PR TITLE
Fixed bug #229

### DIFF
--- a/source/agn.c
+++ b/source/agn.c
@@ -111,22 +111,41 @@ double
 emittance_pow (freqmin, freqmax, lum, alpha)
      double freqmin, freqmax, lum, alpha;
 {
-  double constant, emit;
+  double emit;
   /* these are the frequencies over which the power law is defined - currently set to the
      equivalent of 2 to 10 keV */
 
 
-#define   XFREQMIN  4.84e17
-#define   XFREQMAX  2.42e18
+  //#define   XFREQMIN  4.84e17
+  //#define   XFREQMAX  2.42e18
 
   /* first we need to calculate the constant for the power law function */
-  constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));      /*NSH 1205 - this seems a bit unnecessary now. The constant is calculaed elsewhere, and with the broken power law we could probably get rid of this - is it even working properly now */
-
+ 
+ /* 
+  if (alpha == -1.0) //deal with the pathological case
+  {
+      constant = lum / (log(XFREQMAX) - log(XFREQMIN));    
+}
+else
+{
+    constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));      
+}
+  
+  */
   /* now we need to work out the luminosity between our limited frequency range */
   /* we may need some checking routines to make sure that the requested frequency range is within the defined range,
      or it could default to zero outside the defined range */
-
-  emit = constant * ((pow (freqmax, alpha + 1.0) - pow (freqmin, alpha + 1.0)) / (alpha + 1.0));
+  
+  
+if (alpha == -1.0) //deal with the pathological case
+{
+	emit = geo.const_agn * (log(freqmax) - log(freqmin));
+}
+else
+{
+    emit = geo.const_agn * ((pow (freqmax, alpha + 1.0) - pow (freqmin, alpha + 1.0)) / (alpha + 1.0));
+}	
+  
 
   return (emit);
 }
@@ -160,7 +179,7 @@ double
 emittance_bpow (freqmin, freqmax, lum, alpha)
      double freqmin, freqmax, lum, alpha;
 {
-  double constant, constant_low, constant_hi, emit;
+  double constant_low, constant_hi, emit;
   double e1, e2, e3;
   double atemp, ctemp, f1, f2;
   double pl_low, pl_hi;
@@ -174,8 +193,19 @@ emittance_bpow (freqmin, freqmax, lum, alpha)
   f2 = freqmax;                 /* NSH - 130506 added to reomve 03 compile errors */
   e1 = e2 = e3 = 0.0;           /* NSH - 130506 added to reomve 03 compile errors */
   /* first we need to calculate the constant for the 2-10 kev power law function */
-  constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));
-
+  
+  
+  /*
+  if (alpha == -1.0) //deal with the pathological case
+  {
+      constant = lum / (log(XFREQMAX) - log(XFREQMIN));    
+	  printf ("BLAH Computed constant=%e\n",constant)  ;  
+}
+else
+{
+    constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));    NSH 1205 - this seems a bit unnecessary now. The constant is calculaed elsewhere, and with the broken power law we could probably get rid of this - is it even working properly now 
+}
+  */
 
 /* convert broken power law bands to freq */
 
@@ -185,7 +215,6 @@ emittance_bpow (freqmin, freqmax, lum, alpha)
 
   constant_low = xband.pl_const[0];     //we have already worked out the constants
   constant_hi = xband.pl_const[xband.nbands - 1];
-
 
 
   /* now we need to work out the luminosity between our limited frequency range */
@@ -240,9 +269,14 @@ emittance_bpow (freqmin, freqmax, lum, alpha)
       f1 = freqmin;
       f2 = pl_hi;
     }
-    atemp = alpha;
-    ctemp = constant;
-    e2 = ctemp * ((pow (f2, atemp + 1.0) - pow (f1, atemp + 1.0)) / (atemp + 1.0));
+//    atemp = alpha;
+//    ctemp = constant;
+	
+	
+	e2=emittance_pow (f1, f2, lum, alpha);
+	
+	
+//    e2 = ctemp * ((pow (f2, atemp + 1.0) - pow (f1, atemp + 1.0)) / (atemp + 1.0));
     Log ("Broken power law: Emittance in centre is %e\n", e2);
   }
   else

--- a/source/bands.c
+++ b/source/bands.c
@@ -263,11 +263,16 @@ bands_init (imode, band)
   }
   else if (mode == 5)           /* Set up to compare with cloudy power law table command note that this also sets up the weight and photon index for the PL, to ensure a continuous distribution */
   {
+	  if (geo.agn_ion_spectype != SPECTYPE_CL_TAB)
+	  {
+		  Error("Trying to use a broken power law banding without setting spectype to broken power law - must set spectype to 4\n");
+		  exit(0);
+	  }
     rddoub ("Lowest_energy_to_be_considered(eV)", &xx);
 
     if (xx > geo.agn_cltab_low)
     {
-      xx = geo.agn_cltab_low / 10.0;
+	  xx = geo.agn_cltab_low / 10.0;
       Log ("Lowest  frequency reset to 1/10 of low frequency break\n");
     }
     f1 = xx / HEV;

--- a/source/bb.c
+++ b/source/bb.c
@@ -340,12 +340,22 @@ get_rand_pow (x1, x2, alpha)
 
   r = rand () / MAXRAND;
 
-  x1 = pow (x1, alpha + 1.);
-  x2 = pow (x2, alpha + 1.);
+  if (alpha==-1)
+	  {
+		  x1=log(x1);
+			  x2=log(x2);
+			  a = (1. - r) * x1 + r * x2;
+			  a=exp(a);
+	  } 
+	  else
+	  {
+		  x1 = pow (x1, alpha + 1.);
+  		x2 = pow (x2, alpha + 1.);
 
-  a = (1. - r) * x1 + r * x2;
+	    a = (1. - r) * x1 + r * x2;
 
   a = pow (a, 1. / (alpha + 1.));
+}
   return (a);
 }
 

--- a/source/setup.c
+++ b/source/setup.c
@@ -917,7 +917,15 @@ get_bl_and_agn_params (lstar)
     {
       geo.alpha_agn = (-1.5);
       rddoub ("agn_power_law_index", &geo.alpha_agn);
-      geo.const_agn = geo.lum_agn / (((pow (2.42e18, geo.alpha_agn + 1.)) - pow (4.84e17, geo.alpha_agn + 1.0)) / (geo.alpha_agn + 1.0));
+	  
+      if (geo.alpha_agn == -1.0) //deal with the pathological case
+      {
+          geo.const_agn = geo.lum_agn / (log(2.42e18) - log(4.84e17));    
+    }
+    else
+    {
+        geo.const_agn = geo.lum_agn / (((pow (2.42e18, geo.alpha_agn + 1.)) - pow (4.84e17, geo.alpha_agn + 1.0)) / (geo.alpha_agn + 1.0));
+    }
       Log ("AGN Input parameters give a power law constant of %e\n", geo.const_agn);
     }
     else if (geo.agn_ion_spectype == SPECTYPE_BREM)
@@ -995,8 +1003,18 @@ get_bl_and_agn_params (lstar)
     /* Computes the constant for the power law spectrum from the input alpha and 2-10 luminosity. 
        This is only used in the sim correction factor for the first time through. 
        Afterwards, the photons are used to compute the sim parameters. */
-
-    geo.const_agn = geo.lum_agn / (((pow (2.42e18, geo.alpha_agn + 1.)) - pow (4.84e17, geo.alpha_agn + 1.0)) / (geo.alpha_agn + 1.0));
+	
+	
+    if (geo.alpha_agn == -1.0) //deal with the pathological case
+    {
+        geo.const_agn = geo.lum_agn / (log(2.42e18) - log(4.84e17));    
+  }
+  else
+  {
+      geo.const_agn = geo.lum_agn / (((pow (2.42e18, geo.alpha_agn + 1.)) - pow (4.84e17, geo.alpha_agn + 1.0)) / (geo.alpha_agn + 1.0));
+  }
+	
+	
     Log ("AGN Input parameters give a power law constant of %e\n", geo.const_agn);
 
     if (geo.agn_ion_spectype == SPECTYPE_CL_TAB)        /*NSH 0412 - option added to allow direct comparison with cloudy power law table option */


### PR DESCRIPTION
The primary bug noted in #229 was that the cloudy banding was failing - in fact this was user error, the photon gen was set to normal PL, which meant that the cloudy style banding didn't have the correct variables set. This has been fixed with a simple check to see that the photon gen and banding are compatible. 
Secondarily, a PL alpha of -1 has been selected. Because the integrals required to work out photon weights for PL just used nu^alpha+1/alpha+1 integration, this fails. A check has been put in for the pathological case when alpha=-1 and ln(nu) is now used in that case. 