### PR TITLE
Upstream low temp

### DIFF
--- a/source/cooling.c
+++ b/source/cooling.c
@@ -66,7 +66,7 @@ cooling (xxxplasma, t)
   /*81c - nsh - we now treat DR cooling as a recombinational process - still unsure as to how to treat emission, so at the moment
      it remains here */
 
-  xxxplasma->cool_dr = total_fb (&wmain[xxxplasma->nwind], t, 0, VERY_BIG, FB_REDUCED, 2);
+  xxxplasma->cool_dr = total_fb (&wmain[xxxplasma->nwind], t, 0, VERY_BIG, FB_REDUCED, INNER_SHELL);
 
   /* 78b - nsh adding this line in next to calculate direct ionization cooling without generating photons */
 
@@ -148,7 +148,7 @@ xtotal_emission (one, f1, f2)
   {
     if (geo.rt_mode == RT_MODE_MACRO)       //Switch for macro atoms (SS)
     {
-      xplasma->cool_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_REDUCED, 1);        //outer shellrecombinations
+      xplasma->cool_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_REDUCED, OUTER_SHELL);        //outer shellrecombinations
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
@@ -174,7 +174,7 @@ xtotal_emission (one, f1, f2)
       xplasma->cool_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
 	  /*The free bound cooling is equal to the recomb rate x the electron energy - the boinding energy - this is computed 
 	  with the FB_REDUCED switch */
-      xplasma->cool_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, 1);     //outer shell recombinations
+      xplasma->cool_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, OUTER_SHELL);     //outer shell recombinations
 
 
     }

--- a/source/cooling.c
+++ b/source/cooling.c
@@ -21,6 +21,8 @@
 
   History:
 2004	ksl	Coded as better.c
+2017	nsh - all cooling mechanisms gathered here, removed from the end of
+				ionization.c. 
 
  ************************************************************************/
 
@@ -38,8 +40,7 @@ cooling (xxxplasma, t)
      double t;
 {
 
-  /*Original method */
-  xxxplasma->t_e = t;
+	xxxplasma->t_e = t;
 
 
 
@@ -75,6 +76,8 @@ cooling (xxxplasma, t)
 
   xxxplasma->cool_comp = total_comp (&wmain[xxxplasma->nwind], t);
 
+  /* we now call xtotal emission which computes the cooling rates for processes which can, in principle, make photons. */
+
   xxxplasma->cool_tot =
     xxxplasma->cool_adiabatic + xxxplasma->cool_dr + xxxplasma->cool_di +
     xxxplasma->cool_comp + xtotal_emission (&wmain[xxxplasma->nwind], 0.,
@@ -90,7 +93,8 @@ cooling (xxxplasma, t)
 /***********************************************************
              Space Telescope Science Institute
 
-Synopsis:  total_emission (one, f1, f2) Calculate the total emission of a single cell 
+Synopsis:  xtotal_emission (one, f1, f2) Calculate the total cooling of a single cell 
+			due to free free - line and recombination processes.
 
 Arguments:		
 
@@ -101,34 +105,21 @@ Description:
 	
 
 Notes:
-	Total emission gives the total enery loss due to photons.  It does
+	xtotal_emission gives the total enery loss due to photons.  It does
 	not include other coooling sources, e. g. adiabatic expansion.
 
-	It returns the total luminosity, but also stores the luminosity due
-	to various types of emssion, e.g ff, fb, lines, compton into the
-	Plasms cells
+	It returns the total cooling, but also stores the luminosity due
+	to various types of emssion, e.g ff and  lines into the
+	Plasms cells. The fb cooling calculated here is *not* equal to
+	the fb lumniosity and so this value is stored in cool_rr.
 
 	Comment: The call to this routine was changed when PlasmaPtrs
 	were introduced, but it appears that the various routines 
 	that were called were not changed.
 
 History:
-	97	ksl	Coded
-	98oct	ksl     Removed temperature limits within total_emission in
-			and attempt to concentrate the frequency limits elsewhere.
-	01nov	ksl	Removed superflous code
-	01nov	ksl	Changed call so t_e passed through wind structure.  Other
-			routines should be changed ALSO, BUT NOT NOW
-	04Mar   SS      Modified to divert if Macro Atoms being used.
-	04Apr   SS      Modified to include a collisional cooling term
-	                - this is getting very messy and confusing - I think
-                        I should probably put together a completely separte
-			set of routines for doing the heating and cooling in the
-			macro atom cases. (SS) since this is now not really a
-			total emission but total cooling.
-	05may	ksl	57+ -- To use plasma structure for most things.  If vol
-			is added to plasma then one can change the call
-	11aug	nsh	70 changes made to allow compton heating to be calculated.
+	2017 - copied from total_emission and modified for use in calculatingh
+			cooling alone.
  
  
 **************************************************************/
@@ -151,7 +142,7 @@ xtotal_emission (one, f1, f2)
 
   if (f2 < f1)
   {
-    xplasma->lum_tot = xplasma->lum_lines = xplasma->lum_ff = xplasma->cool_rr = 0;      //NSH 1108 Zero the new cool_comp variable NSH 1101 - removed
+    xplasma->cool_tot = xplasma->lum_lines = xplasma->lum_ff = xplasma->cool_rr = 0;      //NSH 1108 Zero the new cool_comp variable NSH 1101 - removed
   }
   else
   {
@@ -161,32 +152,36 @@ xtotal_emission (one, f1, f2)
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
-      xplasma->lum_tot = xplasma->cool_rr;
+      xplasma->cool_tot = xplasma->cool_rr;
       //Note: This the fb_matom call makes no use of f1 or f2. They are passed for
       //now in case they should be used in the future. But they could
       //also be removed.
       // (SS)
       xplasma->lum_lines = total_bb_cooling (xplasma, t_e);
-      xplasma->lum_tot += xplasma->lum_lines;
+      xplasma->cool_tot += xplasma->lum_lines;
       /* total_bb_cooling gives the total cooling rate due to bb transisions whether they
          are macro atoms or simple ions. */
       xplasma->lum_ff = total_free (one, t_e, f1, f2);
-      xplasma->lum_tot += xplasma->lum_ff;
+      xplasma->cool_tot += xplasma->lum_ff;
 
 
     }
     else                        //default (non-macro atoms) (SS)
     {
-      xplasma->lum_tot = xplasma->lum_lines = total_line_emission (one, f1, f2);
-      xplasma->lum_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
-      xplasma->lum_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, 1);     //outer shell recombinations
+		/*The line cooling is equal to the line emission */
+      xplasma->cool_tot = xplasma->lum_lines = total_line_emission (one, f1, f2);
+	  /* The free free cooling is equal to the free free emission */
+      xplasma->cool_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
+	  /*The free bound cooling is equal to the recomb rate x the electron energy - the boinding energy - this is computed 
+	  with the FB_REDUCED switch */
+      xplasma->cool_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, 1);     //outer shell recombinations
 
 
     }
   }
 
 
