### PR TITLE
Upstream lowtemp2

### DIFF
--- a/source/anisowind.c
+++ b/source/anisowind.c
@@ -53,7 +53,9 @@ and
 		when calculating pdf_rand.  ?? It might be more
 		computationally efficient to switch to isotropic
 		in this case ??
-15aug	ksl	Minor changes for multiple domains
+15aug	ksl	Minor changes for multiple 
+17jun	nsh - changed references from PDFs to CDFs - because
+		this is what they actually are!
 */
 
 #define  TAU_TOP   10.0         /* tau above which we assume the angular distribution function
@@ -102,16 +104,16 @@ randwind (p, lmn, north)
     tau = TAU_BOT;
 
   if (fabs (tau - tau_randwind) > 0.01)
-  {                             // (Re)create pdf
-    make_pdf_randwind (tau);
+  {                             // (Re)create cdf
+    make_cdf_randwind (tau);
     stuff_phot (p, &phot_randwind);
   }
 
-  xlmn[0] = n = pdf_get_rand (pdf_randwind);
+  xlmn[0] = n = cdf_get_rand (cdf_randwind);
   if (sane_check (n))
   {
-    Error ("anisowind:sane_check of pdf_get_rand returned %f\n", n);
-    xlmn[0] = n = pdf_get_rand (pdf_randwind);
+    Error ("anisowind:sane_check of cdf_get_rand returned %f\n", n);
+    xlmn[0] = n = cdf_get_rand (cdf_randwind);
   }
 
   q = sqrt (1. - n * n);
@@ -157,7 +159,7 @@ the cartesian frame */
   return (0);
 }
 
-/* This is the function that is used to generate the pdf for scattering.  It
+/* This is the function that is used to generate the cdf for scattering.  It
 basically is calculating a function that is proportional to the probability
 density.  dP/dcos(theta) for the photon. 
 
@@ -170,6 +172,7 @@ double vrandwind (x)
 	02feb14	ksl	Made changes to set a minimum for vrandwind in
 			in an attempt to prevent problems with pdf
 			generation
+	17jul	nsh	changed PDFs to CDF
 */
 
 #define VRANDWIND_FLOOR 1e-5
@@ -279,7 +282,7 @@ reweightwind (p)
   {
     k = where_in_grid (wmain[p->grid].ndom, p->x);
     tau = sobolev (&wmain[k], p->x, -1., lin_ptr[p->nres], wmain[k].dvds_max);
-    make_pdf_randwind (tau);    // Needed for the normalization
+    make_cdf_randwind (tau);    // Needed for the normalization
     stuff_phot (p, &phot_randwind);
   }
   else
@@ -306,12 +309,12 @@ what we do here */
 // ?? It's definitely needed to make a uniform distribution work
 // but is this reason really right
 
-  z = 2. / pdf_randwind->norm;
+  z = 2. / cdf_randwind->norm;
   x = vrandwind (ctheta) * z;
 
   if (sane_check (x) || x > 2.0)
   {
-    Error ("Reweightwind:sane_check x %f tau %f ctheta %f z %e pdf_randwind->norm %f\n", x, tau, ctheta, z, pdf_randwind->norm);
+    Error ("Reweightwind:sane_check x %f tau %f ctheta %f z %e cdf_randwind->norm %f\n", x, tau, ctheta, z, cdf_randwind->norm);
     x = 2.0;
   }
 
@@ -324,71 +327,72 @@ what we do here */
 /*
  
 
-   make_pdf_rand_wind(tau)
+   make_cdf_rand_wind(tau)
 
    History
 	02june	ksl	Modified make_pdf_randwind so that the first time
 			the program is entered an array of cumulative
 			distribution functions is created.  This is 
 			designed to speed the program up significantly
+	17july 	nsh - modified to call CDFs cdfs as they should be!
 */
 
-int init_make_pdf_randwind = 1;
-int make_pdf_randwind_njumps;
-double make_pdf_randwind_jumps[180];
+int init_make_cdf_randwind = 1;
+int make_cdf_randwind_njumps;
+double make_cdf_randwind_jumps[180];
 #define LOGTAUMIN -2.
 #define LOGTAUMAX 1.
-double pdf_randwind_dlogtau;
+double cdf_randwind_dlogtau;
 
 int
-make_pdf_randwind (tau)
+make_cdf_randwind (tau)
      double tau;
 {
   int jj;
   int echeck;
-  int pdf_gen_from_func ();
+  int cdf_gen_from_func ();
   double vrandwind ();
   double xtau;
   double log10 ();
 
 /* Initalize jumps the first time routine is called */
 
-  if (init_make_pdf_randwind)
+  if (init_make_cdf_randwind)
   {
-    make_pdf_randwind_njumps = 0;
+    make_cdf_randwind_njumps = 0;
     for (jj = -88; jj <= 88; jj += 2)
     {
-      make_pdf_randwind_jumps[make_pdf_randwind_njumps] = sin (jj / 57.29578);
-      make_pdf_randwind_njumps++;
+      make_cdf_randwind_jumps[make_cdf_randwind_njumps] = sin (jj / 57.29578);
+      make_cdf_randwind_njumps++;
     }
-    pdf_randwind_dlogtau = (LOGTAUMAX - LOGTAUMIN) / 99.;
+    cdf_randwind_dlogtau = (LOGTAUMAX - LOGTAUMIN) / 99.;
     for (jj = 0; jj < 100; jj++)
     {
-      xtau = pow (10., LOGTAUMIN + pdf_randwind_dlogtau * jj);
+      xtau = pow (10., LOGTAUMIN + cdf_randwind_dlogtau * jj);
       tau_randwind = xtau;      /* This is passed to vrandwind by an external variable */
       if ((echeck =
-           pdf_gen_from_func (&pdf_randwind_store[jj], &vrandwind, -1.0, 1.0, make_pdf_randwind_njumps, make_pdf_randwind_jumps)) != 0)
+           cdf_gen_from_func (&cdf_randwind_store[jj], &vrandwind, -1.0, 1.0, make_cdf_randwind_njumps, make_cdf_randwind_jumps)) != 0)
       {
-        Error ("Randwind: return from pdf_gen_from_func %d\n", echeck);
+        Error ("Randwind: return from cdf_gen_from_func %d\n", echeck);
       }
     }
-    init_make_pdf_randwind = 0;
+    init_make_cdf_randwind = 0;
   }
 
   if (sane_check (tau))
   {
-    Error ("make_pdf_randwind:sane_check Need proper tau (%e) to make pdf_randwind\n", tau);
+    Error ("make_cdf_randwind:sane_check Need proper tau (%e) to make cdf_randwind\n", tau);
     tau = 10.;                  // Forces something close to isotropic
   }
 
-  jj = (log10 (tau) - LOGTAUMIN) / pdf_randwind_dlogtau + 0.5;
+  jj = (log10 (tau) - LOGTAUMIN) / cdf_randwind_dlogtau + 0.5;
 
   if (jj < 0)
     jj = 0;
   if (jj > 99)
     jj = 99;
 
-  pdf_randwind = &pdf_randwind_store[jj];
+  cdf_randwind = &cdf_randwind_store[jj];
   tau_randwind = tau;           // This is passed to vrandwind by an external variable
 
   return (0);

--- a/source/bb.c
+++ b/source/bb.c
@@ -171,7 +171,6 @@ History:
 #define NMAX 		1000
 
 int ninit_planck = 0;
-struct Cdf cdf_bb;
 
 double old_t = 0;
 double old_freqmin = 0;

--- a/source/brem.c
+++ b/source/brem.c
@@ -59,7 +59,6 @@ brem_d (alpha)
 #define NMAX 		1000
 
 int ninit_brem = 0;
-struct Cdf cdf_brem;
 
 double old_brem_t = 0;
 double old_brem_freqmin = 0;

--- a/source/brem.c
+++ b/source/brem.c
@@ -59,7 +59,7 @@ brem_d (alpha)
 #define NMAX 		1000
 
 int ninit_brem = 0;
-struct Pdf pdf_brem;
+struct Cdf cdf_brem;
 
 double old_brem_t = 0;
 double old_brem_freqmin = 0;
@@ -69,7 +69,7 @@ double cdf_brem_lo, cdf_brem_hi, cdf_brem_tot;  // The precise boundaries in the
 double cdf_brem_ylo, cdf_brem_yhi;      // The places in the CDF defined by freqmin & freqmax
 double brem_lo_freq_alphamin, brem_lo_freq_alphamax, brem_hi_freq_alphamin, brem_hi_freq_alphamax;      //  the limits to use for the low and high frequency values
 
