### PR TITLE
Fix two bugs in AGN power law

### DIFF
--- a/source/agn.c
+++ b/source/agn.c
@@ -44,7 +44,6 @@ Synopsis: agn_init (r, lum, alpha, freqmin, freqmax, ioniz_or_final, f)
 	This is essentially a parallel routine that is set up for other types of 
 	sources.  It actually does not do very much.
 
- 
 	This routine calculates the luminosity of the star and the 
 	luminosity within the frequency boundaries.  BB functions are assumed 
 

--- a/source/agn.c
+++ b/source/agn.c
@@ -18,7 +18,7 @@
 
 
   History:
-10oct	nsh	oded as part of initial effort to include a power law component
+  10oct	nsh	coded as part of initial effort to include a power law component
 		to AGN
 
  ************************************************************************/
@@ -60,7 +60,7 @@ agn_init (r, lum, alpha, freqmin, freqmax, ioniz_or_final, f)
 {
 
   double t;
-  double emit, emittance_bb (), emittance_continuum ();
+  double emit;
   int spectype;
 
 
@@ -111,39 +111,37 @@ double
 emittance_pow (freqmin, freqmax, lum, alpha)
      double freqmin, freqmax, lum, alpha;
 {
-  double emit;
-  /* these are the frequencies over which the power law is defined - currently set to the
-     equivalent of 2 to 10 keV */
+  double emit, fmin;
 
+  /* if we have a PL cutoff, then we need to either adjust the minimum frequency,
+     or return 0 luminosity if the cutoff is above our band */
+  /* in advanced mode, this should always be zero */
+  fmin = freqmin;       // default is no cutoff
+  emit = 0.0;
+  if (freqmax < geo.pl_low_cutoff)
+  {
+    return (emit);
+  }
+  else if (freqmin < geo.pl_low_cutoff)
+  {
+    fmin = geo.pl_low_cutoff;
+  }
 
-  //#define   XFREQMIN  4.84e17
-  //#define   XFREQMAX  2.42e18
+  /* conservative error check */
+  if ( (modes.iadvanced == 0) && (geo.pl_low_cutoff > 0))
+    Error("PL cutoff frequency is non-zero out of advanced mode!");
 
-  /* first we need to calculate the constant for the power law function */
-
-  /* 
-     if (alpha == -1.0) //deal with the pathological case
-     {
-     constant = lum / (log(XFREQMAX) - log(XFREQMIN));    
-     }
-     else
-     {
-     constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));      
-     }
-
-   */
-  /* now we need to work out the luminosity between our limited frequency range */
+  /* we need to work out the luminosity between our limited frequency range */
   /* we may need some checking routines to make sure that the requested frequency range is within the defined range,
      or it could default to zero outside the defined range */
 
-
   if (alpha == -1.0)            //deal with the pathological case
   {
-    emit = geo.const_agn * (log (freqmax) - log (freqmin));
+    emit = geo.const_agn * (log (freqmax) - log (fmin));
   }
   else
   {
-    emit = geo.const_agn * ((pow (freqmax, alpha + 1.0) - pow (freqmin, alpha + 1.0)) / (alpha + 1.0));
+    emit = geo.const_agn * ((pow (freqmax, alpha + 1.0) - pow (fmin, alpha + 1.0)) / (alpha + 1.0));
   }
 
 
@@ -194,20 +192,7 @@ emittance_bpow (freqmin, freqmax, lum, alpha)
   e1 = e2 = e3 = 0.0;           /* NSH - 130506 added to reomve 03 compile errors */
   /* first we need to calculate the constant for the 2-10 kev power law function */
 
-
-  /*
-     if (alpha == -1.0) //deal with the pathological case
-     {
-     constant = lum / (log(XFREQMAX) - log(XFREQMIN));    
-     printf ("BLAH Computed constant=%e\n",constant)  ;  
-     }
-     else
-     {
-     constant = lum / (((pow (XFREQMAX, alpha + 1.)) - pow (XFREQMIN, alpha + 1.0)) / (alpha + 1.0));    NSH 1205 - this seems a bit unnecessary now. The constant is calculaed elsewhere, and with the broken power law we could probably get rid of this - is it even working properly now 
-     }
-   */
-
-/* convert broken power law bands to freq */
+  /* convert broken power law bands to freq */
 
   pl_low = geo.agn_cltab_low / HEV;
   pl_hi = geo.agn_cltab_hi / HEV;
@@ -269,14 +254,9 @@ emittance_bpow (freqmin, freqmax, lum, alpha)
       f1 = freqmin;
       f2 = pl_hi;
     }
-//    atemp = alpha;
-//    ctemp = constant;
-
 
     e2 = emittance_pow (f1, f2, lum, alpha);
 
-
-//    e2 = ctemp * ((pow (f2, atemp + 1.0) - pow (f1, atemp + 1.0)) / (atemp + 1.0));
     Log ("Broken power law: Emittance in centre is %e\n", e2);
   }
   else