-  return (xplasma->lum_tot);
+  return (xplasma->cool_tot);
 
 
 }
@@ -269,5 +264,105 @@ adiabatic_cooling (one, t)
   cooling = nparticles * BOLTZMANN * t * xplasma->vol * one->div_v;
 
   return (cooling);
+}
+
+
+/***********************************************************
+                                       Space Telescope Science Institute
+
+Synopsis:  wind_cooling (f1, f2) calculate the cooling rate of the entire 
+wind between freqencies f1 and f2 
+
+Arguments:		
+
+
+Returns:
+ 
+Description:	
+	
+
+Notes:
+
+History:
+	06may	ksl	57+ -- Changed to accommodate plasma structure.  
+			Note that the call for wind_luminostiy has changed
+			to remove the pointer call.  Ultimately rewrite
+			using plasma structure alone.
+	11aug	nsh	70 Modifications made to incorporate compton cooling
+    11sep   nsh     70 Modifications in incorporate DR cooling (very approximate at the moment)
+	12sep	nsh	73 Added a counter for adiabatic luminosity (!)
+ 	13jul	nsh	76 Split up adiabatic luminosity into heating and cooling.
+ 
+**************************************************************/
+
+double
+wind_cooling (f1, f2)
+     double f1, f2;             /* freqmin and freqmax */
+{
+  double cool, lum_lines, cool_rr, lum_ff, cool_comp, cool_dr, cool_di, cool_adiab, heat_adiab;       //1108 NSH Added a new variable for compton cooling 1408 NSH and for DI cooling
+  //1109 NSH Added a new variable for dielectronic cooling
+  //1307 NSH Added a new variable to split out negtive adiabatic cooling (i.e. heating).
+  int n;
+  double x;
+  int nplasma;
+
+
+  cool = lum_lines = cool_rr = lum_ff = cool_comp = cool_dr = cool_di = cool_adiab = heat_adiab = 0;  //1108 NSH Zero the new counter 1109 including DR counter 1408 and the DI counter
+  for (n = 0; n < NDIM2; n++)
+  {
+
+    if (wmain[n].vol > 0.0)
+    {
+      nplasma = wmain[n].nplasma;
+      cool += x = xtotal_emission (&wmain[n], f1, f2);
+      lum_lines += plasmamain[nplasma].lum_lines;
+      cool_rr += plasmamain[nplasma].cool_rr;
+      lum_ff += plasmamain[nplasma].lum_ff;
+      cool_comp += plasmamain[nplasma].cool_comp; //1108 NSH Increment the new counter by the compton luminosity for that cell.
+      cool_dr += plasmamain[nplasma].cool_dr;     //1109 NSH Increment the new counter by the DR luminosity for the cell.
+      cool_di += plasmamain[nplasma].cool_di;     //1408 NSH Increment the new counter by the DI luminosity for the cell.
+
+      if (geo.adiabatic)        //130722 NSH - slight change to allow for adiabatic heating effect - now logged in a new global variable for reporting.
+      {
+
+        if (plasmamain[nplasma].cool_adiabatic >= 0.0)
+        {
+          cool_adiab += plasmamain[nplasma].cool_adiabatic;
+        }
+        else
+        {
+          heat_adiab += plasmamain[nplasma].cool_adiabatic;
+        }
+      }
+
+      else
+      {
+        cool_adiab = 0.0;
+      }
+
+
+      if (x < 0)
+        Error ("wind_cooling: xtotal emission %8.4e is < 0!\n", x);
+
+      if (recipes_error != 0)
+        Error ("wind_cooling: Received recipes error on cell %d\n", n);
+    }
+  }
+
+/* Deciding which of these to fill is tricky because geo contains
+   values for geo.lum_wind and geo.f_wind separately.  Could be cleaner.
+   ksl 98mar6 */
+
+  //geo.lum_wind=lum;
+  geo.lum_lines = lum_lines;
+  geo.cool_rr = cool_rr;
+  geo.lum_ff = lum_ff;
+  geo.cool_comp = cool_comp;      //1108 NSH The total compton luminosity of the wind is stored in the geo structure
+  geo.cool_dr = cool_dr;          //1109 NSH the total DR luminosity of the wind is stored in the geo structure
+  geo.cool_di = cool_di;          //1408 NSH the total DI luminosity of the wind is stored in the geo structure
+  geo.cool_adiabatic = cool_adiab;
+  geo.heat_adiabatic = heat_adiab;
+
+  return (cool);
 }
 