-// bb_set is the array that pdf_gen_from_func uses to esablish the 
+// bb_set is the array that cdf_gen_from_func uses to esablish the 
 // specific points in the cdf of the dimensionless bb function.
 double brem_set[] = {
   0.05, 0.1, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
@@ -91,13 +91,13 @@ get_rand_brem (freqmin, freqmax)
 
 
   /*First time through create the array containing the proper boundaries for the integral of the brem function,
-     Note calling pdf_gen_from func also defines ylo and yhi */
+     Note calling cdf_gen_from func also defines ylo and yhi */
 
   if (ninit_brem == 0)
   {                             /* First time through p_alpha must be initialized */
-    if ((echeck = pdf_gen_from_func (&pdf_brem, &brem_d, BREM_ALPHAMIN, BREM_ALPHAMAX, 10, brem_set)) != 0)
+    if ((echeck = cdf_gen_from_func (&cdf_brem, &brem_d, BREM_ALPHAMIN, BREM_ALPHAMAX, 10, brem_set)) != 0)
     {
-      Error ("get_rand_brem: on return from pdf_gen_from_func %d\n", echeck);
+      Error ("get_rand_brem: on return from cdf_gen_from_func %d\n", echeck);
     }
 
     /* We need the integral of the brem function outside of the regions of interest as well */
@@ -112,7 +112,7 @@ get_rand_brem (freqmin, freqmax)
   }
 
 /* If temperatures or frequencies have changed since the last call to planck
-redefine various limitsi, including the region of the pdf  to be used
+redefine various limitsi, including the region of the cdf  to be used
 
 Note - ksl - 1211 - It is not obvious why all of these parameters need to be
 reset.  A careful review of them is warranted.
@@ -171,7 +171,7 @@ reset.  A careful review of them is warranted.
 
     if (brem_alphamin < BREM_ALPHAMAX && brem_alphamax > BREM_ALPHAMIN)
     {
-      pdf_limit (&pdf_brem, brem_alphamin, brem_alphamax);
+      cdf_limit (&cdf_brem, brem_alphamin, brem_alphamax);
     }
 
   }
@@ -198,7 +198,7 @@ reset.  A careful review of them is warranted.
   }
   else
   {
-    alpha = pdf_get_rand_limit (&pdf_brem);
+    alpha = cdf_get_rand_limit (&cdf_brem);
   }
 
   freq = BOLTZMANN * geo.brem_temp / H * alpha;

--- a/source/continuum.c
+++ b/source/continuum.c
@@ -66,7 +66,7 @@ one_continuum (spectype, t, g, freqmin, freqmax)
   //OLD not used in routine double par[2];              // For python we assume only two parameter models
   double lambdamin, lambdamax;
   double f;
-  double pdf_get_rand ();
+  double cdf_get_rand ();
   // int model (), nwav;
   int model ();
 
@@ -78,10 +78,10 @@ one_continuum (spectype, t, g, freqmin, freqmax)
     /*  Get_model returns wavelengths in Ang and flux in ergs/cm**2/Ang */
     lambdamin = C * 1e8 / freqmax;
     lambdamax = C * 1e8 / freqmin;
-    if (pdf_gen_from_array
-        (&comp[spectype].xpdf, comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, lambdamin, lambdamax, 1, jump) != 0)
+    if (cdf_gen_from_array
+        (&comp[spectype].xcdf, comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, lambdamin, lambdamax, 1, jump) != 0)
     {
-      Error ("In one_continuum after return from pdf_gen_from_array\n");
+      Error ("In one_continuum after return from cdf_gen_from_array\n");
     }
     old_t = t;
     old_g = g;
@@ -89,7 +89,7 @@ one_continuum (spectype, t, g, freqmin, freqmax)
     old_freqmax = freqmax;
   }
 
-  f = (C * 1.e8 / pdf_get_rand (&comp[spectype].xpdf));
+  f = (C * 1.e8 / cdf_get_rand (&comp[spectype].xcdf));
   if (f > freqmax)
   {
     Error ("one_continuum: f too large %e\n");

--- a/source/emission.c
+++ b/source/emission.c
@@ -735,7 +735,7 @@ History:
  
 **************************************************************/
 
-struct Cdf cdf_ff;
+//struct Cdf cdf_ff;
 double ff_x[200], ff_y[200];
 double one_ff_f1, one_ff_f2, one_ff_te; /* Old values */
 

--- a/source/emission.c
+++ b/source/emission.c
@@ -735,7 +735,7 @@ History:
  
 **************************************************************/
 
-struct Pdf pdf_ff;
+struct Cdf cdf_ff;
 double ff_x[200], ff_y[200];
 double one_ff_f1, one_ff_f2, one_ff_te; /* Old values */
 
@@ -773,10 +773,10 @@ one_ff (one, f1, f2)
 
 
 
-    if ((echeck = pdf_gen_from_array (&pdf_ff, ff_x, ff_y, 200, f1, f2, 0, &dummy)) != 0)
+    if ((echeck = cdf_gen_from_array (&cdf_ff, ff_x, ff_y, 200, f1, f2, 0, &dummy)) != 0)
     {
       Error
-        ("one_ff: pdf_gen_from_array error %d : f1 %g f2 %g te %g ne %g nh %g vol %g\n",
+        ("one_ff: cdf_gen_from_array error %d : f1 %g f2 %g te %g ne %g nh %g vol %g\n",
          echeck, f1, f2, xplasma->t_e, xplasma->ne, xplasma->density[1], one->vol);
       exit (0);
     }
@@ -784,7 +784,7 @@ one_ff (one, f1, f2)
     one_ff_f1 = f1;
     one_ff_f2 = f2;             /* Note that this may not be the best way to check for a previous pdf */
   }
-  freq = pdf_get_rand (&pdf_ff);
+  freq = cdf_get_rand (&cdf_ff);
   return (freq);
 }
 

--- a/source/foo.h
+++ b/source/foo.h
@@ -141,16 +141,16 @@ int spec_read(char filename[]);
 int extract(WindPtr w, PhotPtr p, int itype);
 int extract_one(WindPtr w, PhotPtr pp, int itype, int nspec);
 /* pdf.c */
-int pdf_gen_from_func(PdfPtr pdf, double (*func)(double), double xmin, double xmax, int njumps, double jump[]);
+int cdf_gen_from_func(CdfPtr cdf, double (*func)(double), double xmin, double xmax, int njumps, double jump[]);
 double gen_array_from_func(double (*func)(double), double xmin, double xmax, int pdfsteps);
-int pdf_gen_from_array(PdfPtr pdf, double x[], double y[], int n_xy, double xmin, double xmax, int njumps, double jump[]);
-double pdf_get_rand(PdfPtr pdf);
-int pdf_limit(PdfPtr pdf, double xmin, double xmax);
-double pdf_get_rand_limit(PdfPtr pdf);
-int pdf_to_file(PdfPtr pdf, char filename[]);
-int pdf_check(PdfPtr pdf);
-int recalc_pdf_from_cdf(PdfPtr pdf);
-int pdf_array_fixup(double *x, double *y, int n_xy);
+int cdf_gen_from_array(CdfPtr cdf, double x[], double y[], int n_xy, double xmin, double xmax, int njumps, double jump[]);
+double cdf_get_rand(CdfPtr cdf);
+int cdf_limit(CdfPtr cdf, double xmin, double xmax);
+double cdf_get_rand_limit(CdfPtr cdf);
+int cdf_to_file(CdfPtr cdf, char filename[]);
+int cdf_check(CdfPtr cdf);
+int calc_cdf_gradient(CdfPtr cdf);
+int cdf_array_fixup(double *x, double *y, int n_xy);
 /* roche.c */
 int binary_basics(void);
 double ds_to_roche_2(PhotPtr p);
@@ -288,7 +288,7 @@ int reposition(PhotPtr p);
 int randwind(PhotPtr p, double lmn[3], double north[3]);
 double vrandwind(double x);
 double reweightwind(PhotPtr p);
-int make_pdf_randwind(double tau);
+int make_cdf_randwind(double tau);
 int randwind_thermal_trapping(PhotPtr p, int *nnscat);
 /* util.c */
 int fraction(double value, double array[], int npts, int *ival, double *f, int mode);

--- a/source/foo.h
+++ b/source/foo.h
@@ -151,6 +151,7 @@ int cdf_to_file(CdfPtr cdf, char filename[]);
 int cdf_check(CdfPtr cdf);
 int calc_cdf_gradient(CdfPtr cdf);
 int cdf_array_fixup(double *x, double *y, int n_xy);
+int calloc_cdf(void);
 /* roche.c */
 int binary_basics(void);
 double ds_to_roche_2(PhotPtr p);

--- a/source/get_models.c
+++ b/source/get_models.c
@@ -167,8 +167,8 @@ get_models (modellist, npars, spectype)
   strcpy (comp[ncomps].name, modellist);
   comp[ncomps].modstart = nmods_tot;
   comp[ncomps].npars = npars;
-  comp[ncomps].xpdf.limit1 = -99.;
-  comp[ncomps].xpdf.limit2 = -99.;
+  comp[ncomps].xcdf.limit1 = -99.;
+  comp[ncomps].xcdf.limit2 = -99.;
 
 /* Now get all the models of this type */
   n = nmods_tot;                // This is the starting point since may have read models in before

--- a/source/models.h
+++ b/source/models.h
@@ -57,5 +57,7 @@ struct ModSum
 comp[NCOMPS];
 
 
+
+
 /* In modsum, current[0] often refers to a normalization.  Therefore for parallism, a set of
 models which really only have one parameter, e.g. T, will store that parmeter in .par[1] */

--- a/source/models.h
+++ b/source/models.h
@@ -52,7 +52,7 @@ struct ModSum
   double max[NPARS];
   int nwaves;                   //All models in each comp should have same wavelengths;
   struct Model xmod;            //The current intepolated model of this type 
-  struct Pdf xpdf;              //The current cumulative distribution function for this component
+  struct Cdf xcdf;              //The current cumulative distribution function for this component
 }
 comp[NCOMPS];
 

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -1454,6 +1454,15 @@ int
 	}
 		
 		
+	if (iprob > 0)
+	{
+		Error ("calloc_cdf: Error in allocating memory for a CDF\n");
+		exit(0);
+	}
+		
+    Log
+      ("Allocated %10d bytes for each of %5d variable length CDF arrays totaling %10.3f Mb \n",
+       sizeof (double) * (NCDF+1), 15+NCOMPS+100, 1.e-6  * sizeof (double) * (NCDF+1)*(15+NCOMPS+100));
 		
 		
 

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -231,8 +231,8 @@ This routine stores values of the function in  pdf_array
 
 */
 int
