### PR TITLE
Changes in continuum.c and cdf.c to allow the code to deal with continuum models

### DIFF
--- a/source/bb.c
+++ b/source/bb.c
@@ -625,11 +625,18 @@ emittance_bb (freqmin, freqmax, t)
   
   
   
-  if (alphamin > ALPHAMIN && alphamax < ALPHAMAX) 
+  if (alphamin > ALPHAMIN && alphamax < ALPHAMAX) //We are within the tabulated range
   {
     return (q1 * t * t * t * t * integ_planck_d (alphamin, alphamax));
   }
-  else
+  else if (alphamax > ALPHABIG) 
+  {
+	  if (alphamin > ALPHABIG) //The whole band is above the poitn where we can sensibly integrate the BB function
+	  	return(0);
+	  else   //only the upper part of the band is above ALPHABIG
+	      return (q1 * t * t * t * t * qromb (planck_d, alphamin, ALPHABIG, 1e-7));
+  }
+  else //We are outside the tabulated range and must integrate
   {
     return (q1 * t * t * t * t * qromb (planck_d, alphamin, alphamax, 1e-7));
   }

--- a/source/bb.c
+++ b/source/bb.c
@@ -163,6 +163,7 @@ History:
 	12nov	ksl	Removed some of the old Notes assocaited with this routine.
 			See version earlier than 74 for these old notes.
 	17jul	nsh - changed references to PDFs to CDFs
+    17jul 	nsh - also changed how the BB cdf is generated - low alpha jumps were not really doing anything!
 **************************************************************/
 
 #define ALPHAMIN 0.4            // Region below which we will use a low frequency approximation
@@ -607,7 +608,7 @@ planck_d (alpha)
 // Calculate the emittance of a bb between freqmin and freqmax
 // Should integrate to sigma 
 
-//NSH - 17Jul - made change to if/else statement so that qromb used whenever bounds are not completely withing the tabulated bands.
+//NSH - 17Jul - made change to if/else statement so that qromb used whenever bounds are not completely within the tabulated bands.
 double
 emittance_bb (freqmin, freqmax, t)
      double freqmin, freqmax, t;
@@ -631,7 +632,7 @@ emittance_bb (freqmin, freqmax, t)
   }
   else if (alphamax > ALPHABIG) 
   {
-	  if (alphamin > ALPHABIG) //The whole band is above the poitn where we can sensibly integrate the BB function
+	  if (alphamin > ALPHABIG) //The whole band is above the point where we can sensibly integrate the BB function
 	  	return(0);
 	  else   //only the upper part of the band is above ALPHABIG
 	      return (q1 * t * t * t * t * qromb (planck_d, alphamin, ALPHABIG, 1e-7));

--- a/source/cdf.c
+++ b/source/cdf.c
@@ -569,7 +569,7 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax)
      double xmin, xmax;
 {
   int allzero;
-  int m, n, nn;
+  int m, n;
   double sum, q;
   int echeck,cdf_check (), recalc_pdf_from_cdf ();
 
@@ -624,7 +624,7 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax)
 
   //Now at the end
 
-  nn = n_xy;
+  n = n_xy-1;
   while (y[n] == 0.0)
     {
       xmax = x[n];
@@ -718,7 +718,10 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax)
       sum = pdf_z[pdf_n - 1];
 
       for (n = 1; n < pdf_n; n++)
+	  {
+		  printf ("%e %e\n",pdf_x[n],pdf_z[n]);
 	pdf_z[n] /= sum;
+	  }
 	  
 
 
@@ -781,7 +784,13 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax)
     }				// 57ib 
   if ((echeck = cdf_check (cdf)) != 0)
     {
-      Error ("cdf_gen_from_array: error %d on cdf_check\n", echeck);
+      Error ("cdf_gen_from_array: error %d on cdf_check\n", echeck);	  
+	  for (n=0;n<n_xy;n++)
+		  printf ("pdf_n=%i %e %e\n",pdf_n,x[n],y[n]);
+	  
+	  
+	  
+	  exit(0);
     }
   return (echeck);
 }

--- a/source/cdf.c
+++ b/source/cdf.c
@@ -8,14 +8,14 @@
  	
  	The main routines are
  	
-		pdf_gen_from_func	(&pdf,&func,xmin,xmax,njumps,jump)		
+		cdf_gen_from_func	(&cdf,&func,xmin,xmax,njumps,jump)		
 			Generate a cumulative distrubution function (cdf) from a function
  	          
-		pdf_gen_from_array(&pdf,x,y,n_xy,xmin,xmax,njumps,jump)		
+		cdf_gen_from_array(&cdf,x,y,n_xy,xmin,xmax,njumps,jump)		
 			Generate a cumulative distribution function (cdf) from an
  			array of values
 
-		pdf_get_rand(&pdf)				
+		cdf_get_rand(&cdf)				
 			Generate a single sample from a cdf defined by either of the first
  			two routines 	
  	
@@ -27,10 +27,10 @@
  	pdf.  Note that pdf_gen-from_func or pdf_gen_from_array should have been
  	called previously!
  
-		pdf_limit(&pdf,xmin,xmax)  sets limit1 and limit2 so that one can generate
- 			distributions from a limited range within a previously created pdf.
+		cdf_limit(&pdf,xmin,xmax)  sets limit1 and limit2 so that one can generate
+ 			distributions from a limited range within a previously created cdf.
 
-		pdf_get_rand_limit(&pdf) will samples the pdf but limits the range of
+		cdf_get_rand_limit(&pdf) will samples the cdf but limits the range of
 			the return to lie between xmin and xmax from pdf_limit.
 
 	
@@ -41,18 +41,18 @@
 			number of points.
 
  	There is also a simple diagnostic routine
-		pdf_check(&pdf)
+		cdf_check(&cdf)
 
-	which returns a nonzero number if certain checks of the pdf fail
+	which returns a nonzero number if certain checks of the cdf fail
 	and a routine  
 
-		pdf_to_file(&pdf,filename)				
- 		  	to write a pdf structure to a file
+		cdf_to_file(&cdf,filename)				
+ 		  	to write a cdf structure to a file
 
 
 								
-Arguments for pdf_gen_from_func
-	PdfPtr pdf;		A ptr to a pdf structure (see below)
+Arguments for cdf_gen_from_func
+	CdfPtr cdf;		A ptr to a cdf structure (see below)
 	double (*func)()	The probablility density function to be integrated 
 				to create the pdf
 	double xmin,xmax;	The range over which the function is to be 