--- a/source/cooling.c
+++ b/source/cooling.c
@@ -362,6 +362,9 @@ wind_cooling (f1, f2)
   geo.cool_di = cool_di;          //1408 NSH the total DI luminosity of the wind is stored in the geo structure
   geo.cool_adiabatic = cool_adiab;
   geo.heat_adiabatic = heat_adiab;
+  
+  
+  cool = cool+ cool_comp+cool_dr+cool_di+cool_adiab;
 
   return (cool);
 }

--- a/source/emission.c
+++ b/source/emission.c
@@ -66,6 +66,7 @@ History:
     11sep   nsh     70 Modifications in incorporate DR cooling (very approximate at the moment)
 	12sep	nsh	73 Added a counter for adiabatic luminosity (!)
  	13jul	nsh	76 Split up adiabatic luminosity into heating and cooling.
+    17jun	nsh 81d - removed non photon producing processes - now in wind_cooling
  
 **************************************************************/
 
@@ -73,7 +74,8 @@ double
 wind_luminosity (f1, f2)
      double f1, f2;             /* freqmin and freqmax */
 {
-  double lum, lum_lines, cool_rr, lum_ff, cool_comp, cool_dr, cool_di, lum_adiab, heat_adiab;       //1108 NSH Added a new variable for compton cooling 1408 NSH and for DI cooling
+  double lum, lum_lines, lum_rr, lum_ff;
+	  //cool_comp, cool_dr, cool_di, lum_adiab, heat_adiab;       //1108 NSH Added a new variable for compton cooling 1408 NSH and for DI cooling
   //1109 NSH Added a new variable for dielectronic cooling
   //1307 NSH Added a new variable to split out negtive adiabatic cooling (i.e. heating).
   int n;
@@ -81,7 +83,8 @@ wind_luminosity (f1, f2)
   int nplasma;
 
 
-  lum = lum_lines = cool_rr = lum_ff = cool_comp = cool_dr = cool_di = lum_adiab = heat_adiab = 0;  //1108 NSH Zero the new counter 1109 including DR counter 1408 and the DI counter
+  lum = lum_lines = lum_rr = lum_ff = 0.0;
+	  //cool_comp = cool_dr = cool_di = lum_adiab = heat_adiab = 0;  //1108 NSH Zero the new counter 1109 including DR counter 1408 and the DI counter
   for (n = 0; n < NDIM2; n++)
   {
 
@@ -90,36 +93,36 @@ wind_luminosity (f1, f2)
       nplasma = wmain[n].nplasma;
       lum += x = total_emission (&wmain[n], f1, f2);
       lum_lines += plasmamain[nplasma].lum_lines;
-      cool_rr += plasmamain[nplasma].cool_rr;
+      lum_rr += plasmamain[nplasma].lum_rr;
       lum_ff += plasmamain[nplasma].lum_ff;
-      cool_comp += plasmamain[nplasma].cool_comp; //1108 NSH Increment the new counter by the compton luminosity for that cell.
-      cool_dr += plasmamain[nplasma].cool_dr;     //1109 NSH Increment the new counter by the DR luminosity for the cell.
-      cool_di += plasmamain[nplasma].cool_di;     //1408 NSH Increment the new counter by the DI luminosity for the cell.
+//      cool_comp += plasmamain[nplasma].cool_comp; //1108 NSH Increment the new counter by the compton luminosity for that cell.
+//      cool_dr += plasmamain[nplasma].cool_dr;     //1109 NSH Increment the new counter by the DR luminosity for the cell.
+//      cool_di += plasmamain[nplasma].cool_di;     //1408 NSH Increment the new counter by the DI luminosity for the cell.
 
-      if (geo.adiabatic)        //130722 NSH - slight change to allow for adiabatic heating effect - now logged in a new global variable for reporting.
-      {
+//      if (geo.adiabatic)        //130722 NSH - slight change to allow for adiabatic heating effect - now logged in a new global variable for reporting.
+//      {
 
-        if (plasmamain[nplasma].cool_adiabatic >= 0.0)
-        {
-          lum_adiab += plasmamain[nplasma].cool_adiabatic;
-        }
-        else
-        {
-          heat_adiab += plasmamain[nplasma].cool_adiabatic;
-        }
-      }
+//        if (plasmamain[nplasma].cool_adiabatic >= 0.0)
+//        {
+//          lum_adiab += plasmamain[nplasma].cool_adiabatic;
+//        }
+//        else
+//        {
+//          heat_adiab += plasmamain[nplasma].cool_adiabatic;
+//        }
+//      }
 
-      else
-      {
-        lum_adiab = 0.0;
-      }
+//      else
+//      {
+//        lum_adiab = 0.0;
+//      }
 
 
-      if (x < 0)
-        Error ("wind_luminosity: total emission %8.4e is < 0!\n", x);
+//      if (x < 0)
+//        Error ("wind_luminosity: total emission %8.4e is < 0!\n", x);
 
-      if (recipes_error != 0)
-        Error ("wind_luminosity: Received recipes error on cell %d\n", n);
+//      if (recipes_error != 0)
+//        Error ("wind_luminosity: Received recipes error on cell %d\n", n);
     }
   }
 
@@ -129,13 +132,13 @@ wind_luminosity (f1, f2)
 
   //geo.lum_wind=lum;
   geo.lum_lines = lum_lines;
-  geo.cool_rr = cool_rr;
+  geo.lum_rr = lum_rr;
   geo.lum_ff = lum_ff;