-pdf_gen_from_func (pdf, func, xmin, xmax, njumps, jump)
-     PdfPtr pdf;
+cdf_gen_from_func (cdf, func, xmin, xmax, njumps, jump)
+     CdfPtr cdf;
      double (*func) (double);
      double xmin, xmax;
      double jump[];
@@ -243,7 +243,7 @@ pdf_gen_from_func (pdf, func, xmin, xmax, njumps, jump)
   int j, m, mm, n;
   int njump_min, njump_max;
   int icheck, pdfsteps;
-  int pdf_check (), recalc_pdf_from_cdf ();
+  int cdf_check (), calc_cdf_array ();
   double gen_array_from_func (), delta;
 
   njump_min = njump_max = 0;
@@ -304,31 +304,36 @@ pdf_gen_from_func (pdf, func, xmin, xmax, njumps, jump)
   while (n < 3)
     {
       delta = gen_array_from_func (func, xmin, xmax, pdfsteps);
-      if (delta < 0.1 / NPDF)
+      if (delta < 0.1 / NCDF)
 	break;
       pdfsteps *= 10;
       n = n + 1;
     }
 
+
+
+
+
+
   xstep = (xmax - xmin) / pdfsteps;
 
 /* So at this point pdf_array contains an unnormalized version of the CDF for the function */
-  pdf->x[0] = xmin;
-  pdf->y[0] = 0;
+  cdf->x[0] = xmin;
+  cdf->y[0] = 0;
 
   n = 0;			//This is the position in pdf_array
   mm = 1;			//This is the index to a desired value of y, with no jumps
   j = njump_min;		//This refers to the jumps
-  for (m = 1; m < NPDF; m++)
+  for (m = 1; m < NCDF; m++)
     {
-      y = (float) mm / (NPDF - njumps);	// Desired value of y ignoring jumps
+      y = (float) mm / (NCDF - njumps);	// Desired value of y ignoring jumps
 
       while (pdf_array[n] < y && n < pdfsteps)	// Work one's way through pdf_array
 	{
 	  if (j < njump_max && jump[j] <= xmin + (n + 1) * xstep)
 	    {
-	      pdf->x[m] = xmin + (n + 1) * xstep;	//Not exactly jump but close
-	      pdf->y[m] = pdf_array[n];
+	      cdf->x[m] = xmin + (n + 1) * xstep;	//Not exactly jump but close
+	      cdf->y[m] = pdf_array[n];
 	      j++;		//increment the jump number
 	      m++;		//increment the pdf structure number
 	    }
@@ -336,27 +341,27 @@ pdf_gen_from_func (pdf, func, xmin, xmax, njumps, jump)
 	}
 
       /* So at this point pdf_array[n-1] < x and pdf_array[n]>x */
-      pdf->x[m] = xmin + (n + 1) * xstep;
-      pdf->y[m] = pdf_array[n];
+      cdf->x[m] = xmin + (n + 1) * xstep;
+      cdf->y[m] = pdf_array[n];
       mm++;			// increment the number associated with the desired y ignoring jumps
       /* So pdf->y will contain numbers from 0 to 1 */
     }
 
-  pdf->x[NPDF] = xmax;
-  pdf->y[NPDF] = 1.0;
-  pdf->norm = 1.;		/* pdf_gen_from array produces a properly nomalized cdf and so the
+  cdf->x[NCDF] = xmax;
+  cdf->y[NCDF] = 1.0;
+  cdf->norm = 1.;		/* pdf_gen_from array produces a properly nomalized cdf and so the
 				   normalization is 1.  110629 ksl */
-  pdf->npdf = NPDF;
+  cdf->ncdf = NCDF;
 
 /* Calculate the gradients */
-  if (recalc_pdf_from_cdf (pdf))
+  if (calc_cdf_gradient (cdf))
     {
-      Error ("pdf_gen_from_func: Errro returned from recalc_pdf_from_cdf\n");
+      Error ("cdf_gen_from_func: Errro returned from calc_cdf_gradient\n");
     }				// 57ib 
   /* Check the pdf */
-  if ((icheck = pdf_check (pdf)) != 0)
+  if ((icheck = cdf_check (cdf)) != 0)
     {
-      Error ("pdf_gen_from_function: error %d on pdf_check\n", icheck);
+      Error ("cdf_gen_from_function: error %d on cdf_check\n", icheck);
     }
   return (icheck);
 
@@ -538,8 +543,8 @@ double pdf_x[PDF_ARRAY], pdf_y[PDF_ARRAY], pdf_z[PDF_ARRAY];
 int pdf_n;
 
 int
-pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
-     PdfPtr pdf;
+cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax, njumps, jump)
+     CdfPtr cdf;
      double x[], y[];
      int n_xy;
      double xmin, xmax;
@@ -551,7 +556,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   double sum, q;
   int njump_min, njump_max;
   double ysum;
-  int echeck, pdf_check (), recalc_pdf_from_cdf ();
+  int echeck, cdf_check (), recalc_pdf_from_cdf ();
 
 
 
@@ -559,7 +564,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   /* Check the inputs */
   if (xmax < xmin)
     {
-      Error ("pdf_gen_from_array: xmin %g <= xmax %g\n", xmin, xmax);
+      Error ("cdf_gen_from_array: xmin %g <= xmax %g\n", xmin, xmax);
       return (-1);
     }
   echeck = 0;
