### PR TITLE
removed auger option from py_wind

### DIFF
--- a/source/py_wind.c
+++ b/source/py_wind.c
@@ -89,7 +89,7 @@ char *choice_options = "\n\
    r=t_r, t=t_e,  w=rad_weight,  s=vol,     l=lum,     C=cooling/heating,  b=adiabatic cooling\n\
    a=abs,         L=line lum,    g=photo,   h=recomb,  k=tau H,     m=F_rad, x=total, y=mod_te,\n\
    o=overview,    e=everything,  P=Partial emission meas,  I=Ionisation parameter\n\
-   W=wind_region, D=dvds_ave,    X=position summary, M=macro atom info, G=inner shell\n\
+   W=wind_region, D=dvds_ave,    X=position summary, M=macro atom info\n\
    d=convergence status  E=convergence_all_info   B=PlasmaPtr  J=Radiation density\n\
    H=All Heating and Cooling mechanisms in one shot  O=Spectral model parameters S=Spectral models\n\
    z=Zoom,u=unZoom,Z=switch to/from raw and yz projected modes, F=Create files, A=Change file write defaults\n\
@@ -432,9 +432,9 @@ one_choice (choice, root, ochoice)
   case 'g':                    /*n photo */
     photo_summary (wmain, root, ochoice);
     break;
-  case 'G':                    /* inner shell summary */
-    inner_shell_summary (wmain, root, ochoice);
-    break;
+//  case 'G':    Removed relevant data from python so option removed May 18         /* inner shell summary */
+//    inner_shell_summary (wmain, root, ochoice);
+//    break;
   case 'h':                    /*n photo */
     Log ("Don't get discouraged.  This takes a little while!");
     recomb_summary (wmain, root, ochoice);

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -1920,7 +1920,7 @@ dvds_summary (w, rootname, ochoice)
 }
 
 /* A summary of inner shell ionization */
-
+/* NSH - this code removed May 18 
 int
 inner_shell_summary (w, rootname, ochoice)
      WindPtr w;
@@ -1951,7 +1951,7 @@ inner_shell_summary (w, rootname, ochoice)
   return (0);
 
 }
-
+*/
 
 /* A summary of the Ionization parameter - might not always be present */
 


### PR DESCRIPTION
Removed the subroutine in py_wind that uses the inshl array in the plasma structure because this has been removed. 
I don't think we have any similar array where the inner shell rate is calculated, so I have removed the option to print this out from py_wind as well..