-  geo.cool_comp = cool_comp;      //1108 NSH The total compton luminosity of the wind is stored in the geo structure
-  geo.cool_dr = cool_dr;          //1109 NSH the total DR luminosity of the wind is stored in the geo structure
-  geo.cool_di = cool_di;          //1408 NSH the total DI luminosity of the wind is stored in the geo structure
-  geo.cool_adiabatic = lum_adiab;
-  geo.heat_adiabatic = heat_adiab;
+//  geo.cool_comp = cool_comp;      //1108 NSH The total compton luminosity of the wind is stored in the geo structure
+//  geo.cool_dr = cool_dr;          //1109 NSH the total DR luminosity of the wind is stored in the geo structure
+//  geo.cool_di = cool_di;          //1408 NSH the total DI luminosity of the wind is stored in the geo structure
+//  geo.cool_adiabatic = lum_adiab;
+//  geo.heat_adiabatic = heat_adiab;
 
   return (lum);
 }
@@ -206,13 +209,13 @@ total_emission (one, f1, f2)
 
   if (f2 < f1)
   {
-    xplasma->lum_tot = xplasma->lum_lines = xplasma->lum_ff = xplasma->cool_rr = 0;      //NSH 1108 Zero the new cool_comp variable NSH 1101 - removed
+    xplasma->lum_tot = xplasma->lum_lines = xplasma->lum_ff = xplasma->lum_rr = 0;      //NSH 1108 Zero the new cool_comp variable NSH 1101 - removed
   }
   else
   {
     if (geo.rt_mode == RT_MODE_MACRO)       //Switch for macro atoms (SS)
     {
-      xplasma->cool_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_FULL, 1);        //outer shellrecombinations
+      xplasma->lum_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_FULL, 1);        //outer shellrecombinations
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
@@ -234,7 +237,9 @@ total_emission (one, f1, f2)
     {
       xplasma->lum_tot = xplasma->lum_lines = total_line_emission (one, f1, f2);
       xplasma->lum_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
-      xplasma->lum_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_FULL, 1);     //outer shell recombinations
+	  /* We compute the radiative recombination luminosirty - this is not the same as the rr cooling rate and
+	  	so is stored in a seperate variable */
+      xplasma->lum_tot += xplasma->lum_rr = total_fb (one, t_e, f1, f2, FB_FULL, 1);     //outer shell recombinations
 
 
     }

--- a/source/emission.c
+++ b/source/emission.c
@@ -215,7 +215,7 @@ total_emission (one, f1, f2)
   {
     if (geo.rt_mode == RT_MODE_MACRO)       //Switch for macro atoms (SS)
     {
-      xplasma->lum_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_FULL, 1);        //outer shellrecombinations
+      xplasma->lum_rr = total_fb_matoms (xplasma, t_e, f1, f2) + total_fb (one, t_e, f1, f2, FB_FULL, OUTER_SHELL);        //outer shellrecombinations
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
@@ -239,7 +239,7 @@ total_emission (one, f1, f2)
       xplasma->lum_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
 	  /* We compute the radiative recombination luminosirty - this is not the same as the rr cooling rate and
 	  	so is stored in a seperate variable */
-      xplasma->lum_tot += xplasma->lum_rr = total_fb (one, t_e, f1, f2, FB_FULL, 1);     //outer shell recombinations
+      xplasma->lum_tot += xplasma->lum_rr = total_fb (one, t_e, f1, f2, FB_FULL, OUTER_SHELL);     //outer shell recombinations
 
 
     }

--- a/source/foo.h
+++ b/source/foo.h
@@ -233,6 +233,9 @@ double one_ff(WindPtr one, double f1, double f2);
 double gaunt_ff(double gsquared);
 /* cooling.c */
 double cooling(PlasmaPtr xxxplasma, double t);
+double xtotal_emission(WindPtr one, double f1, double f2);
+double adiabatic_cooling(WindPtr one, double t);
+double wind_cooling(double f1, double f2);
 /* recomb.c */
 double fb_topbase_partial(double freq);
 double integ_fb(double t, double f1, double f2, int nion, int fb_choice, int mode);
@@ -267,8 +270,6 @@ int check_convergence(void);
 int one_shot(PlasmaPtr xplasma, int mode);
 double calc_te(PlasmaPtr xplasma, double tmin, double tmax);
 double zero_emit(double t);
-double xtotal_emission(WindPtr one, double f1, double f2);
-double adiabatic_cooling(WindPtr one, double t);
 /* ispy.c */
 int ispy_init(char filename[], int icycle);
 int ispy_close(void);

--- a/source/foo.h
+++ b/source/foo.h
@@ -245,7 +245,7 @@ int num_recomb(PlasmaPtr xplasma, double t_e, int mode);
 double fb(PlasmaPtr xplasma, double t, double freq, int ion_choice, int fb_choice);
 int init_freebound(double t1, double t2, double f1, double f2);
 double get_nrecomb(double t, int nion, int mode);
-double get_fb(double t, int nion, int narray, int mode);
+double get_fb(double t, int nion, int narray, int fb_choice, int mode);
 double xinteg_fb(double t, double f1, double f2, int nion, int fb_choice);
 double xinteg_inner_fb(double t, double f1, double f2, int nion, int fb_choice);
 double total_rrate(int nion, double T);

--- a/source/gridwind.c
+++ b/source/gridwind.c
@@ -734,6 +734,11 @@ calloc_dyn_plasma (nelem)
       Error ("calloc_dyn_plasma: Error in allocating memory for cool_rr_ion\n");
       exit (0);
     }
