### PR TITLE
Fixed bug #327

### DIFF
--- a/source/python.c
+++ b/source/python.c
@@ -554,7 +554,7 @@ main (argc, argv)
 
   if (geo.tstar <= 0.0)
     geo.star_radiation = 0;
-  if (geo.disk_mdot <= 0.0)
+  if (geo.disk_mdot <= 0.0 && geo.disk_tprofile == DISK_TPROFILE_STANDARD)
     geo.disk_radiation = 0;
   if (geo.t_bl <= 0.0 || geo.lum_bl <= 0.0)
     geo.bl_radiation = 0;


### PR DESCRIPTION
Made a change to the test at line 557 in python.c

Before, if disk_mdot was set to zero, it turned off the disk. However this should only be the case if we have a standard temperature profile. If we don't, then we never ask for mdot.