@@ -568,25 +573,25 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
       if (x[n] <= x[n - 1])
 	{
 	  Error
-	    ("pdf_gen_from_array: input x not in ascending order at element %5d/%5d  %11.6e %11.6e\n",
+	    ("cdf_gen_from_array: input x not in ascending order at element %5d/%5d  %11.6e %11.6e\n",
 	     n, n_xy, x[n - 1], x[n]);
 	  echeck = 1;
 	}
       if (y[n] < 0)
 	{
-	  Error ("pdf_gen_from_array: input y not >= 0\n");
+	  Error ("cdf_gen_from_array: input y not >= 0\n");
 	  exit (0);
 	}
     }
 
   if (echeck == 1)
     {
-      Error ("pdf_from_array: Trying to fix the input array\n");
+      Error ("cdf_from_array: Trying to fix the input array\n");
 
-      n=pdf_array_fixup (x, y, n_xy);
+      n=cdf_array_fixup (x, y, n_xy);
 
       if (n!=n_xy) {
-          Log("pdf_gen_from_array: Reduced input array  %d to %d elements\n",n_xy,n);
+          Log("cdf_gen_from_array: Reduced input array  %d to %d elements\n",n_xy,n);
           n_xy=n;
       }
 
@@ -595,7 +600,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	  if (x[n] <= x[n - 1])
 	    {
 	      Error
-		("pdf_gen_from_array: Recheck: input x not in ascending order at element %5d/%5d  %11.6e %11.6e\n",
+		("cdf_gen_from_array: Recheck: input x not in ascending order at element %5d/%5d  %11.6e %11.6e\n",
 		 n, n_xy, x[n - 1], x[n]);
 	      echeck = 1;
 	    }
@@ -614,7 +619,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	  if (jump[j] <= jump[j - 1])
 	    {
 	      Error
-		("pdf_gen_from_array: jump[%d]=%g <=jump[%d]=%g out of order\n",
+		("cdf_gen_from_array: jump[%d]=%g <=jump[%d]=%g out of order\n",
 		 j - 1, jump[j - 1], j, jump[j]);
 	      return (-1);
 	    }
@@ -642,7 +647,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
       if (y[n] < 0)
 	{
 	  Error
-	    ("pdf_gen_from_array: probability density %g < 0 at element %d\n",
+	    ("cdf_gen_from_array: probability density %g < 0 at element %d\n",
 	     y[n], n);
 	  return (-1);
 	}
@@ -653,11 +658,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
     }
   /* OK, all the input data seems OK, by which we maen that we have checked that the pdf is positive */
 
-  if (6e15 < xmin && xmin < 7e15)
-{
-	for (n=0;n<n_xy;n++)
-		printf ("AFTER_CHECKS n %i x %e y %e\n",n,x[n],y[n]);
-}
+
 
   /* Now modify x so that there is a value of x that corresponds to each value of njump.  We make the
    * assumption that the jump is a positive jump, and so we want everthing up to this point to reflect
@@ -680,11 +681,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
     }
 
 
-  if (6e15 < xmin && xmin < 7e15)
-{
-	for (n=0;n<n_xy;n++)
-		printf ("AFTER_JUMP_MOD n %i x %e y %e\n",n,x[n],y[n]);
-}
+
 
 
   /* The next two checks look to see if there is a part of the CDF that is all zeros as the start or end of the distribution
@@ -711,11 +708,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 
   //xmin and xmax now bracket the non zero parts of the input array
 
-  if (6e15 < xmin && xmin < 7e15)
-{
-	for (n=0;n<n_xy;n++)
-		printf ("AFTER_ZERO_MOD n %i x %e y %e\n",n,x[n],y[n]);
-}
+
 
 /* Shuffle x and y into pdf_xx and pdf_yy allowing for xmin and xmax */
 
@@ -758,13 +751,13 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	  if (pdf_n > PDF_ARRAY)
 	    {
 	      Error
-		("pdf_gen_from_array: pdf_n (%d) exceeded maximum array size PDF_ARRAY (%d) \n",
+		("cdf_gen_from_array: pdf_n (%d) exceeded maximum array size PDF_ARRAY (%d) \n",
 		 pdf_n, PDF_ARRAY);
 	      Error
-		("pdf_gen_from_array: n_xy %d xmin %f xmax %f njumps %d\n",
+		("cdf_gen_from_array: n_xy %d xmin %f xmax %f njumps %d\n",
 		 n_xy, xmin, xmax, njumps);
 	      Error
-		("pdf_gen_from_array: Consider increasing PDF_ARRAY to a value > n_xy + njumps, and recompiling\n");
+		("cdf_gen_from_array: Consider increasing PDF_ARRAY to a value > n_xy + njumps, and recompiling\n");
 	      exit (0);
 	    }
 	}
@@ -781,11 +774,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	}
       pdf_n++;
 
-	  if (6e15 < xmin && xmin < 7e15)
-  {
-  	for (n=0;n<pdf_n;n++)
-  		printf ("AFTER_SHUFFLE n %i x %e y %e\n",n,pdf_x[n],pdf_y[n]);
-}
+
 
 
 /* So at this point, have probability density in pdf_x, pdf_y for the points
@@ -823,7 +812,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	{
 	  if (pdf_z[n] < pdf_z[n - 1])
 	    {
-	      Error ("pdf_gen_from_array: pdf_z is not monotonic at %d\n", n);
+	      Error ("cdf_gen_from_array: pdf_z is not monotonic at %d\n", n);
 	      echeck = 1;
 	    }
 	}
@@ -832,7 +821,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	{
 	  for (n = 0; n < pdf_n; n++)
 	    {
-	      Log ("pdf_gen_from_array: %5d %11.6e %11.6e %11.6e\n", n,
+	      Log ("cdf_gen_from_array: %5d %11.6e %11.6e %11.6e\n", n,
 		   pdf_x[n], pdf_y[n], pdf_z[n]);
 	    }
 	  echeck = 0;
@@ -852,22 +841,23 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 
 
 
-  pdf->x[0] = xmin;
-  pdf->y[0] = 0;
+
+  cdf->x[0] = xmin;
+  cdf->y[0] = 0;
 
   j = njump_min;		// j refers to the jump points
   m = 0;			//m referest to points in pdf_x and pdf_y
   nn = 1;			// nn refers to the non_jump points
-  for (n = 1; n < NPDF && m < pdf_n; n++)
+  for (n = 1; n < NCDF && m < pdf_n; n++)
     {
-      ysum = ((double) nn) / (NPDF);	/* This is the target with no jumps */
+      ysum = ((double) nn) / (NCDF);	/* This is the target with no jumps */
 
       while (pdf_z[m] < ysum)
 	{
 	  if (pdf_x[m] == jump[j])
 	    {
-	      pdf->x[n] = pdf_x[m];
-	      pdf->y[n] = pdf_z[m];
+	      cdf->x[n] = pdf_x[m];
+	      cdf->y[n] = pdf_z[m];
 	      n++;
 	      j++;
 	    }
@@ -875,8 +865,8 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	  m++;			//increment m if necessary
 	}
 
-      pdf->x[n] = pdf_x[m];
-      pdf->y[n] = pdf_z[m];	/* this is pdf_z because that is where the cdf is stored */
+      cdf->x[n] = pdf_x[m];
+      cdf->y[n] = pdf_z[m];	/* this is pdf_z because that is where the cdf is stored */
       m++;			/* This assures that no two points will be the same x value */
       nn++;
     }
@@ -885,37 +875,33 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 
 
 
-  pdf->npdf = nn;
-  pdf->x[nn] = xmax;
-  pdf->y[nn] = 1.0;
-  pdf->norm = sum;		/* The normalizing factor that would convert the function we
+  cdf->ncdf = nn;
+  cdf->x[nn] = xmax;
+  cdf->y[nn] = 1.0;
+  cdf->norm = sum;		/* The normalizing factor that would convert the function we
 				   have been given into a proper probability density function */
 
-	  if (6e15 < xmin && xmin < 7e15)
-  {
-  	for (n=0;n<NPDF;n++)
-  		printf ("PDF n %i x %e y %e\n",n,pdf->x[n],pdf->y[n]);
-}
+
 
 
 /* Calculate the gradients */
-  if (recalc_pdf_from_cdf (pdf))
+  if (calc_cdf_gradient (cdf))
     {
-      Error ("pdf_gen_from_array: Error returned from recalc_pdf_from_cdf\n");
+      Error ("cdf_gen_from_array: Error returned from calc_cdf_gradient\n");
       for (n = njump_min; n < njump_max; n++)
 	{
-	  Error ("pdf_gen_from_array: njump %3d jump %11.6e\n", n, jump[n]);
+	  Error ("cdf_gen_from_array: njump %3d jump %11.6e\n", n, jump[n]);
 	}
       if (njump_min == njump_max)
 	{
-	  Error ("pdf_gen_from_array: There were no jumps in the pdf\n");
+	  Error ("cdf_gen_from_array: There were no jumps in the pdf\n");
 	}
 
 
     }				// 57ib 
-  if ((echeck = pdf_check (pdf)) != 0)
+  if ((echeck = cdf_check (cdf)) != 0)
     {
-      Error ("pdf_gen_from_array: error %d on pdf_check\n", echeck);
+      Error ("cdf_gen_from_array: error %d on cdf_check\n", echeck);
     }
   return (echeck);
 }
@@ -940,8 +926,8 @@ History:
 */
 
 double
-pdf_get_rand (pdf)
-     PdfPtr pdf;
+cdf_get_rand (cdf)
+     CdfPtr cdf;
 {
   double x, r;
   int i, j;
@@ -950,33 +936,33 @@ pdf_get_rand (pdf)
   int xquadratic ();
 /* Find the interval within which x lies */
   r = rand () / MAXRAND;	/* r must be slightly less than 1 */
-  i = r * pdf->npdf;		/* so i initially lies between 0 and the size of the pdf array -1 */
-  while (pdf->y[i + 1] < r && i < pdf->npdf - 1)
+  i = r * cdf->ncdf;		/* so i initially lies between 0 and the size of the pdf array -1 */
+  while (cdf->y[i + 1] < r && i < cdf->ncdf - 1)
     i++;
-  while (pdf->y[i] > r && i > 0)
+  while (cdf->y[i] > r && i > 0)
     i--;
 /* Now calculate a place within that interval */
   q = rand () / MAXRAND;
-  a = 0.5 * (pdf->d[i + 1] - pdf->d[i]);
-  b = pdf->d[i];
-  c = (-0.5) * (pdf->d[i + 1] + pdf->d[i]) * q;
+  a = 0.5 * (cdf->d[i + 1] - cdf->d[i]);
+  b = cdf->d[i];
+  c = (-0.5) * (cdf->d[i + 1] + cdf->d[i]) * q;
   if ((j = xquadratic (a, b, c, s)) < 0)
     {
-      Error ("pdf_get_rand: %d\n", j);
+      Error ("cdf_get_rand: %d\n", j);
     }
   else
     {
       q = s[j];
       if (q < 0 || q > 1)
 	{
-	  Error ("pdf_get_rand: q out of range %d  %f\n", j, q);
+	  Error ("cdf_get_rand: q out of range %d  %f\n", j, q);
 	}
     }
 
-  x = pdf->x[i] * (1. - q) + pdf->x[i + 1] * q;
-  if (!(pdf->x[0] <= x && x <= pdf->x[pdf->npdf]))
+  x = cdf->x[i] * (1. - q) + cdf->x[i + 1] * q;
+  if (!(cdf->x[0] <= x && x <= cdf->x[cdf->ncdf]))
     {
-      Error ("pdf_get_rand: %g %d %g %g\n", r, i, q, x);
+      Error ("cdf_get_rand: %g %d %g %g\n", r, i, q, x);
     }
   return (x);
 }
@@ -984,7 +970,7 @@ pdf_get_rand (pdf)
 
 
 /* 
-We have defined the pdf in such a way that one can generate a random number 0 and
+We have defined the cdf in such a way that one can generate a random number 0 and
 1, find the place in the y array that corresponds to this and map back onto the 
 x values (which is what is returned. We now want to limit the range of the returned
 x values, but we need to know in terms of the original array where thiese values
@@ -998,86 +984,88 @@ the CDF but we need x too
 
 	06sep	ksl	57i -- Added the xlimits to the pdf
     17jun ksl Modified for variable sizes of distribution function
+	7 Jul nsh Modified to make everything refer to CDFs as they should be
 */
 
 int
-pdf_limit (pdf, xmin, xmax)
-     PdfPtr pdf;
+cdf_limit (cdf, xmin, xmax)
+     CdfPtr cdf;
      double xmin, xmax;
 {
   int i;
   double q;
-  if (pdf->y[pdf->npdf] != 1.0)
+  if (cdf->y[cdf->ncdf] != 1.0)
     {
-      Error ("pdf_limit: pdf not defined!)");
+      Error ("cdf_limit: cdf not defined!)");
       exit (0);
     }
-  if (xmin >= pdf->x[pdf->npdf])
+  if (xmin >= cdf->x[cdf->ncdf])
     {
-      Error ("pdf_limit: xmin %g > pdf->x[pdf->npdf] %g\n", xmin,
-	     pdf->x[pdf->npdf]);
+      Error ("cdf_limit: xmin %g > cdf->x[cdf->ncdf] %g\n", xmin,
+	     cdf->x[cdf->ncdf]);
 //      exit (0);
     }
-  if (xmax <= pdf->x[0])
+  if (xmax <= cdf->x[0])
     {
-      Error ("pdf_limit: xmax %g < pdf->x[0] %g\n", xmax, pdf->x[0]);
+      Error ("cdf_limit: xmax %g < cdf->x[0] %g\n", xmax, cdf->x[0]);
       exit (0);
     }
 
 /* Set the limits for the minimum */
 
-  if (xmin <= pdf->x[0])
+  if (xmin <= cdf->x[0])
     {
-      pdf->limit1 = 0;
-      pdf->x1 = pdf->x[0];
+      cdf->limit1 = 0;
+      cdf->x1 = cdf->x[0];
     }
   else
     {
-      pdf->x1 = xmin;
+      cdf->x1 = xmin;
       i = 0;
-      while (xmin > pdf->x[i])
+      while (xmin > cdf->x[i])
 	{
 	  i++;
 	}
-      q = (xmin - pdf->x[i - 1]) / (pdf->x[i] - pdf->x[i - 1]);
-      pdf->limit1 = pdf->y[i - 1] + q * (pdf->y[i] - pdf->y[i - 1]);
+      q = (xmin - cdf->x[i - 1]) / (cdf->x[i] - cdf->x[i - 1]);
+      cdf->limit1 = cdf->y[i - 1] + q * (cdf->y[i] - cdf->y[i - 1]);
     }
 
 /* Now set the limits for the maximum */
 
-  if (xmax >= pdf->x[pdf->npdf])
+  if (xmax >= cdf->x[cdf->ncdf])
     {
-      pdf->limit2 = 1.0;
-      pdf->x2 = pdf->x[pdf->npdf];
+      cdf->limit2 = 1.0;
+      cdf->x2 = cdf->x[cdf->ncdf];
     }
   else
     {
-      pdf->x2 = xmax;
-      i = pdf->npdf;
-      while (xmax <= pdf->x[i])
+      cdf->x2 = xmax;
+      i = cdf->ncdf;
+      while (xmax <= cdf->x[i])
 	{
 	  i--;
 	}
-      q = (xmax - pdf->x[i]) / (pdf->x[i + 1] - pdf->x[i]);
-      pdf->limit2 = pdf->y[i] + q * (pdf->y[i + 1] - pdf->y[i]);
+      q = (xmax - cdf->x[i]) / (cdf->x[i + 1] - cdf->x[i]);
+      cdf->limit2 = cdf->y[i] + q * (cdf->y[i + 1] - cdf->y[i]);
     }
 
   return (0);
 }
 
 /*
-pdf_get_rand_limit (pdf)
+cdf_get_rand_limit (cdf)
 
 History
 	06sep	ksl	57h -- Modified to account for the fact
 			that the probability density is not 
 			uniform between intervals.
     17jul   ksl Modified for variable lengths of pdfs
+	17jul   nsh Changed terminology to CDF
 
 */
 double
-pdf_get_rand_limit (pdf)
-     PdfPtr pdf;
+cdf_get_rand_limit (cdf)
+     CdfPtr cdf;
 {
   double x, r;
   int i, j;
@@ -1085,18 +1073,18 @@ pdf_get_rand_limit (pdf)
   double a, b, c, s[2];
   int xquadratic ();
   r = rand () / MAXRAND;	/* r must be slightly less than 1 */
-  r = r * pdf->limit2 + (1. - r) * pdf->limit1;
-  i = r * pdf->npdf;
-  while (pdf->y[i + 1] < r && i < pdf->npdf - 1)
+  r = r * cdf->limit2 + (1. - r) * cdf->limit1;
+  i = r * cdf->ncdf;
+  while (cdf->y[i + 1] < r && i < cdf->ncdf - 1)
     i++;
-  while (pdf->y[i] > r && i > 0)
+  while (cdf->y[i] > r && i > 0)
     i--;
   while (TRUE)
     {
       q = rand () / MAXRAND;
-      a = 0.5 * (pdf->d[i + 1] - pdf->d[i]);
-      b = pdf->d[i];
-      c = (-0.5) * (pdf->d[i + 1] + pdf->d[i]) * q;
+      a = 0.5 * (cdf->d[i + 1] - cdf->d[i]);
+      b = cdf->d[i];
+      c = (-0.5) * (cdf->d[i + 1] + cdf->d[i]) * q;
       if ((j = xquadratic (a, b, c, s)) < 0)
 	{
 	  Error ("pdf_get_rand: %d\n", j);
@@ -1106,12 +1094,12 @@ pdf_get_rand_limit (pdf)
 	  q = s[j];
 	  if (q < 0 || q > 1)
 	    {
-	      Error ("pdf_get_rand: q out of range %d  %f\n", j, q);
+	      Error ("cdf_get_rand_limit: q out of range %d  %f\n", j, q);
 	    }
 	}
 
-      x = pdf->x[i] * (1. - q) + pdf->x[i + 1] * q;
-      if (pdf->x1 < x && x < pdf->x2)
+      x = cdf->x[i] * (1. - q) + cdf->x[i + 1] * q;
+      if (cdf->x1 < x && x < cdf->x2)
 	break;
     }
 
@@ -1129,8 +1117,8 @@ a file
 */
 
 int
-pdf_to_file (pdf, filename)
-     PdfPtr pdf;
+cdf_to_file (cdf, filename)
+     CdfPtr cdf;
      char filename[];
 {
   FILE *fopen (), *fptr;
@@ -1138,16 +1126,16 @@ pdf_to_file (pdf, filename)
   fptr = fopen (filename, "w");
   fprintf (fptr,
 	   "# limits (portion.to.sample)   %10.4g %10.4g\n",
-	   pdf->limit1, pdf->limit2);
+	   cdf->limit1, cdf->limit2);
   fprintf (fptr,
 	   "# x1 x2  Range(to.be.returned) %10.4g %10.4g\n",
-	   pdf->x1, pdf->x2);
-  fprintf (fptr, "# norm   Scale.factor          %10.4g \n", pdf->norm);
+	   cdf->x1, cdf->x2);
+  fprintf (fptr, "# norm   Scale.factor          %10.4g \n", cdf->norm);
   fprintf (fptr, "#n x y  1-y d\n");
-  for (n = 0; n <= pdf->npdf; n++)
+  for (n = 0; n <= cdf->ncdf; n++)
     fprintf (fptr,
 	     "%3d %14.8e	%14.8e %14.8e  %14.8e\n",
-	     n, pdf->x[n], pdf->y[n], 1. - pdf->y[n], pdf->d[n]);
+	     n, cdf->x[n], cdf->y[n], 1. - cdf->y[n], cdf->d[n]);
   fclose (fptr);
   return (0);
 }