--- a/source/setup.c
+++ b/source/setup.c
@@ -911,7 +911,12 @@ get_bl_and_agn_params (lstar)
     // set the default for the radius of the BH to be 6 R_Schwartschild.
     // rddoub("R_agn(cm)",&geo.r_agn);
 
-    rddoub ("lum_agn(ergs/s)", &geo.lum_agn);
+    /* if we have a "blackbody agn" the luminosity is set by Stefan Boltzmann law
+       once the AGN blackbody temp is read in, otherwise set by user */
+    else if (geo.agn_ion_spectype != SPECTYPE_BB)
+      rddoub ("lum_agn(ergs/s)", &geo.lum_agn);
+
+
     Log ("OK, the agn lum will be about %.2e the disk lum\n", geo.lum_agn / xbl);
     if (geo.agn_ion_spectype == SPECTYPE_POW || geo.agn_ion_spectype == SPECTYPE_CL_TAB)
     {
@@ -940,6 +945,12 @@ get_bl_and_agn_params (lstar)
       geo.const_agn = temp_const_agn;
       Log ("AGN Input parameters give a Bremsstrahlung constant of %e\n", temp_const_agn);
 
+    }
+    else if (geo.agn_ion_spectype == SPECTYPE_BB)
+    {
+      /* note that alpha_agn holds the temperature in the case of "blackbody agn" */
+      rddoub ("agn_blackbody_temp(K)", &geo.alpha_agn);
+      geo.lum_agn = 4 * PI * geo.r_agn * geo.r_agn * STEFAN_BOLTZMANN * pow (geo.alpha_agn, 4.);
     }
 
     /* JM 1502 -- lines to add a low frequency power law cutoff. accessible

--- a/source/setup.c
+++ b/source/setup.c
@@ -943,9 +943,10 @@ get_bl_and_agn_params (lstar)
     }
 
     /* JM 1502 -- lines to add a low frequency power law cutoff. accessible
-       only in advanced mode. default is zero which is checked before we call photo_gen_agn */
+       only in advanced mode and for non broken power law. 
+       default is zero which is checked before we call photo_gen_agn */
     geo.pl_low_cutoff = 0.0;
-    if (modes.iadvanced)
+    if (modes.iadvanced && (geo.agn_ion_spectype == SPECTYPE_POW))
       rddoub ("agn_power_law_cutoff", &geo.pl_low_cutoff);
 
     rdint ("geometry_for_pl_source(0=sphere,1=lamp_post)", &geo.pl_geometry);


### PR DESCRIPTION
This pull request fixes issues #244 and #227 

For the former, it involves making sure that the banded luminosities take into account the power law cutoff, to avoid the code failing when it tries to generate PL photons. Only happens in advanced mode.

For the latter, it means an extra question for the use to give a temperature for a blackbody AGN. lum_agn is then dispensed with as a question and is instead calculated from 4*PI*R^2*SIGMA*T^4. Not used in production runs yet.