@@ -63,32 +63,30 @@ Arguments for pdf_gen_from_func
 				and xmax
 	int njumps;		The size of jumps[]
 
-Arguments for pdf_gen_from_array are same as above except
+Arguments for cdf_gen_from_array are same as above except
  	
-	double x[],y[]		The one dimensional arrays containg the places x where the cumulative 
-				distribution function density has been evaluated.  The array need not 
-				be uniformly spaced. y is the value of the cdf at the point x 
-	double d[]		The rate of change of the probability density at x, which is calculated
-				from the CDF. -- Added 57i
+	double x[],y[]		The one dimensional arrays containg the places x where the probability 
+				density function density has been evaluated.  The array need not 
+				be uniformly spaced. y is the value of the pdf at the point x 
 	int n_xy		The size of x[] and y[]
 
 Arguments for pdf_get_rand
-	PdfPtr pdf		pdf (See below)	is a structure which contains the cumulative
+	CdfPtr cdf		cdf (See below)	is a structure which contains the cumulative
 				distribution function.
 
-Arguments for pdf_limit
-	double xmin,xmax	Here xmin and xmax will cause pdf[].limit1 and pdf[].limit2 to be set
+Arguments for cdf_limit
+	double xmin,xmax	Here xmin and xmax will cause cdf[].limit1 and cdf[].limit2 to be set
 				in such a way that when you call pdf_get_rand_limit the distribution
 				will be sampled only between xmin and xmax.  Watch out though
 				because if xmin and xmax lie outside of the original value of xmin
 				and xmax then the distribution will not extend this far.							
 Arguments for pdf_to_file
-	PdfPtr pdf
+	PdfPtr cdf
 	char filename[]		If you can't figure this out, you are in deep trouble!
 				
 Returns:
-	All of the routines return 0 on successful completion, except pdf_get_rand which returns
-	a random value between xmin and xmax.  Multiple calls to pdf_get_rand should regenerate
+	All of the routines return 0 on successful completion, except cdf_get_rand which returns
+	a random value between xmin and xmax.  Multiple calls to cdf_get_rand should regenerate
 	the probability density function.
 	
 	If there is an error the routines usually send an error message to the screen and logfile
@@ -101,38 +99,36 @@ Description:
 	and then allow one to sample that distribution function.  The procedure is either
 	to call pdf_gen_from_func if you have a function whose probability distribution you
 	want (as might be the case if you were generating bremsstrahlung photons and you knew
-	the formula)  or pdf_gen_from_array (as might be the case if you were trying to
+	the formula)  or cdf_gen_from_array (as might be the case if you were trying to
 	generate Monte Carlo spectra from precalculated Kurucz models).
 	
 	The result of calling either of these routines will be to populate a structure of
-	the form Pdf
-		pdf->x[]  will contain NPDF values of x between xmin and xmax.  The values will be
+	the form Cdf
+		cdf->x[]  will contain NPDF values of x between xmin and xmax.  The values will be
 			spaced so that it is almost but not quite true that if you generate a uniform
 			number n between 0 and NPDF you could just read off the value pdf[n].x and
 			that by doing this multiple times you could regenerate the distribution function
-		pdf->y[]  will contain values between 0 and 1 and is the integral of the cumulative
+		cdf->y[]  will contain values between 0 and 1 and is the integral of the cumulative
 			distribution function from xmin to pdf[].x
 			
-	Once a pdf has been generated, one samples the pdf by calls to pdf_get_rand which 
-	creates a random number between 0 and 1, finds the elements in pdf which surround
+	Once a cdf has been generated, one samples the cdf by calls to cdf_get_rand which 
+	creates a random number between 0 and 1, finds the elements in cdf which surround
 	the random number and interpolates to return a value x. 
 	
 	It is possible to force specific values of x to appear in the pdf.  This is desirable
 	if there are edges where the probability density changes rapidly, as for example
 	at the Lyman edge in a stellar spectrum.  By using jumps properly you can assure