+    if ((plasmamain[n].lum_rr_ion = calloc (sizeof (double), nions)) == NULL)
+    {
+      Error ("calloc_dyn_plasma: Error in allocating memory for lum_rr_ion\n");
+      exit (0);
+    }
     if ((plasmamain[n].inner_recomb = calloc (sizeof (double), nions)) == NULL)
     {
       Error ("calloc_dyn_plasma: Error in allocating memory for inner_recomb\n");

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -531,6 +531,8 @@ meaning in nebular concentrations.
    04June   SS  Modified so that changes in the heating rate due to changes in the
                 temperature are included for macro atoms.
 	06may	ksl	Modified for plasma structue
+	17jun	nsh	cooling calculations all gathered together into cooling which is in
+				cooling.c
  */
 
 
@@ -627,7 +629,7 @@ zero_emit (t)
   xxxplasma->heat_tot += xxxplasma->heat_photo_macro;
   xxxplasma->heat_photo += xxxplasma->heat_photo_macro;
 
-
+  /*81d - nsh - all cooling calculations moved into seperate routine.
 
 //OLD  /* 70d - ksl - Added next line so that adiabatic cooling reflects the temperature we
 //OLD   * are testing.  Adiabatic cooling is proportional to temperature

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -394,7 +394,7 @@ iwind = -1 	Don't generate any wind photons at all
      geo.f_tot, geo.f_star, geo.f_disk, geo.f_bl, geo.f_agn, geo.f_wind, geo.f_matom, geo.f_kpkt);
 
   Log
-    ("!! xdefine_phot: wind  ff %8.2e       fb %8.2e   lines %8.2e  for freq %8.2e %8.2e\n", geo.lum_ff, geo.cool_rr, geo.lum_lines, f1, f2);
+    ("!! xdefine_phot: wind  ff %8.2e       fb %8.2e   lines %8.2e  for freq %8.2e %8.2e\n", geo.lum_ff, geo.lum_rr, geo.lum_lines, f1, f2);
 
 
 

--- a/source/python.h
+++ b/source/python.h
@@ -433,7 +433,7 @@ struct geometry
 
   /* Define the choices for calculating the FB, see, e.g. integ_fb */
 
-#define FB_FULL         0   /* Calculate fb emissivity including energy associated with the threshold*/
+#define FB_FULL         1   /* Calculate fb emissivity including energy associated with the threshold*/
 #define FB_REDUCED      1   /* Calcuate the fb emissivity without the threshold energy */
 #define FB_RATE         2   /* Calulate the fb recombinarion rate  */
 
@@ -485,7 +485,8 @@ struct geometry
   double agn_cltab_hi_alpha;    //photon index for the high frequency end       
 
 
-  double lum_ff, cool_rr, lum_lines;     /* The luminosity of the wind as a result of ff, fb, and line radiation */
+  double lum_ff, lum_rr, lum_lines;     /* The luminosity of the wind as a result of ff, fb, and line radiation */
+  double cool_rr;				/*1706 NSH - the cooling rate due to radiative recombination - not the same as the luminosity */
   double cool_comp;              /*1108 NSH The luminosity of the wind as a result of compton cooling */
   double cool_di;                /* 1409 NSH The direct ionization luminosity */
   double cool_dr;                /*1109 NSH The luminosity of the wind due to dielectronic recombination */
@@ -496,7 +497,8 @@ struct geometry
 
 /* These variables are copies of the lum variables above, and are only calculated during ionization cycles
    This is a bugfix for JM130621, windsave bug */
-  double lum_ff_ioniz, cool_rr_ioniz, lum_lines_ioniz;
+  double lum_ff_ioniz, lum_rr_ioniz, lum_lines_ioniz;
+  double cool_rr_ioniz;
   double cool_comp_ioniz;
   double cool_di_ioniz;          /* 1409 NSH The direct ionization luminosity */
   double cool_dr_ioniz;
@@ -799,6 +801,7 @@ typedef struct plasma
   /* The total luminosity of all processes in the cell (Not the same 
                                    as what escapes the cell) */
   double lum_lines, lum_ff, cool_adiabatic;
+  double lum_rr;                 /* 1706 NSH - the radiative recobination luminosity - not the same as the cooling rate */
   double cool_comp;              /* 1108 NSH The compton luminosity of the cell */
   double cool_di;                /* 1409 NSH The direct ionization luminosity */
   double cool_dr;                /* 1109 NSH The dielectronic recombination luminosity of the cell */
@@ -808,6 +811,7 @@ typedef struct plasma
 
   double cool_tot_ioniz;
   double lum_lines_ioniz, lum_ff_ioniz, cool_adiabatic_ioniz;
+  double lum_rr_ioniz;
   double cool_comp_ioniz;        /* 1108 NSH The compton luminosity of the cell */
   double cool_di_ioniz;          /* 1409 NSH The direct ionization luminosity */
   double cool_dr_ioniz;          /* 1109 NSH The dielectronic recombination luminosity of the cell */

--- a/source/python.h
+++ b/source/python.h
@@ -433,7 +433,7 @@ struct geometry
 
   /* Define the choices for calculating the FB, see, e.g. integ_fb */
 
-#define FB_FULL         1   /* Calculate fb emissivity including energy associated with the threshold*/
+#define FB_FULL         0   /* Calculate fb emissivity including energy associated with the threshold*/
 #define FB_REDUCED      1   /* Calcuate the fb emissivity without the threshold energy */
 #define FB_RATE         2   /* Calulate the fb recombinarion rate  */
 

--- a/source/python.h
+++ b/source/python.h
@@ -436,6 +436,12 @@ struct geometry
 #define FB_FULL         0   /* Calculate fb emissivity including energy associated with the threshold*/
 #define FB_REDUCED      1   /* Calcuate the fb emissivity without the threshold energy */
 #define FB_RATE         2   /* Calulate the fb recombinarion rate  */
+  
+  
+  /* Define the modes for free bound integrals */
+#define OUTER_SHELL  1
+
+#define INNER_SHELL  2
 
   /* The frequency bands used when calculating parameters like a power law slope in limited regions. */
 
@@ -780,6 +786,9 @@ typedef struct plasma
                                    by this ion via photoionization. 78 - changed to dynamic allocation */
   double *cool_rr_ion;              /* The amount of energy being released from the electron pool
                                    by this ion via recombination. 78 - changed to dynamic allocation */
+  double *lum_rr_ion;              /* The recombination luminosity
+	                                   by this ion via recombination. 78 - changed to dynamic allocation */
+	  
   double *cool_dr_ion;
   //OLD double j, ave_freq, lum;      /*Respectively mean intensity, intensity_averaged frequency, 
   double j, ave_freq;      /*Respectively mean intensity, intensity_averaged frequency, 
@@ -1236,9 +1245,9 @@ xband;
 struct fbstruc
 {
   double f1, f2;
-  double emiss[NIONS][NTEMPS];
-  double emiss_inner[NIONS][NTEMPS];    //Emissivity of recombinations to inner shells
-  double emiss_upper[NIONS][NTEMPS];    //The emissivity of recombinations to the highest energy level we have
+  double cool[NIONS][NTEMPS];		//cooling rate due to radiative recombination
+  double lum[NIONS][NTEMPS];           //emissivity due to radiative recombinaion
+  double cool_inner[NIONS][NTEMPS];    //cooling rate due to recombinations to inner shells
 }
 freebound[NFB];
 

--- a/source/templates.h
+++ b/source/templates.h
@@ -233,6 +233,9 @@ double one_ff(WindPtr one, double f1, double f2);
 double gaunt_ff(double gsquared);
 /* cooling.c */
 double cooling(PlasmaPtr xxxplasma, double t);
+double xtotal_emission(WindPtr one, double f1, double f2);
+double adiabatic_cooling(WindPtr one, double t);
+double wind_cooling(double f1, double f2);
 /* recomb.c */
 double fb_topbase_partial(double freq);
 double integ_fb(double t, double f1, double f2, int nion, int fb_choice, int mode);
@@ -267,8 +270,6 @@ int check_convergence(void);
 int one_shot(PlasmaPtr xplasma, int mode);
 double calc_te(PlasmaPtr xplasma, double tmin, double tmax);
 double zero_emit(double t);
-double xtotal_emission(WindPtr one, double f1, double f2);
-double adiabatic_cooling(WindPtr one, double t);
 /* ispy.c */
 int ispy_init(char filename[], int icycle);
 int ispy_close(void);

--- a/source/templates.h
+++ b/source/templates.h
@@ -245,7 +245,7 @@ int num_recomb(PlasmaPtr xplasma, double t_e, int mode);
 double fb(PlasmaPtr xplasma, double t, double freq, int ion_choice, int fb_choice);
 int init_freebound(double t1, double t2, double f1, double f2);
 double get_nrecomb(double t, int nion, int mode);
-double get_fb(double t, int nion, int narray, int mode);
+double get_fb(double t, int nion, int narray, int fb_choice, int mode);
 double xinteg_fb(double t, double f1, double f2, int nion, int fb_choice);
 double xinteg_inner_fb(double t, double f1, double f2, int nion, int fb_choice);
 double total_rrate(int nion, double T);

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -102,6 +102,7 @@ WindPtr (w);
 
   /*1108 NSH csum added to sum compton heating 1204 NSH icsum added to sum induced compton heating */
   double wtest, xsum, asum, psum, fsum, lsum, csum, icsum, ausum;
+  double cool_sum,lum_sum; //1706 - the total cooling and luminosity of the wind
   double c_rec, n_rec, o_rec, fe_rec;   //1701- NSH more outputs to show cooling from a few other elements
   int nn;                       //1701 - loop variable to compute recomb cooling
 
@@ -757,7 +758,8 @@ WindPtr (w);
 
 
 
-  asum = wind_cooling (0.0, VERY_BIG);       /*We call wind_cooling here to obtain an up to date set of cooling rates */
+  cool_sum = wind_cooling (0.0, VERY_BIG);       /*We call wind_cooling here to obtain an up to date set of cooling rates */
+  lum_sum = wind_luminosity (0.0, VERY_BIG);       /*and we also call wind_luminosity to get the luminosities */
 
 
   if (modes.zeus_connect == 1 && geo.hydro_domain_number > -1)  //If we are running in zeus connect mode, we output heating and cooling rates.
@@ -801,11 +803,11 @@ WindPtr (w);
    * not-only adiabatic cooling, but also goe.cool_comp, geo_cool_dr and geo.cool_di */
   Log
     ("!!wind_update: Wind luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
-     asum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
+     lum_sum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
 
   Log
     ("!!wind_update: Wind cooling     %8.2e (recomb %8.2e ff %8.2e compton %8.2e DR %8.2e DI %8.2e lines %8.2e adiabatic %8.2e) after update\n",
-     asum + geo.cool_comp + geo.cool_dr + geo.cool_di + geo.cool_adiabatic,
+     cool_sum,
      geo.cool_rr, geo.lum_ff, geo.cool_comp, geo.cool_dr, geo.cool_di, geo.lum_lines, geo.cool_adiabatic);
 
 
@@ -899,11 +901,13 @@ WindPtr (w);
       /* 1110 NSH Added this line to report all cooling mechanisms, including those that do not generate photons. */
       Log
         ("OUTPUT Wind_cooling(ergs-1cm-3)     %8.2e (recomb %8.2e ff %8.2e compton %8.2e DR %8.2e DI %8.2e adiabatic %8.2e lines %8.2e ) after update\n",
-         (asum + geo.cool_comp + geo.cool_dr + geo.cool_di +
-          geo.cool_adiabatic) / w[n].vol, geo.cool_rr / w[n].vol,
+         cool_sum / w[n].vol, geo.cool_rr / w[n].vol,
          geo.lum_ff / w[n].vol, geo.cool_comp / w[n].vol,
          geo.cool_dr / w[n].vol, geo.cool_di / w[n].vol, geo.cool_adiabatic / w[n].vol, geo.lum_lines / w[n].vol);
-
+         Log
+           ("OUTPUT Wind_luminosity(ergs-1cm-3)     %8.2e (recomb %8.2e ff %8.2e lines %8.2e ) after update\n",
+            cool_sum / w[n].vol, geo.cool_rr / w[n].vol,
+            geo.lum_ff / w[n].vol, geo.lum_lines / w[n].vol);
       /* NSH 1701 calculate the recombination cooling for other elements */
 
       c_rec = n_rec = o_rec = fe_rec = 0.0;
@@ -934,7 +938,7 @@ WindPtr (w);
       /* 1110 NSH Added this line to report all cooling mechanisms, including those that do not generate photons. */
       Log
         ("OUTPUT Balance      Cooling=%8.2e Heating=%8.2e Lum=%8.2e T_e=%e after update\n",
-         asum + geo.cool_comp + geo.cool_dr + geo.cool_di + geo.cool_adiabatic, xsum, asum, plasmamain[nstart].t_e);
+         cool_sum, xsum, lum_sum, plasmamain[nstart].t_e);
 
       for (n = 0; n < nelements; n++)
       {

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -101,7 +101,7 @@ WindPtr (w);
   double trad, nh;
 
   /*1108 NSH csum added to sum compton heating 1204 NSH icsum added to sum induced compton heating */
-  double wtest, xsum, asum, psum, fsum, lsum, csum, icsum, ausum;
+  double wtest, xsum, psum, fsum, lsum, csum, icsum, ausum;
   double cool_sum,lum_sum; //1706 - the total cooling and luminosity of the wind
   double c_rec, n_rec, o_rec, fe_rec;   //1701- NSH more outputs to show cooling from a few other elements
   int nn;                       //1701 - loop variable to compute recomb cooling
@@ -137,7 +137,7 @@ WindPtr (w);
      NIONS changed to nions for the 12 arrays in plasma that are now dynamically allocated 
   NSH 1703 changed NLTE_LEVELS to nlte_levels  and NTOP_PHOT to nphot_tot since they are dynamically allocated now */
   size_of_commbuffer =
-    8 * (12 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 107) * (floor (NPLASMA / np_mpi_global) + 1);
+    8 * (13 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 109) * (floor (NPLASMA / np_mpi_global) + 1);
   commbuffer = (char *) malloc (size_of_commbuffer * sizeof (char));
 
   /* JM 1409 -- Initialise parallel only variables */
@@ -406,6 +406,7 @@ WindPtr (w);
         MPI_Pack (plasmamain[n].xscatters, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (plasmamain[n].heat_ion, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (plasmamain[n].cool_rr_ion, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+        MPI_Pack (plasmamain[n].lum_rr_ion, nions, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].j, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].j_direct, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].j_scatt, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
@@ -424,6 +425,7 @@ WindPtr (w);
         MPI_Pack (&plasmamain[n].cool_dr, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_di, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_rr, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+        MPI_Pack (&plasmamain[n].lum_rr, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_rr_metals, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].lum_tot, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].lum_tot_old, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
@@ -435,6 +437,7 @@ WindPtr (w);
         MPI_Pack (&plasmamain[n].cool_dr_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_di_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_rr_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
+        MPI_Pack (&plasmamain[n].lum_rr_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].cool_rr_metals_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (&plasmamain[n].lum_tot_ioniz, 1, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
         MPI_Pack (plasmamain[n].dmo_dt, 3, MPI_DOUBLE, commbuffer, size_of_commbuffer, &position, MPI_COMM_WORLD);
@@ -539,6 +542,7 @@ WindPtr (w);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, plasmamain[n].xscatters, nions, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, plasmamain[n].heat_ion, nions, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, plasmamain[n].cool_rr_ion, nions, MPI_DOUBLE, MPI_COMM_WORLD);
+        MPI_Unpack (commbuffer, size_of_commbuffer, &position, plasmamain[n].lum_rr_ion, nions, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].j, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].j_direct, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].j_scatt, 1, MPI_DOUBLE, MPI_COMM_WORLD);
@@ -557,6 +561,7 @@ WindPtr (w);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_dr, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_di, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_rr, 1, MPI_DOUBLE, MPI_COMM_WORLD);
+        MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].lum_rr, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_rr_metals, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].lum_tot, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].lum_tot_old, 1, MPI_DOUBLE, MPI_COMM_WORLD);
@@ -568,6 +573,7 @@ WindPtr (w);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_dr_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_di_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_rr_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
+        MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].lum_rr_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].cool_rr_metals_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, &plasmamain[n].lum_tot_ioniz, 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Unpack (commbuffer, size_of_commbuffer, &position, plasmamain[n].dmo_dt, 3, MPI_DOUBLE, MPI_COMM_WORLD);
@@ -713,6 +719,7 @@ WindPtr (w);
     plasmamain[nplasma].cool_tot_ioniz = plasmamain[nplasma].cool_tot;
     plasmamain[nplasma].lum_ff_ioniz = plasmamain[nplasma].lum_ff;
     plasmamain[nplasma].cool_rr_ioniz = plasmamain[nplasma].cool_rr;
