### PR TITLE
Upstream lowtemp2

### DIFF
--- a/source/get_atomicdata.c
+++ b/source/get_atomicdata.c
@@ -2980,6 +2980,8 @@ index_phot_top ()
   for (n = 0; n < ntop_phot + nxphot; n++)
   {
     phot_top_ptr[n] = &phot_top[index[n + 1] - 1];
+  	printf ("NPHOT test n=%i f_0=%e z=%i state=%i\n",n,phot_top_ptr[n]->freq[0],phot_top_ptr[n]->z,phot_top_ptr[n]->istate);
+	
   }
 
   /* Free the memory for the arrays */
@@ -3094,6 +3096,8 @@ indexx (n, arrin, indx)
   if (n < 2)
   {
     Log_silent ("Nothing for indexx to do! Only one element\n");
+	indx[0]=0;
+	indx[1]=1;  /* NSH 1707 - We still need to populate the array */
     return;
   }
 

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -547,12 +547,16 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   int echeck, pdf_check (), recalc_pdf_from_cdf ();
 
 
+
+
   /* Check the inputs */
   if (xmax < xmin)
     {
       Error ("pdf_gen_from_array: xmin %g <= xmax %g\n", xmin, xmax);
       return (-1);
     }
+	
+	
 
 /* Determine which jumps are in the range of xmin and xmax */
   njump_min = njump_max = 0;
@@ -602,6 +606,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
     }
   /* OK, all the input data seems OK, by which we maen that we have checked that the pdf is positive */
 
+	
 
   /* Now modify x so that there is a value of x that corresponds to each value of njump.  We make the
    * assumption that the jump is a positive jump, and so we want everthing up to this point to reflect
@@ -622,6 +627,34 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 
 	}
     }
+	
+
+	
+	
+    /* The next two checks look to see if there is a part of the CDF that is all zeros as the start or end of the distribution
+  
+    Start first */
+
+	n=0;
+	while (y[n]==0.0)
+	{
+		xmin=x[n];
+		n++;
+	}
+	
+	//Now at the end
+	
+	nn=n_xy;
+	while (y[n]==0.0)
+	{
+		xmax=x[n];
+		n--;
+	}
+	
+	
+	
+	//xmin and xmax now bracket the non zero parts of the input array
+	
 
 
 
@@ -688,6 +721,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	  pdf_y[pdf_n] = y[m - 1];	//Again assume constant prob. density outside lims
 	}
       pdf_n++;
+	  
+	  
+	
+	  
+	  
 
 /* So at this point, have probability density in pdf_x, pdf_y for the points
  * specified by the input array but we want the cumulative distribution
@@ -710,6 +748,8 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
    the input array, or more explicitly, at the points specied in the array
    pdf_x
 */
+	  
+
 
       /* Add a check that the pdf_z is monotonic. This check should not really be necessary
        * since by construction this should be the case*/
@@ -770,15 +810,24 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   pdf->y[NPDF] = 1.0;
   pdf->norm = sum;		/* The normalizing factor that would convert the function we
 				   have been given into a proper probability density function */
+	  
+	  
+
 
 /* Calculate the gradients */
   recalc_pdf_from_cdf (pdf);	// 57ib 
+  
+
+  
   if ((echeck = pdf_check (pdf)) != 0)
     {
       Error ("pdf_gen_from_array: error %d on pdf_check\n", echeck);
     }
   return (echeck);
 }
+
+
+
 
 
 /* 


### PR DESCRIPTION
Three main changes:
1: A small change to get atomic data that allows index to properly deal with occasions where only one element exists.
2: pdf.c - a test in pdf_from_array to look for leading zeros and trailing zeros in the supplied array. This ensures zero photons will be made from areas where there is zero flux!
3: changes in recomb.c - one_fb - the array sent to pdf_gen_from_array is now a variable length (well up to 300) and data points are made around jumps. They are 1km/s above and below the jump. This needs more work, ideally making the arrays more dynamic for a start, and probably larger subject to not massively increasing runtime