-	that edges will be sharp in the regenerated distribution (since otherwse pdf_get_rand
+	that edges will be sharp in the regenerated distribution (since otherwse cdf_get_rand
 	will linearly interpolate between two points on the opposite sides of the edge).
 
 Notes:
 	Must be compiled with log.c since it makes use of the "python" logging routines for
 	errors.
 
-	The fact that these routines start with pdf... is historical and represents a poor
-	choice of nomenclature.  We reallly mean comulative distribution functions
-
 	It would probably be desirable to modify this so that the size of the parallel 
 	arrays being generated could be determined from inside the program.  In that case
-	NPDF would have to become the maximum size.
+	NPDF would have to become the maximum size. - NSH stis was tried in Jul 2017 - turns
+	out to be very hard!
 
 
 	Error??: For Kurucz models, The probability distribution beyond the He edge  
@@ -142,7 +138,9 @@ Notes:
 	everything down.  This is an another argument that the whole routine pdf_gen_from_array
 	neeeds to be rewritten to avoid using NPDF altogether.  One way to do this
 	would be simply to use the values of x and y in creating an inital pdf.  There
-	is however a question of resampling.
+	is however a question of resampling. - NSH Jul 2017 - this has been addressed
+	by removing the sampling aspect. Turns out with the faster machines we dont
+	need to be so careful about making it easy to find the right point in a CDF.
 	
 
 History:
@@ -180,6 +178,9 @@ History:
 			the number of points that are used in the array pdf_array in situations
 			where the binning is too course.  In the process, eliminated pdf_init.  
 			It was only called by one routine.  
+	17Jul   nsh Modified to make everything refer to CDFs as they should be, also changed
+			cdf_gen_from_array to work on a supplied array - no jumps.
+
  
 **************************************************************/
 
@@ -215,7 +216,7 @@ double *pdf_array;
 
 Description:
 
-This routine stores values of the function in  pdf_array
+This routine stores values of the function in  cdf_array
 
 	02feb	ksl	Modified to handle a problem in which the
 			pdf was not monotonic because of the 
@@ -391,7 +392,7 @@ cdf_gen_from_func (cdf, func, xmin, xmax, njumps, jump)
 gen_array_from_func
 
 
-This is a routine which is called by pdf_gen_from_func which simply calculates the cumulative
+This is a routine which is called by cdf_gen_from_func which simply calculates the cumulative
 distribution of the function in equally spaced steps between xmin and xmax.  The CDF is properly
 normalized.
 
@@ -515,7 +516,7 @@ gen_array_from_func (func, xmin, xmax, pdfsteps)
 
 
 /*  
-pdf_gen_from_array
+cdf_gen_from_array
 
 The one dimensional arrays containg the places x where the probability
 density y has been evaluated.  The array need not be uniformly spaced.  
@@ -525,7 +526,7 @@ one can linearly interpolate between points
 Notes:
 
 
-	06sep -- There are differences between this and pdf_gen_from_func
+	06sep -- There are differences between this and cdf_gen_from_func
 	that look historical -- ksl
 
 
@@ -553,7 +554,7 @@ History:
 			so that problems with this would be easier to update in
 			future.
 	1405	JM -- Increased PDF array for use with disk14 models
-	1707	NSH -- Removed code for jumps - we now just supply asuitable unscaled pdf
+	1707	NSH -- Removed code for jumps - we now just supply a suitable unscaled pdf
 */
 
 #define PDF_ARRAY  28000
@@ -801,7 +802,7 @@ cdf_gen_from_array (cdf, x, y, n_xy, xmin, xmax)
 
 
 /* 
-pdf_get_rand
+cdf_get_rand
 
 
 Our searching routine assumes we can predict roughly where in the
@@ -812,7 +813,8 @@ History:
 	06sep	ksl	57i -- Modified to account for the fact
 			that the probability density is not 
 			uniform between intervals.
-    17jun   ksl Modified for variable sizes of distribution function
+    17jun   ksl Modified for variable sizes of distribution function	
+	17jul	nsh Modified to use gsl routine to find the right point in the CDF.
 */
 
 double
@@ -876,9 +878,8 @@ find that minimum and maximum value. Having done this one can call pdf_get_rand_
 Error Some of this is not quite right.  It's intended to let us generate limits in
 the CDF but we need x too
 
-	06sep	ksl	57i -- Added the xlimits to the pdf
+	06sep	ksl	57i -- Added the xlimits to the cdf
     17jun ksl Modified for variable sizes of distribution function
-	7 Jul nsh Modified to make everything refer to CDFs as they should be
 */
 
 int
@@ -954,7 +955,6 @@ History
 			that the probability density is not 
 			uniform between intervals.
     17jul   ksl Modified for variable lengths of pdfs
-	17jul   nsh Changed terminology to CDF
 
 */
 double
@@ -1158,7 +1158,13 @@ Description:
 	allow one to calculate a first order correction
 	to a uniform distibution between the points
 	where the gradient has been calculated.
-                                                                                             
+                                            
+	XXX NSH - the way that the ends are dealt with is bot
+		great - we should really try to come up with an
+		extrapolation rather than just fill in the same gradients
+		for the second and penultimate cells into the 
+		forst and last cells.
+											 											
 Notes:
 
 	d is calculated by differencing the cdf.  Thus

--- a/source/cdf.c
+++ b/source/cdf.c
@@ -554,7 +554,10 @@ History:
 			so that problems with this would be easier to update in
 			future.
 	1405	JM -- Increased PDF array for use with disk14 models
-	1707	NSH -- Removed code for jumps - we now just supply a suitable unscaled pdf
+	1707	NSH -- Removed code for jumps - we now just supply a suitable unscaled pdf, 
+			The code expects data between xmin and xmax - it scan cope with 
+			leading ro training zeros, but does require at least two non zero
+			points, otherwise it cannt make a CDF.
 */
 
 #define PDF_ARRAY  28000
@@ -710,9 +713,6 @@ nmax--;
     cdf->norm = sum;
 	  
 }
-
-
-
 
 
 /* Calculate the gradients */
@@ -1157,6 +1157,9 @@ calc_cdf_gradient (cdf)
     }
   /* Fill in the ends */
 	  cdf->d[0] = cdf->d[1];
+	  
+	  
+	  //XXX NSH - this routine does not treat the ends of the array very well - it just asumes the same gradient - we could do better...
 	  
 //NSH - a couple of other ways of doing this - linear interpolation from the previous points, or just the gradient of the current interval - none works great.	  
 	  

--- a/source/cdf.c
+++ b/source/cdf.c
@@ -371,9 +371,9 @@ cdf_gen_from_func (cdf, func, xmin, xmax, njumps, jump)
     }				// 57ib 
 	
 	
-	printf ("BLAH %e %e %e\n",cdf->x[0],cdf->y[0],cdf->d[0]);
-	printf ("BLAH %e %e %e\n",cdf->x[1],cdf->y[1],cdf->d[1]);
-	printf ("BLAH %e %e %e\n",cdf->x[2],cdf->y[2],cdf->d[2]);
+//	printf ("BLAH %e %e %e\n",cdf->x[0],cdf->y[0],cdf->d[0]);
+//	printf ("BLAH %e %e %e\n",cdf->x[1],cdf->y[1],cdf->d[1]);
+//	printf ("BLAH %e %e %e\n",cdf->x[2],cdf->y[2],cdf->d[2]);
 	
 	
   /* Check the pdf */

--- a/source/continuum.c
+++ b/source/continuum.c
@@ -89,13 +89,19 @@ one_continuum (spectype, t, g, freqmin, freqmax)
 	  
 	  for (n=0;n<comp[spectype].nwaves;n++)
 	  {
-			  
+//		  printf ("%e %e ",comp[spectype].xmod.w[n],comp[spectype].xmod.f[n]);
 		  if (comp[spectype].xmod.w[n] > lambdamin && comp[spectype].xmod.w[n] <= lambdamax)
 		  {
+//			  printf (" inserted %e %e\n",lambdamin,lambdamax);
 			  w_local[nwave]=comp[spectype].xmod.w[n];
 			  f_local[nwave]=comp[spectype].xmod.f[n];
 			  nwave++;
 		  }
+//		  else
+//		  {
+//		  printf ("\n ");
+//	  		}
+		  
 	  }
 	  
 	  if (comp[spectype].xmod.w[0] < lambdamax && lambdamax < comp[spectype].xmod.w[comp[spectype].nwaves-1])
@@ -105,6 +111,26 @@ one_continuum (spectype, t, g, freqmin, freqmax)
 		  f_local[nwave]=y;
 		  nwave++;
 	  }