@@ -1170,89 +1158,89 @@ pdf_to_file (pdf, filename)
  */
 
 int
-pdf_check (pdf)
-     PdfPtr pdf;
+cdf_check (cdf)
+     CdfPtr cdf;
 {
   int n;
   double x, y;
   int hcheck, icheck, jcheck, kcheck, fcheck;
   hcheck = icheck = jcheck = kcheck = fcheck = 0;
-  x = pdf->x[0];
-  y = pdf->y[0];
+  x = cdf->x[0];
+  y = cdf->y[0];
   if (y != 0.0)
     {
       Error
-	("pdf_check: cumulative distribution function should start at 0 not %e\n",
+	("cdf_check: cumulative distribution function should start at 0 not %e\n",
 	 y);
       hcheck = 1;
     }
-  if (pdf->y[pdf->npdf] != 1.0)
+  if (cdf->y[cdf->ncdf] != 1.0)
     {
       Error
-	("pdf_check: cumulative distribution function should end at 1 not %e\n",
-	 pdf->y[pdf->npdf - 1]);
+	("cdf_check: cumulative distribution function should end at 1 not %e\n",
+	 cdf->y[cdf->ncdf - 1]);
       icheck = 1;
     }
 
-  for (n = 1; n < pdf->npdf + 1; n++)
+  for (n = 1; n < cdf->ncdf + 1; n++)
     {
       // Note the equal sign here 
-      if (x <= pdf->x[n])
-	x = pdf->x[n];
+      if (x <= cdf->x[n])
+	x = cdf->x[n];
       else
 	{
 	  jcheck = 1;
-	  Error ("pdf_check: x problem n %d x %f pdf->x[n] %f\n", n,
-		 x, pdf->x[n]);
+	  Error ("cdf_check: x problem n %d x %f pdf->x[n] %f\n", n,
+		 x, cdf->x[n]);
 	}
       // Note the equal sign here 
-      if (y <= pdf->y[n])
-	y = pdf->y[n];
+      if (y <= cdf->y[n])
+	y = cdf->y[n];
       else
 	{
 	  kcheck = 1;
-	  Error ("pdf_check: y problem n %d y %f pdf->y[n] %f\n", n,
-		 y, pdf->y[n]);
+	  Error ("cdf_check: y problem n %d y %f pdf->y[n] %f\n", n,
+		 y, cdf->y[n]);
 	}
     }
   if (jcheck == 1)
     {
-      Error ("pdf_check: x values in pdf should be monotonic\n");
+      Error ("cdf_check: x values in pdf should be monotonic\n");
     }
   if (kcheck == 1)
     {
       Error
-	("pdf_check: cumulative distribution function should be monotonic\n");
+	("cdf_check: cumulative distribution function should be monotonic\n");
     }
 
   if (hcheck != 0 || icheck != 0 || jcheck != 0 || kcheck != 0)
     {
-      pdf_to_file (pdf, "pdf.diag");
+      cdf_to_file (cdf, "cdf.diag");
       fcheck = hcheck * 1000 + icheck * 100 + jcheck * 10 + kcheck;
-      Error ("pdf_check %d %d %d %d %d\n", fcheck, hcheck,
+      Error ("cdf_check %d %d %d %d %d\n", fcheck, hcheck,
 	     icheck, jcheck, kcheck);
     }
 
-/* Next section is a dangerous attempt to repair the pdf  */
+/* Next section is a dangerous attempt to repair the cdf  */
 
   if (hcheck != 0)
-    pdf->y[0] = 0.0;
+    cdf->y[0] = 0.0;
   if (icheck != 0)
-    pdf->y[pdf->npdf] = 1.0;
+    cdf->y[cdf->ncdf] = 1.0;
   if (jcheck != 0)
     {
-      for (n = 0; n < pdf->npdf; n++)
+      for (n = 0; n < cdf->ncdf; n++)
 	{
-	  if (pdf->x[n] >= pdf->x[n + 1])
-	    pdf->x[n + 1] = pdf->x[n] + 1.e-20;
+	  if (cdf->x[n] >= cdf->x[n + 1])
+	    cdf->x[n + 1] = cdf->x[n] + 1.e-20;
 	}
     }
   if (kcheck != 0)
     {
-      for (n = 0; n < pdf->npdf; n++)
+      for (n = 0; n < cdf->ncdf; n++)
 	{
-	  if (pdf->y[n] >= pdf->y[n] + 1)
-	    pdf->y[n + 1] = pdf->y[n] + 1.e-20;
+	  if (cdf->y[n] >= cdf->y[n] + 1)
+	    cdf->y[n + 1] = cdf->y[n] + 1.e-20;
 	}
     }
 
@@ -1264,7 +1252,7 @@ pdf_check (pdf)
                 Space Telescope Science Institute
                                                                                              
 Synopsis:
-	recalc_pdf_from_cdf(pdf)
+	calc_cdf_gradient(cdf)
                                                                                              
 Arguments:
                                                                                              
@@ -1272,7 +1260,7 @@ Returns:
                                                                                              
 Description:
 
-	Calculate the pdf form a cdf 
+	Calculate the gradient of a cdf at each point
 	allow one to calculate a first order correction
 	to a uniform distibution between the points
 	where the gradient has been calculated.
@@ -1289,54 +1277,55 @@ History:
 			within a pdf interval.
 	06nov	ksl	58b: Fixed problem occuring when there
 			were two points in cdf with same x
+	17jul	nsh modified name to better relfect what it does
                                                                                              
 **************************************************************/
 
 int
-recalc_pdf_from_cdf (pdf)
-     PdfPtr pdf;
+calc_cdf_gradient (cdf)
+     CdfPtr cdf;
 {
   int n, istat;
   double dx1, dx2, dy1, dy2;
 
   istat = 0;
-  for (n = 1; n < pdf->npdf; n++)
+  for (n = 1; n < cdf->ncdf; n++)
     {
-      dy1 = pdf->y[n] - pdf->y[n - 1];
-      dx1 = pdf->x[n] - pdf->x[n - 1];
-      dy2 = pdf->y[n + 1] - pdf->y[n];
-      dx2 = pdf->x[n + 1] - pdf->x[n];
+      dy1 = cdf->y[n] - cdf->y[n - 1];
+      dx1 = cdf->x[n] - cdf->x[n - 1];
+      dy2 = cdf->y[n + 1] - cdf->y[n];
+      dx2 = cdf->x[n + 1] - cdf->x[n];
       if (dx1 != 0.0 && dx2 != 0.0)
 	{
-	  pdf->d[n] = 0.5 * (dy1 / dx1 + dy2 / dx2);
+	  cdf->d[n] = 0.5 * (dy1 / dx1 + dy2 / dx2);
 	}
       else if (dx1 != 0.0)
 	{
-	  pdf->d[n] = dy1 / dx1;
+	  cdf->d[n] = dy1 / dx1;
 	}
       else if (dx2 != 0.0)
 	{
-	  pdf->d[n] = dy2 / dx2;
+	  cdf->d[n] = dy2 / dx2;
 	}
       else
 	{
-	  pdf->d[n] = 0.0;
+	  cdf->d[n] = 0.0;
 	  Error
-	    ("recalc_pdf_from_cdf: dx1 and dx2 both 0 at  %3d %11.6e\n", n,
-	     pdf->x[n]);
+	    ("calc_cdf_gradient: dx1 and dx2 both 0 at  %3d %11.6e\n", n,
+	     cdf->x[n]);
 	  istat = 1;
 	}
 
     }
   /* Fill in the ends */
-  pdf->d[0] = pdf->d[1];
-  pdf->d[pdf->npdf] = pdf->d[pdf->npdf - 1];
+  cdf->d[0] = cdf->d[1];
+  cdf->d[cdf->ncdf] = cdf->d[cdf->ncdf - 1];
   return (istat);
 }
 
 
 int
-pdf_array_fixup (x, y, n_xy)
+cdf_array_fixup (x, y, n_xy)
      double *x, *y;
      int n_xy;
 {
@@ -1374,6 +1363,11 @@ pdf_array_fixup (x, y, n_xy)
         m++;
       }
     }
+	free(order);
+	free(xx);
+	free(yy);
+		
+		
 
   return(m);
 }

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -653,7 +653,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
     }
   /* OK, all the input data seems OK, by which we maen that we have checked that the pdf is positive */
 
