### PR TITLE
Commit to fix #235

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,7 +58,7 @@ clean:
 	cd $(GSL); make clean;  
 	cd $(PYTHON)/source/; make clean
 	rm -rf $(PYTHON)/include/gsl/
-	rm -f lib/*
+	rm -f lib/lib*
 	
 
 
@@ -68,4 +68,4 @@ distclean:
 	cd $(GSL); make distclean 
 	cd $(PYTHON)/source/; make clean
 	rm -rf $(PYTHON)/include/gsl/
-	rm -f lib/*
+	rm -f lib/lib*

--- a/Makefile.in
+++ b/Makefile.in
@@ -29,8 +29,8 @@ MAKE_SOURCE = cd $(PYTHON)/source; make CC=$(CMAKE) python; make CC=$(CMAKE) py_
 
 
 ifeq (True, $(LIBS))
-	INSTALL_GSL = cd $(GSL); ./configure --disable-shared --prefix=$(GSL); make; make check 2>&1; make install; make clean; 
-	MOVE_GSL = mkdir $(PYTHON)/include/gsl/; mv $(GSL)/include/gsl/* $(PYTHON)/include/gsl; mv $(GSL)/lib/* $(PYTHON)/lib/;
+	INSTALL_GSL = cd $(GSL); ./configure --disable-shared --prefix=$(GSL) CC=gcc CCP=ccp; make; make check 2>&1; make install; make clean; 
+	MOVE_GSL = mkdir $(PYTHON)/include/gsl/; mv $(GSL)/include/gsl/* $(PYTHON)/include/gsl; mv $(GSL)/lib/lib* $(PYTHON)/lib/;
 else
 	INSTALL_GSL = 
 	MOVE_GSL =
@@ -57,9 +57,15 @@ clean:
 	rm -f *.o *~
 	cd $(GSL); make clean;  
 	cd $(PYTHON)/source/; make clean
+	rm -rf $(PYTHON)/include/gsl/
+	rm -f lib/*
+	
+
 
 # runs a more rigorous clean in gsl
 distclean:
 	rm -f *.o *~
 	cd $(GSL); make distclean 
 	cd $(PYTHON)/source/; make clean
+	rm -rf $(PYTHON)/include/gsl/
+	rm -f lib/*

--- a/Makefile.in
+++ b/Makefile.in
@@ -58,7 +58,7 @@ clean:
 	cd $(GSL); make clean;  
 	cd $(PYTHON)/source/; make clean
 	rm -rf $(PYTHON)/include/gsl/
-	rm -f lib/lib*
+	rm -f $(PYTHON)/lib/lib*
 	
 
 
@@ -68,4 +68,4 @@ distclean:
 	cd $(GSL); make distclean 
 	cd $(PYTHON)/source/; make clean
 	rm -rf $(PYTHON)/include/gsl/
-	rm -f lib/lib*
+	rm -f $(PYTHON)/lib/lib*

--- a/lib/README
+++ b/lib/README
@@ -1,3 +1,0 @@
-Folder to store library files for GSL and CFITSIO
-
-Linked using the LIB variable in Makefile


### PR DESCRIPTION
A few small changes to Makefile.in to force gsl to be compiled with gcc and ccp. 
In addition, some changes to allow one to run make clean and then make install again. 
Make clean did not empty out the lib and include directories, causing errors when make install tried to copy libraries from gsl. 