+	  
+	  
+	  //There are two pathological cases to deal with, when we only have one non zero point, we need to make an extra point just up/dpown from the penultimate/zecond point so we can make a sensible CDF.
+	  
+	  
+	  if (f_local[nwave-2]==0.0) //We have a zero just inside the end
+	  {
+		  nwave++;
+		  w_local[nwave-1]=w_local[nwave-2];
+		  f_local[nwave-1]=f_local[nwave-2];
+		  w_local[nwave-2]=w_local[nwave-3]/(1.-DELTA_V/(2.*C));
+		  linterp(w_local[nwave-2], comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, &y, 0);
+		  f_local[nwave-2]=y;
+	  }
+	  
+	  
+	  
+	  
+	  
+	  
 //	  printf ("BLAH min %e max %e\n",lambdamin,lambdamax);
 //	  printf ("BLAH wmin %e wmax %e\n",comp[spectype].xmod.w[0],comp[spectype].xmod.w[comp[spectype].nwaves-1]);
 	  

--- a/source/continuum.c
+++ b/source/continuum.c
@@ -65,21 +65,59 @@ one_continuum (spectype, t, g, freqmin, freqmax)
 {
   //OLD not used in routine double par[2];              // For python we assume only two parameter models
   double lambdamin, lambdamax;
-  double f;
+  double w_local[NCDF],f_local[NCDF];
+  double f,y;
   double cdf_get_rand ();
   // int model (), nwav;
   int model ();
+  int n,nwave;
 
   if (old_t != t || old_g != g || old_freqmin != freqmin || old_freqmax != freqmax)
   {                             /* Then we must initialize */
+//	  printf ("Initialising coz %e ne %e or %e ne %e or %e ne %e or %e ne %e\n",old_t,t,old_g,g,old_freqmin,freqmin,old_freqmax,freqmax);
+	  
+      lambdamin = C * 1e8 / freqmax;
+      lambdamax = C * 1e8 / freqmin;
+	  nwave=0;
+	  if (comp[spectype].xmod.w[0] < lambdamin && lambdamin < comp[spectype].xmod.w[comp[spectype].nwaves-1])
+	  {
+		  w_local[nwave]=lambdamin;
+		  linterp(lambdamin, comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, &y, 0);
+		  f_local[nwave]=y;
+		  nwave++;
+	  }
+	  
+	  for (n=0;n<comp[spectype].nwaves;n++)
+	  {
+			  
+		  if (comp[spectype].xmod.w[n] > lambdamin && comp[spectype].xmod.w[n] <= lambdamax)
+		  {
+			  w_local[nwave]=comp[spectype].xmod.w[n];
+			  f_local[nwave]=comp[spectype].xmod.f[n];
+			  nwave++;
+		  }
+	  }
+	  
+	  if (comp[spectype].xmod.w[0] < lambdamax && lambdamax < comp[spectype].xmod.w[comp[spectype].nwaves-1])
+	  {
+		  w_local[nwave]=lambdamax;
+		  linterp(lambdamax, comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, &y, 0);
+		  f_local[nwave]=y;
+		  nwave++;
+	  }
+//	  printf ("BLAH min %e max %e\n",lambdamin,lambdamax);
+//	  printf ("BLAH wmin %e wmax %e\n",comp[spectype].xmod.w[0],comp[spectype].xmod.w[comp[spectype].nwaves-1]);
+	  
+//	  for (n=0;n<nwave;n++)
+//		  printf ("BLAH %e %e\n",w_local[n],f_local[n]);
+	  
     //OLD not used in routine par[0] = t;
     //OLD not used in routine par[1] = g;
     //OLD nwav not used here ksl.  nwav = model (spectype, par);
     /*  Get_model returns wavelengths in Ang and flux in ergs/cm**2/Ang */
-    lambdamin = C * 1e8 / freqmax;
-    lambdamax = C * 1e8 / freqmin;
+
     if (cdf_gen_from_array
-        (&comp[spectype].xcdf, comp[spectype].xmod.w, comp[spectype].xmod.f, comp[spectype].nwaves, lambdamin, lambdamax) != 0)
+        (&comp[spectype].xcdf, w_local, f_local, nwave, lambdamin, lambdamax) != 0)
     {
       Error ("In one_continuum after return from cdf_gen_from_array\n");
     }

--- a/source/cooling.c
+++ b/source/cooling.c
@@ -67,26 +67,8 @@ cooling (xxxplasma, t)
 
   /*81c - nsh - we now treat DR cooling as a recombinational process - still unsure as to how to treat emission, so at the moment
      it remains here */
-  xxxplasma->cool_dr = total_fb (&wmain[xxxplasma->nwind], t, 0, VERY_BIG, FB_REDUCED, INNER_SHELL);
-  
-//  f1=2.641e15;
-//  f2=1.523e16;
-  
-//  df=(f2-f1)/200;
-//  printf ("FB_TEST total %e\n",total_fb (&wmain[xxxplasma->nwind], t, f1, f2, FB_FULL, OUTER_SHELL));
-//  for (n=1;n<200;n++)
-//  {
-//	  lower= total_fb (&wmain[xxxplasma->nwind], t, f1, f1+(n*df), FB_FULL, OUTER_SHELL);
-//	  upper= total_fb (&wmain[xxxplasma->nwind], t, f1+(n*df), f2, FB_FULL, OUTER_SHELL);
-//	  test= total_fb (&wmain[xxxplasma->nwind], t, f1+((n-1)*df), f1+((n)*df), FB_FULL, OUTER_SHELL);
-//	  printf ("FB_TEST1 break %e lower %e upper %e total %e\n",f1+(n*df),lower,upper,lower+upper);
-//	  printf ("FB_TEST2 %e to %e = %e\n",f1+((n-1)*df), f1+((n)*df),test);
-//	  printf ("FB_TEST3 %e %e \n",f1+((n-1)*df),fb (xxxplasma, t, f1+((n-1)*df), nions, FB_FULL));
-//  	}  
-  
-  
-//  exit(0);
-  
+	
+  xxxplasma->cool_dr = total_fb (&wmain[xxxplasma->nwind], t, 0, VERY_BIG, FB_REDUCED, INNER_SHELL);  
 
   /* 78b - nsh adding this line in next to calculate direct ionization cooling without generating photons */
 
@@ -174,11 +156,11 @@ xtotal_emission (one, f1, f2)
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
-      cooling = xplasma->cool_rr;
       //Note: This the fb_matom call makes no use of f1 or f2. They are passed for
       //now in case they should be used in the future. But they could
       //also be removed.
       // (SS)
+      cooling = xplasma->cool_rr;
       xplasma->lum_lines = total_bb_cooling (xplasma, t_e);
       cooling += xplasma->lum_lines;
       /* total_bb_cooling gives the total cooling rate due to bb transisions whether they
@@ -314,6 +296,7 @@ History:
     11sep   nsh     70 Modifications in incorporate DR cooling (very approximate at the moment)
 	12sep	nsh	73 Added a counter for adiabatic luminosity (!)
  	13jul	nsh	76 Split up adiabatic luminosity into heating and cooling.
+    17aug   nsh xchanges to wind cooling to reflect the way we now
  
 **************************************************************/
 
@@ -336,7 +319,8 @@ wind_cooling (f1, f2)
     if (wmain[n].vol > 0.0)
     {
       nplasma = wmain[n].nplasma;
-      cool += x = cooling (&plasmamain[nplasma],plasmamain[nplasma].t_e);
+      cool += x = cooling (&plasmamain[nplasma],plasmamain[nplasma].t_e);  //1708 - changed this call - now computes cooling rather than luminosity - also we popultate a local
+	  //array called cool, rather than the xplasma array - this was overrwting the xplasma array with incorrect data. 
       lum_lines += plasmamain[nplasma].lum_lines;
       cool_rr += plasmamain[nplasma].cool_rr;
       lum_ff += plasmamain[nplasma].lum_ff;

--- a/source/cooling.c
+++ b/source/cooling.c
@@ -153,8 +153,10 @@ xtotal_emission (one, f1, f2)
 {
   double t_e;
   int nplasma;
+  double cooling;
   PlasmaPtr xplasma;
 
+  cooling=0.0;
   nplasma = one->nplasma;
   xplasma = &plasmamain[nplasma];
 
@@ -172,36 +174,36 @@ xtotal_emission (one, f1, f2)
       //The first term here is the fb cooling due to macro ions and the second gives
       //the fb cooling due to simple ions.
       //total_fb has been modified to exclude recombinations treated using macro atoms.
-      xplasma->cool_tot = xplasma->cool_rr;
+      cooling = xplasma->cool_rr;
       //Note: This the fb_matom call makes no use of f1 or f2. They are passed for
       //now in case they should be used in the future. But they could
       //also be removed.
       // (SS)
       xplasma->lum_lines = total_bb_cooling (xplasma, t_e);
-      xplasma->cool_tot += xplasma->lum_lines;
+      cooling += xplasma->lum_lines;
       /* total_bb_cooling gives the total cooling rate due to bb transisions whether they
          are macro atoms or simple ions. */
       xplasma->lum_ff = total_free (one, t_e, f1, f2);
-      xplasma->cool_tot += xplasma->lum_ff;
+      cooling += xplasma->lum_ff;
 
 
     }
     else                        //default (non-macro atoms) (SS)
     {
 		/*The line cooling is equal to the line emission */
-      xplasma->cool_tot = xplasma->lum_lines = total_line_emission (one, f1, f2);
+      cooling = xplasma->lum_lines = total_line_emission (one, f1, f2);
 	  /* The free free cooling is equal to the free free emission */
-      xplasma->cool_tot += xplasma->lum_ff = total_free (one, t_e, f1, f2);
+      cooling += xplasma->lum_ff = total_free (one, t_e, f1, f2);
 	  /*The free bound cooling is equal to the recomb rate x the electron energy - the boinding energy - this is computed 
 	  with the FB_REDUCED switch */
-      xplasma->cool_tot += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, OUTER_SHELL);     //outer shell recombinations
+      cooling += xplasma->cool_rr = total_fb (one, t_e, f1, f2, FB_REDUCED, OUTER_SHELL);     //outer shell recombinations
 
 
     }
   }
 
 