+    plasmamain[nplasma].lum_rr_ioniz = plasmamain[nplasma].lum_rr;
     plasmamain[nplasma].cool_rr_metals_ioniz = plasmamain[nplasma].cool_rr_metals;
     plasmamain[nplasma].lum_lines_ioniz = plasmamain[nplasma].lum_lines;
     plasmamain[nplasma].cool_comp_ioniz = plasmamain[nplasma].cool_comp;
@@ -1033,7 +1040,7 @@ wind_rad_init ()
     plasmamain[n].heat_z = 0.0;
     plasmamain[n].max_freq = 0.0;       //NSH 120814 Zero the counter which works out the maximum frequency seen in a cell and hence the maximum applicable frequency of the power law estimators.
     plasmamain[n].cool_tot = plasmamain[n].lum_tot = plasmamain[n].lum_lines = plasmamain[n].lum_ff = 0.0;
-    plasmamain[n].cool_rr = plasmamain[n].cool_rr_metals = 0.0;
+    plasmamain[n].cool_rr = plasmamain[n].cool_rr_metals = plasmamain[n].lum_rr = 0.0;
     plasmamain[n].nrad = plasmamain[n].nioniz = 0;
     plasmamain[n].comp_nujnu = -1e99;   //1701 NSH Zero the integrated specific intensity for the cell
     plasmamain[n].cool_comp = 0.0;       //1108 NSH Zero the compton luminosity for the cell