-
+  if (6e15 < xmin && xmin < 7e15)
+{
+	for (n=0;n<n_xy;n++)
+		printf ("AFTER_CHECKS n %i x %e y %e\n",n,x[n],y[n]);
+}
 
   /* Now modify x so that there is a value of x that corresponds to each value of njump.  We make the
    * assumption that the jump is a positive jump, and so we want everthing up to this point to reflect
@@ -676,6 +680,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
     }
 
 
+  if (6e15 < xmin && xmin < 7e15)
+{
+	for (n=0;n<n_xy;n++)
+		printf ("AFTER_JUMP_MOD n %i x %e y %e\n",n,x[n],y[n]);
+}
 
 
   /* The next two checks look to see if there is a part of the CDF that is all zeros as the start or end of the distribution
@@ -702,8 +711,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 
   //xmin and xmax now bracket the non zero parts of the input array
 
-
-
+  if (6e15 < xmin && xmin < 7e15)
+{
+	for (n=0;n<n_xy;n++)
+		printf ("AFTER_ZERO_MOD n %i x %e y %e\n",n,x[n],y[n]);
+}
 
 /* Shuffle x and y into pdf_xx and pdf_yy allowing for xmin and xmax */
 
@@ -769,9 +781,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
 	}
       pdf_n++;
 
-
-
-
+	  if (6e15 < xmin && xmin < 7e15)
+  {
+  	for (n=0;n<pdf_n;n++)
+  		printf ("AFTER_SHUFFLE n %i x %e y %e\n",n,pdf_x[n],pdf_y[n]);
+}
 
 
 /* So at this point, have probability density in pdf_x, pdf_y for the points
@@ -795,8 +809,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
    the input array, or more explicitly, at the points specied in the array
    pdf_x
 */
-
-
+	  if (6e15 < xmin && xmin < 7e15)
+  {
+    	for (n=0;n<pdf_n;n++)
+    		printf ("CDF n %i x %e y %e\n",n,pdf_x[n],pdf_z[n]);
+	}
 
       /* Add a check that the pdf_z is monotonic. This check should not really be necessary
        * since by construction this should be the case*/
@@ -841,7 +858,7 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   j = njump_min;		// j refers to the jump points
   m = 0;			//m referest to points in pdf_x and pdf_y
   nn = 1;			// nn refers to the non_jump points
-  for (n = 1; n < NPDF && m < n_xy; n++)
+  for (n = 1; n < NPDF && m < pdf_n; n++)
     {
       ysum = ((double) nn) / (NPDF);	/* This is the target with no jumps */
 
@@ -863,6 +880,9 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
       m++;			/* This assures that no two points will be the same x value */
       nn++;
     }
+	
+	
+
 
 
   pdf->npdf = nn;
@@ -871,7 +891,11 @@ pdf_gen_from_array (pdf, x, y, n_xy, xmin, xmax, njumps, jump)
   pdf->norm = sum;		/* The normalizing factor that would convert the function we
 				   have been given into a proper probability density function */
 
-
+	  if (6e15 < xmin && xmin < 7e15)
+  {
+  	for (n=0;n<NPDF;n++)
+  		printf ("PDF n %i x %e y %e\n",n,pdf->x[n],pdf->y[n]);
+}
 
 
 /* Calculate the gradients */

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -800,11 +800,7 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax, njumps, jump)
    the input array, or more explicitly, at the points specied in the array
    pdf_x
 */
-	  if (6e15 < xmin && xmin < 7e15)
-  {
-    	for (n=0;n<pdf_n;n++)
-    		printf ("CDF n %i x %e y %e\n",n,pdf_x[n],pdf_z[n]);
-	}
+
 
       /* Add a check that the pdf_z is monotonic. This check should not really be necessary
        * since by construction this should be the case*/

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -189,6 +189,7 @@ History:
 #include "atomic.h"
 #include "python.h"
 #include <gsl/gsl_sort.h>
+#include <gsl/gsl_interp.h>
 
 
 /*  The structure is defined in python.h.  Here for reference only */