-  return (xplasma->cool_tot);
+  return (cooling);
 
 
 }
@@ -334,7 +336,7 @@ wind_cooling (f1, f2)
     if (wmain[n].vol > 0.0)
     {
       nplasma = wmain[n].nplasma;
-      cool += x = xtotal_emission (&wmain[n], f1, f2);
+      cool += x = cooling (&plasmamain[nplasma],plasmamain[nplasma].t_e);
       lum_lines += plasmamain[nplasma].lum_lines;
       cool_rr += plasmamain[nplasma].cool_rr;
       lum_ff += plasmamain[nplasma].lum_ff;

--- a/source/emission.c
+++ b/source/emission.c
@@ -821,13 +821,15 @@ one_ff (one, f1, f2)
 
   if (xplasma->t_e != one_ff_te || f1 != one_ff_f1 || f2 != one_ff_f2)
   {                             /* Generate a new pdf */
-
-    dfreq = (f2 - f1) / ARRAY_PDF-1;
-    for (n = 0; n < ARRAY_PDF; n++)
+    dfreq = (f2 - f1) / (ARRAY_PDF-1);
+    for (n = 0; n < ARRAY_PDF-1; n++)
     {
       ff_x[n] = f1 + dfreq * n;
       ff_y[n] = ff (one, xplasma->t_e, ff_x[n]);
     }
+	
+	ff_x[ARRAY_PDF-1] = f2;
+    ff_y[ARRAY_PDF-1] = ff (one, xplasma->t_e, ff_x[ARRAY_PDF-1]);
 
 
 

--- a/source/emission.c
+++ b/source/emission.c
@@ -409,20 +409,20 @@ for (n=0;n<NPLASMA;n++)
   		  Error_silent ("photo_gen_wind: On return from one_ff: icell %d vol %g t_e %g\n", icell, wmain[icell].vol, plasmamain[nplasma].t_e);
   		p[np].freq = 0.0;
 		}
-	    if (icell==1100)
-	  	  printf ("PHOT FF freq %e weight %e out\n",p[np].freq,weight);
+//	    if (icell==1100)
+//	  	  printf ("PHOT FF freq %e weight %e out\n",p[np].freq,weight);
 	}
 	else if (np<photstart+ptype[n][0]+ptype[n][1])
 	{
 		p[np].freq = one_fb (&wmain[icell], freqmin, freqmax);
-	    if (icell==1100)
-	  	  printf ("PHOT FB freq %e weight %e out\n",p[np].freq,weight);
+//	    if (icell==1100)
+//	  	  printf ("PHOT FB freq %e weight %e out\n",p[np].freq,weight);
 	}
 	else
 	{
 		p[np].freq = one_line (&wmain[icell], freqmin, freqmax, &p[n].nres);       /*And fill all the rest of the luminosity up with line photons */
-	    if (icell==1100)
-	  	  printf ("PHOT LI freq %e weight %e out\n",p[np].freq,weight);
+//	    if (icell==1100)
+//	  	  printf ("PHOT LI freq %e weight %e out\n",p[np].freq,weight);
 	}
 
     p[np].w = weight;