@@ -1059,7 +1066,7 @@ wind_rad_init ()
 
     for (i = 0; i < nions; i++)
     {
-      plasmamain[n].ioniz[i] = plasmamain[n].recomb[i] = plasmamain[n].heat_ion[i] = plasmamain[n].cool_rr_ion[i] = 0.0;
+      plasmamain[n].ioniz[i] = plasmamain[n].recomb[i] = plasmamain[n].heat_ion[i] = plasmamain[n].cool_rr_ion[i] = plasmamain[n].lum_rr_ion[i] = 0.0;
 
     }
 

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -728,6 +728,7 @@ WindPtr (w);
      cycles in the windsavefile even if the spectral cycles are run */
   geo.lum_ff_ioniz = geo.lum_ff;
   geo.cool_rr_ioniz = geo.cool_rr;
+  geo.lum_rr_ioniz = geo.lum_rr;
   geo.lum_lines_ioniz = geo.lum_lines;
   geo.cool_comp_ioniz = geo.cool_comp;
   geo.cool_dr_ioniz = geo.cool_dr;
@@ -756,7 +757,7 @@ WindPtr (w);
 
 
 
-  asum = wind_luminosity (0.0, VERY_BIG);       /*We call wind_luminosity here to obtain an up to date set of cooling rates */
+  asum = wind_cooling (0.0, VERY_BIG);       /*We call wind_cooling here to obtain an up to date set of cooling rates */
 
 
   if (modes.zeus_connect == 1 && geo.hydro_domain_number > -1)  //If we are running in zeus connect mode, we output heating and cooling rates.