@@ -930,17 +931,21 @@ cdf_get_rand (cdf)
      CdfPtr cdf;
 {
   double x, r;
-  int i, j;
+  int i, j,i1;
   double q;
   double a, b, c, s[2];
   int xquadratic ();
 /* Find the interval within which x lies */
   r = rand () / MAXRAND;	/* r must be slightly less than 1 */
-  i = r * cdf->ncdf;		/* so i initially lies between 0 and the size of the pdf array -1 */
-  while (cdf->y[i + 1] < r && i < cdf->ncdf - 1)
-    i++;
-  while (cdf->y[i] > r && i > 0)
-    i--;
+//  i = r * cdf->ncdf;		/* so i initially lies between 0 and the size of the pdf array -1 */
+//  while (cdf->y[i + 1] < r && i < cdf->ncdf - 1)
+//    i++;
+//  while (cdf->y[i] > r && i > 0)
+//    i--;
+  
+    i=gsl_interp_bsearch(cdf->y,r,0,cdf->ncdf);
+  
+  
 /* Now calculate a place within that interval */
   q = rand () / MAXRAND;
   a = 0.5 * (cdf->d[i + 1] - cdf->d[i]);

--- a/source/pdf.c
+++ b/source/pdf.c
@@ -188,6 +188,7 @@ History:
 
 #include "atomic.h"
 #include "python.h"
+#include "models.h"
 #include <gsl/gsl_sort.h>
 #include <gsl/gsl_interp.h>
 
@@ -931,7 +932,7 @@ cdf_get_rand (cdf)
      CdfPtr cdf;
 {
   double x, r;
-  int i, j,i1;
+  int i, j;
   double q;
   double a, b, c, s[2];
   int xquadratic ();
@@ -1376,3 +1377,94 @@ cdf_array_fixup (x, y, n_xy)
 
   return(m);
 }
+
+int
+	calloc_cdf()
+{
+	int i;
+	int iprob;
+	
+	iprob=0;
+/* Allocate CDFs arrays for free free photon generation */
+	
+    if ((cdf_ff.x = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	if ((cdf_ff.y = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;  
+	if ((cdf_ff.d = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	
+/* Allocate CDF arrays for recombination photon generation */	
+	
+	if ((cdf_fb.x = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	if ((cdf_fb.y = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;  
+	if ((cdf_fb.d = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	
+	
+/* Allocate CDF arrays for isotropic photon generation */	
+	
+	if ((cdf_vcos.x = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	if ((cdf_vcos.y = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;  
+	if ((cdf_vcos.d = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	
+	
+/* Allocate CDF arrays for blackbody photon generation */	
+	
+	if ((cdf_bb.x = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	if ((cdf_bb.y = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;  
+	if ((cdf_bb.d = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	
+/* Allocate CDF arrays for bremsrahlumnf  photon generation */	
+	
+	if ((cdf_brem.x = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	if ((cdf_brem.y = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;  
+	if ((cdf_brem.d = calloc (sizeof (double), NCDF+1)) == NULL)
+		iprob++;
+	
+	
+/* Allocate CDF arrays for stellar atmoshperes models */	
+		
+	for (i=0;i<NCOMPS;i++)
+	{
+		if ((comp[i].xcdf.x = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;
+		if ((comp[i].xcdf.y = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;  
+		if ((comp[i].xcdf.d = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;
+	}
+		
+/* Allocate CDF arrays for aniostropic scattering */
+		
+	for (i=0;i<100;i++)
+	{
+		if ((cdf_randwind_store[i].x = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;
+		if ((cdf_randwind_store[i].y = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;  
+		if ((cdf_randwind_store[i].d = calloc (sizeof (double), NCDF+1)) == NULL)
+			iprob++;
+	}
+		
+		
+		
+		
+
+			return(iprob);
+		
+	
+	
+}
+
+

--- a/source/python.c
+++ b/source/python.c
@@ -729,6 +729,11 @@ main (argc, argv)
     }
   }
 
+  /* Allocate arrays for various CDFs */
+  
+  calloc_cdf();
+
+
 
   /* Next line finally defines the wind if this is the initial time this model is being run */
 

--- a/source/python.h
+++ b/source/python.h
@@ -1181,13 +1181,13 @@ properly create the CDF, this was added for python_43.2  */
  
  /* NSH 17/7 - Structure renamed to reflect the fact that this is a CDF, also made dynamically allocated */
  
-#define NCDF 2000
+#define NCDF 200 //The default size for these arrays
  
  typedef struct Cdf
  {
-   double x[NCDF+1];           /* Positions for which the CDF is calculated */
-   double y[NCDF+1];           /* The value of the CDF at x */
-   double d[NCDF+1];           /* 57i -- the rate of change of the CDF at x */
+   double *x;           /* Positions for which the CDF is calculated */
+   double *y;           /* The value of the CDF at x */
+   double *d;           /* 57i -- the rate of change of the CDF at x */
    double limit1, limit2;        /* Limits (running from 0 to 1) that define a portion
                                     of the CDF to sample */
    double x1, x2;                /* limits if they exist on what is returned */
@@ -1195,6 +1195,13 @@ properly create the CDF, this was added for python_43.2  */
    int ncdf;                     /* Size of this CDF */
  }
   *CdfPtr, cdf_dummy; 
+  
+  struct Cdf cdf_ff; 
+  struct Cdf cdf_fb; 
+  struct Cdf cdf_vcos;
+  struct Cdf cdf_bb;
+  struct Cdf cdf_brem;
+  
  
 
 

--- a/source/python.h
+++ b/source/python.h
@@ -1181,7 +1181,7 @@ properly create the CDF, this was added for python_43.2  */
  
  /* NSH 17/7 - Structure renamed to reflect the fact that this is a CDF, also made dynamically allocated */
  
-#define NCDF 200
+#define NCDF 2000
  
  typedef struct Cdf
  {

--- a/source/python.h
+++ b/source/python.h
@@ -1160,22 +1160,42 @@ generated from a function which is usually only proportional to the probability 
 function.  It is sometimes useful, e.g. in calculating the reweighting function to
 have access to the proper normalization.  Since the one needs the normalization to
 properly create the CDF, this was added for python_43.2  */
-#define NPDF 200
 
-typedef struct Pdf
-{
-  double x[NPDF + 1];           /* Positions for which the probability density
-                                   is calculated */
-  double y[NPDF + 1];           /* The value of the CDF at x */
-  double d[NPDF + 1];           /* 57i -- the rate of change of the probability
-                                   density at x */
-  double limit1, limit2;        /* Limits (running from 0 to 1) that define a portion
-                                   of the CDF to sample */
-  double x1, x2;                /* limits if they exist on what is returned */
-  double norm;                  //The scaling factor which would renormalize the pdf
-  int npdf;                     /* Size of this pdf */
-}
- *PdfPtr, pdf_dummy;
+//#define NPDF 200
+
+//typedef struct Pdf
+//{
+//  double x[NPDF + 1];           /* Positions for which the probability density
+//                                   is calculated */
+//  double y[NPDF + 1];           /* The value of the CDF at x */
+//  double d[NPDF + 1];           /* 57i -- the rate of change of the probability
+//                                   density at x */
+//  double limit1, limit2;        /* Limits (running from 0 to 1) that define a portion
+//                                   of the CDF to sample */
+//  double x1, x2;                /* limits if they exist on what is returned */
+//  double norm;                  //The scaling factor which would renormalize the pdf
+//  int npdf;                     /* Size of this pdf */
+//}
+// *PdfPtr, pdf_dummy;
+ 
+ 
+ /* NSH 17/7 - Structure renamed to reflect the fact that this is a CDF, also made dynamically allocated */
+ 
+#define NCDF 200
+ 
+ typedef struct Cdf
+ {
+   double x[NCDF+1];           /* Positions for which the CDF is calculated */
+   double y[NCDF+1];           /* The value of the CDF at x */
+   double d[NCDF+1];           /* 57i -- the rate of change of the CDF at x */
+   double limit1, limit2;        /* Limits (running from 0 to 1) that define a portion
+                                    of the CDF to sample */
+   double x1, x2;                /* limits if they exist on what is returned */
+   double norm;                  //The scaling factor which would renormalize the CDF
+   int ncdf;                     /* Size of this CDF */
+ }
+  *CdfPtr, cdf_dummy; 
+ 
 
 
 /* Variable used to allow something to be printed out the first few times
@@ -1198,11 +1218,11 @@ FILE *epltptr;                  //TEST
 /* Allow for the transfer of tau info to scattering routine */
 
 
-struct Pdf pdf_randwind_store[100];
-PdfPtr pdf_randwind;
+struct Cdf cdf_randwind_store[100];
+CdfPtr cdf_randwind;
 struct photon phot_randwind;
 
-/* N.B. pdf_randwind and phot_randwind are used in the routine anisowind for 
+/* N.B. cdf_randwind and phot_randwind are used in the routine anisowind for 
 as part of effort to incorporate anisotropic scattering in to python.  
 Added for python_43.2 */
 

--- a/source/random.c
+++ b/source/random.c
@@ -63,7 +63,7 @@ History:
 
 double zzz[] = { 0.0, 0.0, 1.0 };
 
-struct Cdf cdf_vcos;
+
 int init_vcos = 0;
 
 int
@@ -75,9 +75,9 @@ randvcos (lmn, north)
   double q, jumps[5];
 // double s;
   struct basis nbasis;
-  int echeck, pdf_gen_from_func ();
+  int echeck, cdf_gen_from_func ();
   int create_basis (), project_from ();
-  double vcos (), pdf_get_rand ();
+  double vcos (), cdf_get_rand ();
   double phi;
 
   if (init_vcos == 0)

--- a/source/random.c
+++ b/source/random.c
@@ -63,7 +63,7 @@ History:
 
 double zzz[] = { 0.0, 0.0, 1.0 };
 
-struct Pdf pdf_vcos;
+struct Cdf cdf_vcos;
 int init_vcos = 0;
 
 int
@@ -88,16 +88,16 @@ randvcos (lmn, north)
     jumps[3] = 0.06976;
     jumps[4] = 0.08716;
 
-    if ((echeck = pdf_gen_from_func (&pdf_vcos, &vcos, 0., 1., 5, jumps)) != 0)
+    if ((echeck = cdf_gen_from_func (&cdf_vcos, &vcos, 0., 1., 5, jumps)) != 0)
 //old ksl 04mar  pdf_gen_from_func (&pdf_vcos, &vcos, 0., 1., 5, &jumps)) != 0)
     {
-      Error ("Randvcos: return from pdf_gen_from_func %d\n", echeck);;
+      Error ("Randvcos: return from cdf_gen_from_func %d\n", echeck);;
     }
     init_vcos = 1;
   }
 
 
-  n = pdf_get_rand (&pdf_vcos);
+  n = cdf_get_rand (&cdf_vcos);
   q = sqrt (1. - n * n);
 
 //  The next set of lines are all wrong

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -645,6 +645,15 @@ use that instead if possible --  57h */
 	
 	/* At this point, the variable nnn stores the number of points */
 	
+	
+  if (6e15 < f1 && f1 < 7e15)
+{
+	for (n=0;n<nnn+2;n++)
+		printf ("recomb %i x %e y %e\n",n,fb_x[n],fb_y[n]);
+}
+
+
+printf ("RECOMB GENERATION");
 
     if (pdf_gen_from_array (&pdf_fb, fb_x, fb_y, nnn, f1, f2, fb_njumps, fb_jumps) != 0)
     {

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -508,6 +508,7 @@ total_fb (one, t, f1, f2, fb_choice, mode)
 			the same conditions.  This reduces very significantly
 			the number of times one has to construct a pdf, which is
 			the main time sink for the program
+	17jul	NSH - changed references from PDF to CDF
                                                                                                    
  ************************************************************************/
 
@@ -518,7 +519,7 @@ double xfb_jumps[NLEVELS];     // This is just a dummy array that parallels fb_j
 int fb_njumps = (-1);
 
 WindPtr ww_fb;
-struct Pdf pdf_fb;
+struct Cdf cdf_fb;
 double one_fb_f1, one_fb_f2, one_fb_te; /* Old values */
 
 double
@@ -555,12 +556,12 @@ use that instead if possible --  57h */
     return (freq);
   }
 
-  delta = 500;                  // Fudge factor to prevent generation a photon if t has changed only slightly
-  /* Check to see if we have already generated a pdf */
+  delta = 500;                  // Fudge factor to prevent generation of a CDF if t has changed only slightly
+  /* Check to see if we have already generated a cdf */
   if (tt > (one_fb_te + delta) || tt < (one_fb_te - delta) || f1 != one_fb_f1 || f2 != one_fb_f2)
   {
 
-/* Then need to generate a new pdf */
+/* Then need to generate a new cdf */
 
     ww_fb = one;
 
@@ -586,7 +587,7 @@ use that instead if possible --  57h */
 
       /* The next line sorts the fb_jumps by frequency and eliminates
        * duplicate frequencies which is what was causing the error in
-       * pdf.c when more than one jump was intended
+       * cdf.c when more than one jump was intended
        */
 
 	  if (fb_njumps > 1) //We only need to sort and compress if we have more than one jump
@@ -646,16 +647,11 @@ use that instead if possible --  57h */
 	/* At this point, the variable nnn stores the number of points */
 	
 	
-  if (6e15 < f1 && f1 < 7e15)
-{
-	for (n=0;n<nnn+2;n++)
-		printf ("recomb %i x %e y %e\n",n,fb_x[n],fb_y[n]);
-}
 
 
 printf ("RECOMB GENERATION");
 
-    if (pdf_gen_from_array (&pdf_fb, fb_x, fb_y, nnn, f1, f2, fb_njumps, fb_jumps) != 0)
+    if (cdf_gen_from_array (&cdf_fb, fb_x, fb_y, nnn, f1, f2, fb_njumps, fb_jumps) != 0)
     {
       Error ("one_fb after error: f1 %g f2 %g te %g ne %g nh %g vol %g\n",
              f1, f2, xplasma->t_e, xplasma->ne, xplasma->density[1], one->vol);
@@ -664,16 +660,16 @@ printf ("RECOMB GENERATION");
     }
     one_fb_te = xplasma->t_e;
     one_fb_f1 = f1;
-    one_fb_f2 = f2;             /* Note that this may not be the best way to check for a previous pdf */
+    one_fb_f2 = f2;             /* Note that this may not be the best way to check for a previous cdf */
   }
 
-/* OK, we have not created a new pdf, cdf actually.  We are in a position to
+/* OK, we have not created a new cdf actually.  We are in a position to
 generate photons */
 
   //Debug ("one_fb, got here 2\n");
 
 /* First generate the photon we need */
-  freq = pdf_get_rand (&pdf_fb);
+  freq = cdf_get_rand (&cdf_fb);
   if (freq<f1 || freq > f2) {
       Error("one_fb:  freq %e  freqmin %e freqmax %e out of range\n",freq,f1,f2);
   }
@@ -682,7 +678,7 @@ generate photons */
 
   for (n = 0; n < NSTORE; n++)
   {
-    xphot->freq[n] = pdf_get_rand (&pdf_fb);
+    xphot->freq[n] = cdf_get_rand (&cdf_fb);
   if (xphot->freq[n]<f1 || xphot->freq[n] > f2) {
       Error("one_fb:  freq %e  freqmin %e freqmax %e out of range\n",xphot->freq[n],f1,f2);
   }

--- a/source/templates.h
+++ b/source/templates.h
@@ -141,16 +141,16 @@ int spec_read(char filename[]);
 int extract(WindPtr w, PhotPtr p, int itype);
 int extract_one(WindPtr w, PhotPtr pp, int itype, int nspec);
 /* pdf.c */
-int pdf_gen_from_func(PdfPtr pdf, double (*func)(double), double xmin, double xmax, int njumps, double jump[]);
+int cdf_gen_from_func(CdfPtr cdf, double (*func)(double), double xmin, double xmax, int njumps, double jump[]);
 double gen_array_from_func(double (*func)(double), double xmin, double xmax, int pdfsteps);
-int pdf_gen_from_array(PdfPtr pdf, double x[], double y[], int n_xy, double xmin, double xmax, int njumps, double jump[]);
-double pdf_get_rand(PdfPtr pdf);
-int pdf_limit(PdfPtr pdf, double xmin, double xmax);
-double pdf_get_rand_limit(PdfPtr pdf);
-int pdf_to_file(PdfPtr pdf, char filename[]);
-int pdf_check(PdfPtr pdf);
-int recalc_pdf_from_cdf(PdfPtr pdf);
-int pdf_array_fixup(double *x, double *y, int n_xy);
+int cdf_gen_from_array(CdfPtr cdf, double x[], double y[], int n_xy, double xmin, double xmax, int njumps, double jump[]);
+double cdf_get_rand(CdfPtr cdf);
+int cdf_limit(CdfPtr cdf, double xmin, double xmax);
+double cdf_get_rand_limit(CdfPtr cdf);
+int cdf_to_file(CdfPtr cdf, char filename[]);
+int cdf_check(CdfPtr cdf);
+int calc_cdf_gradient(CdfPtr cdf);
+int cdf_array_fixup(double *x, double *y, int n_xy);
 /* roche.c */
 int binary_basics(void);
 double ds_to_roche_2(PhotPtr p);
@@ -288,7 +288,7 @@ int reposition(PhotPtr p);
 int randwind(PhotPtr p, double lmn[3], double north[3]);
 double vrandwind(double x);
 double reweightwind(PhotPtr p);
-int make_pdf_randwind(double tau);
+int make_cdf_randwind(double tau);
 int randwind_thermal_trapping(PhotPtr p, int *nnscat);
 /* util.c */
 int fraction(double value, double array[], int npts, int *ival, double *f, int mode);

--- a/source/templates.h
+++ b/source/templates.h
@@ -151,6 +151,7 @@ int cdf_to_file(CdfPtr cdf, char filename[]);
 int cdf_check(CdfPtr cdf);
 int calc_cdf_gradient(CdfPtr cdf);
 int cdf_array_fixup(double *x, double *y, int n_xy);
+int calloc_cdf(void);
 /* roche.c */
 int binary_basics(void);
 double ds_to_roche_2(PhotPtr p);

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -309,6 +309,7 @@ define_wind ()
   /* Allocate space for the plasma arrays */
 
   calloc_plasma (NPLASMA);
+  printf ("GOING TO CALLOC PLASMA\n");
   calloc_dyn_plasma (NPLASMA);  /*78a NSH 1407 - allocate space for dynamically sized arrays */
   create_maps (CHOICE);         /* Populate the maps from plasmamain & wmain */
 


### PR DESCRIPTION
First pull request of the project to overhaul the calculation of CDFs in python. This pull includes:

Renaming of all pdf routines and variables to cdf - which is what they are
Conversion of cdfs to dynamic allocation. In this pull, all that happens is that they are all dynamically allocated to have length NCDF (in python.h). This happens in python.c, just after the cones are set up. It should happen for all runs, wether restarts or from scratch. The new subroutine that does it is calloc_cdf (in pdf.c - yes, I need to rename this file!)

Initial tests suggest all is well, but these changes affect huge sections of the code.