--- a/source/emission.c
+++ b/source/emission.c
@@ -199,13 +199,31 @@ total_emission (one, f1, f2)
                                    integrated */
 {
   double t_e;
-  int nplasma;
+  int nplasma,n;
   PlasmaPtr xplasma;
 
   nplasma = one->nplasma;
   xplasma = &plasmamain[nplasma];
 
   t_e = xplasma->t_e;           // Change so calls to total emission are simpler
+  
+  
+
+//f2=1e16;
+//f1=1e15;
+//t_e=400;
+
+//for (n=200;n<600;n++)
+//{
+//	t_e=pow(10.,n/100.);
+//	printf ("FB_FULL temp %e total_fb %e %e\n",t_e,total_fb (one, t_e, f1, f2, FB_FULL, OUTER_SHELL),total_fb (one, t_e, f1, f2, FB_REDUCED, OUTER_SHELL));
+	
+  //}
+ //exit(0); 
+ 
+ 
+ 
+  
 
   if (f2 < f1)
   {
@@ -391,14 +409,20 @@ for (n=0;n<NPLASMA;n++)
   		  Error_silent ("photo_gen_wind: On return from one_ff: icell %d vol %g t_e %g\n", icell, wmain[icell].vol, plasmamain[nplasma].t_e);
   		p[np].freq = 0.0;
 		}
+	    if (icell==1100)
+	  	  printf ("PHOT FF freq %e weight %e out\n",p[np].freq,weight);
 	}
 	else if (np<photstart+ptype[n][0]+ptype[n][1])
 	{
 		p[np].freq = one_fb (&wmain[icell], freqmin, freqmax);
+	    if (icell==1100)
+	  	  printf ("PHOT FB freq %e weight %e out\n",p[np].freq,weight);
 	}
 	else
 	{
 		p[np].freq = one_line (&wmain[icell], freqmin, freqmax, &p[n].nres);       /*And fill all the rest of the luminosity up with line photons */
+	    if (icell==1100)
+	  	  printf ("PHOT LI freq %e weight %e out\n",p[np].freq,weight);
 	}
 
     p[np].w = weight;
@@ -459,6 +483,8 @@ was a resonant scatter but we want isotropic scattering anyway.  */
     }
 	
   }
+  
+
 
 
   return (nphot);               /* Return the number of photons generated */

--- a/source/get_atomicdata.c
+++ b/source/get_atomicdata.c
@@ -2979,9 +2979,7 @@ index_phot_top ()
 
   for (n = 0; n < ntop_phot + nxphot; n++)
   {
-    phot_top_ptr[n] = &phot_top[index[n + 1] - 1];
-  	printf ("NPHOT test n=%i f_0=%e z=%i state=%i\n",n,phot_top_ptr[n]->freq[0],phot_top_ptr[n]->z,phot_top_ptr[n]->istate);
-	
+    phot_top_ptr[n] = &phot_top[index[n + 1] - 1];	
   }
 
   /* Free the memory for the arrays */

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -430,6 +430,7 @@ one_shot (xplasma, mode)
 	{
 	  xplasma->t_e = TMAX;
 	}
+	zero_emit(xplasma->t_e);  //Get the heating and cooling rates correctly for the new temperature
     }
 
 

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -3234,14 +3234,14 @@ complete_physical_summary (w, rootname, ochoice)
 
   printf ("n\tnplasma\tinwind\ti\tj\tx\tz\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
 rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tconv\tconv_tr\tconv_te\tconv_hc\t \
-cool_tot\tlum_tot\tcool_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
+cool_tot\tlum_tot\tlum_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
 heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
   if (ochoice)
     fprintf (fptr, "n\tnplasma\tinwind\ti\tj\tx\tz\tr\ttheta\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
 rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tXi\tconv\tconv_tr\tconv_te\tconv_hc\t \
-cool_tot\tlum_tot\tcool_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
+cool_tot\tlum_tot\tlum_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
 heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
@@ -3294,7 +3294,15 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
             %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
-            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\n", n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2], w[n].rcen, w[n].thetacen / RADIAN, vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol, plasmamain[np].rho, plasmamain[np].ne, plasmamain[np].t_e, plasmamain[np].t_r, plasmamain[np].ntot, plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].xi, plasmamain[np].converge_whole, plasmamain[np].converge_t_r, plasmamain[np].converge_t_e, plasmamain[np].converge_hc, plasmamain[np].lum_tot + plasmamain[np].cool_comp + plasmamain[np].cool_adiabatic + plasmamain[np].cool_dr, plasmamain[np].lum_tot, plasmamain[np].cool_rr, plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].cool_adiabatic, plasmamain[np].cool_comp, plasmamain[np].cool_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, plasmamain[np].heat_auger, plasmamain[np].heat_lines, plasmamain[np].heat_ff, plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp, h1den, h2den, he1den, he2den, he3den, c3den, c4den, c5den, n5den, o6den, si4den);
+            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\n", n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2], w[n].rcen, 
+	  w[n].thetacen / RADIAN, vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol, plasmamain[np].rho, plasmamain[np].ne, 
+	  plasmamain[np].t_e, plasmamain[np].t_r, plasmamain[np].ntot, plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].xi, 
+	  plasmamain[np].converge_whole, plasmamain[np].converge_t_r, plasmamain[np].converge_t_e, plasmamain[np].converge_hc, 
+	  plasmamain[np].cool_tot , 
+	  plasmamain[np].lum_tot, plasmamain[np].lum_rr, plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].cool_adiabatic, 
+	  plasmamain[np].cool_comp, plasmamain[np].cool_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, plasmamain[np].heat_auger, 
+	  plasmamain[np].heat_lines, plasmamain[np].heat_ff, plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp, h1den, h2den, he1den, 
+	  he2den, he3den, c3den, c4den, c5den, n5den, o6den, si4den);
     }
     else
     {

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -3240,14 +3240,14 @@ complete_physical_summary (w, rootname, ochoice)
 
   printf ("n\tnplasma\tinwind\ti\tj\tx\tz\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
 rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tconv\tconv_tr\tconv_te\tconv_hc\t \
-cool_tot\tlum_tot\tlum_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
+cool_tot\tlum_tot\tlum_rr\tcool_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
 heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
   if (ochoice)
     fprintf (fptr, "n\tnplasma\tinwind\ti\tj\tx\tz\tr\ttheta\tv\tvx\tvy\tvz\tdvds_ave\tvol\t \
 rho\tne\tte\ttr\tnphot\tw\tave_freq\tIP\tXi\tconv\tconv_tr\tconv_te\tconv_hc\t \
-cool_tot\tlum_tot\tlum_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
+cool_tot\tlum_tot\tlum_rr\tcool_rr\tlum_ff\tlum_lines\tcool_adiabatic\tcool_comp\tcool_dr\t \
 heat_tot\theat_photo\theat_auger\theat_lines\theat_ff\theat_comp\theat_ind_comp\t \
 ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\n");
 
@@ -3298,14 +3298,14 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
       if (ochoice)
         fprintf (fptr, "%i %i %i %i %i %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e %i %8.4e %8.4e %8.4e %8.4e \
-            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\
+            %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e \
             %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e %8.4e\n", n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2], w[n].rcen, 
 	  w[n].thetacen / RADIAN, vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol, plasmamain[np].rho, plasmamain[np].ne, 
 	  plasmamain[np].t_e, plasmamain[np].t_r, plasmamain[np].ntot, plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].xi, 
 	  plasmamain[np].converge_whole, plasmamain[np].converge_t_r, plasmamain[np].converge_t_e, plasmamain[np].converge_hc, 
 	  plasmamain[np].cool_tot , 
-	  plasmamain[np].lum_tot, plasmamain[np].lum_rr, plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].cool_adiabatic, 
+	  plasmamain[np].lum_tot, plasmamain[np].lum_rr,plasmamain[np].cool_rr, plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].cool_adiabatic, 
 	  plasmamain[np].cool_comp, plasmamain[np].cool_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, plasmamain[np].heat_auger, 
 	  plasmamain[np].heat_lines, plasmamain[np].heat_ff, plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp, h1den, h2den, he1den, 
 	  he2den, he3den, c3den, c4den, c5den, n5den, o6den, si4den);