@@ -800,7 +801,7 @@ WindPtr (w);
    * not-only adiabatic cooling, but also goe.cool_comp, geo_cool_dr and geo.cool_di */
   Log
     ("!!wind_update: Wind luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
-     asum, geo.cool_rr, geo.lum_ff, geo.lum_lines);
+     asum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
 
   Log
     ("!!wind_update: Wind cooling     %8.2e (recomb %8.2e ff %8.2e compton %8.2e DR %8.2e DI %8.2e lines %8.2e adiabatic %8.2e) after update\n",

--- a/source/windsave.c
+++ b/source/windsave.c
@@ -118,6 +118,8 @@ in the plasma structure */
     n += fwrite (plasmamain[m].heat_ion, sizeof (double), nions, fptr);
     n += fwrite (plasmamain[m].cool_rr_ion, sizeof (double), nions, fptr);
     n += fwrite (plasmamain[m].cool_dr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].lum_rr_ion, sizeof (double), nions, fptr);
+
 
     n += fwrite (plasmamain[m].levden, sizeof (double), nlte_levels, fptr);
     n += fwrite (plasmamain[m].recomb_simple, sizeof (double), nphot_total, fptr);
@@ -266,6 +268,7 @@ wind_read (filename)
     n += fread (plasmamain[m].heat_ion, sizeof (double), nions, fptr);
     n += fread (plasmamain[m].cool_rr_ion, sizeof (double), nions, fptr);
     n += fread (plasmamain[m].cool_dr_ion, sizeof (double), nions, fptr);
+    n += fread (plasmamain[m].lum_rr_ion, sizeof (double), nions, fptr);
 
     n += fread (plasmamain[m].levden, sizeof (double), nlte_levels, fptr);
     n += fread (plasmamain[m].recomb_simple, sizeof (double), nphot_total, fptr);


### PR DESCRIPTION
NSH's attempt to finish off the changes to make the wind luminosity due to radiative recombination correct. I  set up a third 'lookup' table in the fbstruc structure which contains the integrals done with the "FB_FULL" option. This required passing the fb_choice variable to get__fb so that the correct lookup table can be consulted. 
I have also tried to replace use the FB_FULL etc paramaters wherever possible, andI have also introduced INNER_SHELL and OUTER_SHELL parameters for the mode variable in the various freebound subroutines to improve readability. 
Some commenting done, more to be completed.