### PR TITLE
Upstream low temp

### DIFF
--- a/source/emission.c
+++ b/source/emission.c
@@ -358,7 +358,7 @@ photo_gen_wind (p, weight, freqmin, freqmax, photstart, nphot)
         p[n].freq = 0.0;
       }
     }
-    else if ((xlumsum += plasmamain[nplasma].cool_rr) > xlum)    /*Do the same for fb */
+    else if ((xlumsum += plasmamain[nplasma].lum_rr) > xlum)    /*Do the same for fb */
     {
       p[n].freq = one_fb (&wmain[icell], freqmin, freqmax);
     }

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -238,15 +238,7 @@ convergence (xplasma)
 						     xplasma->t_e)) > epsilon)
 	xplasma->techeck = techeck = 1;
       if ((xplasma->converge_hc =
-	   fabs (xplasma->heat_tot -
-		 (xplasma->cool_adiabatic + xplasma->lum_tot +
-		  xplasma->cool_dr + xplasma->cool_di +
-		  xplasma->cool_comp)) / fabs (xplasma->heat_tot +
-					      xplasma->cool_comp +
-					      xplasma->cool_adiabatic +
-					      xplasma->cool_dr +
-					      xplasma->cool_di +
-					      xplasma->lum_tot)) > epsilon)
+	   fabs (xplasma->heat_tot - xplasma->cool_tot) / fabs (xplasma->heat_tot + xplasma->cool_tot)) > epsilon)
 	xplasma->hccheck = hccheck = 1;
     }
   else				//If the cell has reached the maximum temperature
@@ -629,7 +621,7 @@ zero_emit (t)
   xxxplasma->heat_tot += xxxplasma->heat_photo_macro;
   xxxplasma->heat_photo += xxxplasma->heat_photo_macro;
 
-  /*81d - nsh - all cooling calculations moved into seperate routine.
+  /*81d - nsh - all cooling calculations moved into seperate routine.*/
 
 //OLD  /* 70d - ksl - Added next line so that adiabatic cooling reflects the temperature we
 //OLD   * are testing.  Adiabatic cooling is proportional to temperature

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -138,7 +138,7 @@ WindPtr (w);
      NIONS changed to nions for the 12 arrays in plasma that are now dynamically allocated 
   NSH 1703 changed NLTE_LEVELS to nlte_levels  and NTOP_PHOT to nphot_tot since they are dynamically allocated now */
   size_of_commbuffer =
-    8 * (13 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 112) * (floor (NPLASMA / np_mpi_global) + 1);
+    8 * (13 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 212) * (floor (NPLASMA / np_mpi_global) + 1);
   commbuffer = (char *) malloc (size_of_commbuffer * sizeof (char));
 
   /* JM 1409 -- Initialise parallel only variables */

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -138,7 +138,7 @@ WindPtr (w);
      NIONS changed to nions for the 12 arrays in plasma that are now dynamically allocated 
   NSH 1703 changed NLTE_LEVELS to nlte_levels  and NTOP_PHOT to nphot_tot since they are dynamically allocated now */
   size_of_commbuffer =
-    8 * (13 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 212) * (floor (NPLASMA / np_mpi_global) + 1);
+    8 * (13 * nions + nlte_levels + 2 * nphot_total + 12 * NXBANDS + 2 * LPDF + NAUGER + 112) * (floor (NPLASMA / np_mpi_global) + 1);
   commbuffer = (char *) malloc (size_of_commbuffer * sizeof (char));
 
   /* JM 1409 -- Initialise parallel only variables */


### PR DESCRIPTION
Two changes in this pull:
Firstly, in photon gen, the number of rr photons being made was still using cool_rr, which meant far too few were still being made, with the excess going into line photons. Now corrected
Secondly, the HC convergence check was still using the lum_tot + all the various non lum cooling mechanisms. Now fixed to use the cool_tot variable.