@@ -3325,7 +3325,7 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
       if (ochoice)
         fprintf (fptr, "%i %i %i %i %i %8.4e %8.4e 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
-            0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
+            0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 \
             0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0\n", n, np, w[n].inwind, ii, jj, w[n].x[0], w[n].x[2]);
     }

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -3304,10 +3304,11 @@ ionH1\tionH2\tionHe1\tionHe2\tionHe3\tionC3\tionC4\tionC5\tionN5\tionO6\tionSi4\
 	  w[n].thetacen / RADIAN, vtot, w[n].v[0], w[n].v[1], w[n].v[2], w[n].dvds_ave, w[n].vol, plasmamain[np].rho, plasmamain[np].ne, 
 	  plasmamain[np].t_e, plasmamain[np].t_r, plasmamain[np].ntot, plasmamain[np].w, plasmamain[np].ave_freq, plasmamain[np].ip, plasmamain[np].xi, 
 	  plasmamain[np].converge_whole, plasmamain[np].converge_t_r, plasmamain[np].converge_t_e, plasmamain[np].converge_hc, 
-	  plasmamain[np].cool_tot , 
-	  plasmamain[np].lum_tot, plasmamain[np].lum_rr,plasmamain[np].cool_rr, plasmamain[np].lum_ff, plasmamain[np].lum_lines, plasmamain[np].cool_adiabatic, 
-	  plasmamain[np].cool_comp, plasmamain[np].cool_dr, plasmamain[np].heat_tot, plasmamain[np].heat_photo, plasmamain[np].heat_auger, 
-	  plasmamain[np].heat_lines, plasmamain[np].heat_ff, plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp, h1den, h2den, he1den, 
+	  plasmamain[np].cool_tot_ioniz+ plasmamain[np].cool_comp_ioniz + plasmamain[np].cool_adiabatic_ioniz + plasmamain[np].cool_dr_ioniz, 
+	  plasmamain[np].lum_tot_ioniz, plasmamain[np].lum_rr_ioniz,plasmamain[np].cool_rr_ioniz, plasmamain[np].lum_ff_ioniz, plasmamain[np].lum_lines_ioniz, 
+	  plasmamain[np].cool_adiabatic_ioniz, plasmamain[np].cool_comp_ioniz, plasmamain[np].cool_dr_ioniz, plasmamain[np].heat_tot, plasmamain[np].heat_photo,
+	  plasmamain[np].heat_auger, plasmamain[np].heat_lines, plasmamain[np].heat_ff, plasmamain[np].heat_comp, plasmamain[np].heat_ind_comp,
+	  h1den, h2den, he1den, 
 	  he2den, he3den, c3den, c4den, c5den, n5den, o6den, si4den);
     }
     else

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -1516,6 +1516,12 @@ a:printf ("There are %i wind elements in this model\n", NDIM2);
   /*70g compton removed from luminosity reporting, it is now a cooling mechanism but does not produce photons
      DR cooling also added in to report */
   Log
