### PR TITLE
Fix for bug #393

### DIFF
--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -871,6 +871,21 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
   logrmin=log(rmin);
   logdr=(logrmax-logrmin)/STEPS;
 
+  for (nrings = 0; nrings < NRINGS; nrings++) //Initialise the structure
+  {
+    disk.nphot[nrings] = 0;
+    disk.nphot[nrings] = 0;
+	disk.r[nrings] = 0;
+	disk.t[nrings] = 0;	
+    disk.nhit[nrings] = 0;
+    disk.heat[nrings] = 0;
+    disk.ave_freq[nrings] = 0;
+    disk.w[nrings] = 0;
+    disk.t_hit[nrings] = 0;
+  }
+
+
+
 
   ltot = 0;
 
@@ -903,7 +918,6 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
   icheck=0;
   
 
-  i=0;
   for (logr=logrmin;logr<logrmax;logr+=logdr)
   {
     r=exp(logr);
@@ -920,17 +934,11 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
       emit = emittance_bb (freqmin, freqmax, t);
 	  
     }
-	if (emit>0 && icheck==0) icheck=1; //We have passed an annulus with emission.
-	if (emit==0.0 && icheck==1) logrmax=log(r); //This will drop us out of the loop - we will have a truncated disk
-	
     (*ftot) += emit * (2. * r + dr) * dr;
-
-	i++;
   }
 
   (*ftot) *= q1;
   
-  // logdr=(logrmax-logrmin)/STEPS;
 
 
   /* If *ftot is 0 in this energy range then all the photons come elsewhere, e. g. the star or BL  */
@@ -950,7 +958,6 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
   nrings = 1;
   f = 0;
   
-  logdr=(logrmax-logrmin)/STEPS; //Regrid, using the possible new value of rmax
   i=0;
   for (logr=logrmin;logr<logrmax;logr+=logdr)
   {
@@ -969,7 +976,7 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
     }
 
     f += q1 * emit * (2. * r + dr) * dr;
-    	
+	i++;
     /* EPSILON to assure that roundoffs don't affect result of if statement */
     if (f / (*ftot) * (NRINGS - 1) >= nrings)
     {
@@ -982,11 +989,10 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
       nrings++;
       if (nrings >= NRINGS)
       {
-        Error_silent ("disk_init: Got to ftot %e at r %e < rmax %e. OK if freqs are high\n", f, r, rmax);		
+//        Error_silent ("disk_init: Got to ftot %e at r %e < rmax %e. OK if freqs are high\n", f, r, rmax);		Not *really* an error, the error below deals with a *real* problem.		
         break;
       }
     }
-	i++;
   }
   if (nrings < NRINGS - 1)
   {
@@ -994,8 +1000,8 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
     exit (0);
   }
 
-
-//  disk.r[NRINGS - 1] = rmax;  //We do not want to automatically set the outer edge of the disk to rmax, we may well have got to ftot earlier - indeed we normally do.
+ 
+  disk.r[NRINGS - 1] = exp(logrmax); 
   disk.v[NRINGS - 1] = sqrt (G * geo.mstar / disk.r[NRINGS - 1]);
 
 
@@ -1016,7 +1022,7 @@ disk_init (rmin, rmax, m, mdot, freqmin, freqmax, ioniz_or_final, ftot)
     disk.heat[nrings] = 0;
     disk.ave_freq[nrings] = 0;
     disk.w[nrings] = 0;
-    disk.t_hit[nrings] = 0;
+    disk.t_hit[nrings] = 0;	
   }
 
   geo.lum_disk = ltot;

--- a/source/python.h
+++ b/source/python.h
@@ -597,7 +597,7 @@ geo;
 
 
 /* xdisk is a structure that is used to store information about the disk in a system */
-#define NRINGS	301             /* The actual number of rings completely defined
+#define NRINGS	3001             /* The actual number of rings completely defined
                                    is NRINGS-1 ... or from 0 to NRINGS-2.  This is
                                    because you need an outer radius...but the rest
                                    of this element is not filled in. */

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -67,7 +67,7 @@ WindPtr (w);
 
   /*1108 NSH csum added to sum compton heating 1204 NSH icsum added to sum induced compton heating */
   double wtest, xsum, psum, fsum, lsum, csum, icsum, ausum;
-  double cool_sum,lum_sum; //1706 - the total cooling and luminosity of the wind
+  double cool_sum,lum_sum, rad_sum; //1706 - the total cooling and luminosity of the wind
   double apsum,aausum,abstot; //Absorbed photon energy from PI and auger
   double c_rec, n_rec, o_rec, fe_rec;   //1701- NSH more outputs to show cooling from a few other elements
   double c_lum, n_lum, o_lum, fe_lum;   //1708- NSH and luminosities as well
@@ -796,6 +796,13 @@ WindPtr (w);
   Log
     ("!!wind_update: Wind luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
      lum_sum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
+	 
+	 
+     rad_sum = wind_luminosity (xband.f1[0], xband.f2[xband.nbands-1]);       /*and we also call wind_luminosity to get the luminosities */
+	 
+    Log
+       ("!!wind_update: Rad  luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
+         rad_sum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
 
   Log
     ("!!wind_update: Wind cooling     %8.2e (recomb %8.2e ff %8.2e compton %8.2e DR %8.2e DI %8.2e lines %8.2e adiabatic %8.2e) after update\n",


### PR DESCRIPTION
Main change is in photon_gen.c, where disk_init has been changed to use a logarithmic grid to compute the disk luminosity. This captures the part of the disk where the luminosity changes fastest better, and works better for high frequencies. This meant that there were more "ftot reached before rmax" errors, but this is actually fine, since it meant that we reached ftot in the last annulus *more* often than before - which is what we want. Therefore this odd error has been removed.
There is also a change in python.h, increasing the number of disk annuli from 301 to 3001. 