+    ("t_e  %8.2e lum_tot %8.2e lum_lines  %8.2e lum_ff  %8.2e lum_rr     %8.2e \n",
+     xplasma->t_e, xplasma->lum_tot_ioniz, xplasma->lum_lines_ioniz, xplasma->lum_ff_ioniz, xplasma->lum_rr_ioniz);
+     Log
+       ("t_e  %8.2e lum_tot %8.2e lum_lines  %8.2e lum_ff  %8.2e lum_rr     %8.2e \n",
+        xplasma->t_e, xplasma->lum_tot, xplasma->lum_lines, xplasma->lum_ff, xplasma->lum_rr);
+  Log
     ("t_e %8.2e cool_tot %8.2e lum_lines  %8.2e lum_ff  %8.2e cool_rr     %8.2e cool_comp %8.2e cool_adiab %8.2e cool_DR %8.2e \n",
      xplasma->t_e, xplasma->cool_tot_ioniz + xplasma->cool_comp_ioniz + xplasma->cool_adiabatic_ioniz + xplasma->cool_dr_ioniz,
      xplasma->lum_lines_ioniz, xplasma->lum_ff_ioniz, xplasma->cool_rr_ioniz, xplasma->cool_comp_ioniz, xplasma->cool_adiabatic_ioniz,

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -620,13 +620,13 @@ use that instead if possible --  57h */
   nnn=0;   //Zero the index for elements in the flux array
 	nn=0;  //Zero the index for elements in the jump array
 	  n=0;  //Zero the counting element for equally spaced frequencies
-    dfreq = (f2 - f1) / ARRAY_PDF; //This is the frequency spacing for the equally spaced elements
+    dfreq = (f2 - f1) / (ARRAY_PDF-1); //This is the frequency spacing for the equally spaced elements
     while (n < (ARRAY_PDF) && nnn < NCDF)   //We keep going until n=ARRAY_PDF-1, which will give the maximum required frequency
     {
 		freq=f1 + dfreq * n;  //The frequency of the array element we would make in the normal run of things
 		if (freq > fb_jumps[nn] && nn < fb_njumps) //The element we were going to make has a frequency abouve the jump
 		{
-			fb_x[nnn]=fb_jumps[nn]*(1.-DELTA_V/(2.*C));  //We make one frequency point 1km/s below the jump
+			fb_x[nnn]=fb_jumps[nn]*(1.-DELTA_V/(2.*C));  //We make one frequency point DELTA_V cm/s below the jump
 			fb_y[nnn]=fb (xplasma, xplasma->t_e, fb_x[nnn], nions, FB_FULL); //And the flux for that point
 			nnn=nnn+1;			//increase the index of the created array
 			fb_x[nnn]=fb_jumps[nn]*(1.+DELTA_V/(2*C));  //And one frequency point just above the jump
@@ -636,7 +636,7 @@ use that instead if possible --  57h */
 		}
 		else  //We haven't hit a jump
 		{
-			if (freq > fb_x[nnn-1])  //Deal with the unusual case where the upper point in our 'jump' pair is above the next ragular point
+			if (freq > fb_x[nnn-1])  //Deal with the unusual case where the upper point in our 'jump' pair is above the next regular point
 				{
       			fb_x[nnn] = freq;   //Set the next array element frequency
       			fb_y[nnn] = fb (xplasma, xplasma->t_e, fb_x[nnn], nions, FB_FULL); //And the flux
@@ -649,6 +649,12 @@ use that instead if possible --  57h */
   		  		}
  	 	}
     }
+	
+	//Ensure the last point lines up exatly with f2
+	
+	fb_x[nnn-1]=f2;
+	fb_y[nnn-1]=fb (xplasma, xplasma->t_e, f2, nions, FB_FULL);
+	
 
 	if (nnn > NCDF)
 	{

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -601,6 +601,12 @@ use that instead if possible --  57h */
 
     }
 	
+	
+//	f2=1e16;
+//	f1=1e15;
+//	xplasma->t_e=5000;
+	
+	
 
     //!BUG SSMay04
     //It doesn't seem to work unless this is zero? (SS May04)
@@ -653,10 +659,10 @@ use that instead if possible --  57h */
 		
 	/* At this point, the variable nnn stores the number of points */
 	
+//	for (n=0;n<nnn;n++)
+//		printf ("FB_TEST te=%e freq %e emittance %e out\n",xplasma->t_e,fb_x[n],fb_y[n]);
 	
-
-
-	
+//	exit(0);
 
     if (cdf_gen_from_array (&cdf_fb, fb_x, fb_y, nnn, f1, f2) != 0)
     {

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -689,6 +689,12 @@ WindPtr (w);
   }
 
   /* Check the balance between the absorbed and the emitted flux */
+  
+  //NSH 0717 - first we need to ensure the cooling and luminosities reflect the current temperature
+  
+  cool_sum = wind_cooling (0.0, VERY_BIG);       /*We call wind_cooling here to obtain an up to date set of cooling rates */
+  lum_sum = wind_luminosity (0.0, VERY_BIG);       /*and we also call wind_luminosity to get the luminosities */
+  
 
   xsum = psum = ausum = lsum = fsum = csum = icsum = apsum = aausum = abstot = 0; //1108 NSH zero the new csum counter for compton heating
 
@@ -725,8 +731,7 @@ WindPtr (w);
 
     /* JM130621- bugfix for windsave bug- needed so that we have the luminosities from ionization
        cycles in the windsavefile even if the spectral cycles are run */
-	if (nplasma==62)
-		printf("BLAH nwing=%i nplasma=%i lum_rr=%e\n",plasmamain[nplasma].nwind,nplasma,plasmamain[nplasma].lum_rr);
+	
     plasmamain[nplasma].cool_tot_ioniz = plasmamain[nplasma].cool_tot;
     plasmamain[nplasma].lum_ff_ioniz = plasmamain[nplasma].lum_ff;
     plasmamain[nplasma].cool_rr_ioniz = plasmamain[nplasma].cool_rr;
@@ -776,8 +781,7 @@ WindPtr (w);
 
 
 
-  cool_sum = wind_cooling (0.0, VERY_BIG);       /*We call wind_cooling here to obtain an up to date set of cooling rates */
-  lum_sum = wind_luminosity (0.0, VERY_BIG);       /*and we also call wind_luminosity to get the luminosities */
+
 
 
   if (modes.zeus_connect == 1 && geo.hydro_domain_number > -1)  //If we are running in zeus connect mode, we output heating and cooling rates.

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -725,7 +725,8 @@ WindPtr (w);
 
     /* JM130621- bugfix for windsave bug- needed so that we have the luminosities from ionization
        cycles in the windsavefile even if the spectral cycles are run */
-
+	if (nplasma==62)
+		printf("BLAH nwing=%i nplasma=%i lum_rr=%e\n",plasmamain[nplasma].nwind,nplasma,plasmamain[nplasma].lum_rr);
     plasmamain[nplasma].cool_tot_ioniz = plasmamain[nplasma].cool_tot;
     plasmamain[nplasma].lum_ff_ioniz = plasmamain[nplasma].lum_ff;
     plasmamain[nplasma].cool_rr_ioniz = plasmamain[nplasma].cool_rr;


### PR DESCRIPTION
1: Changes in continuum.c and cdf.c to allow the code to deal with continuum models. The problem was that the new way that pdf_gen_from_array works means that it expects a suitably bounded array to convert into a pdf, however one_continuum was sending the whole model. This routine now truncates the array and checks for errors before calling cdf_gen_from_array
