### PR TITLE
Fix for issue #417

### DIFF
--- a/source/estimators.c
+++ b/source/estimators.c
@@ -1017,6 +1017,12 @@ get_gamma (cont_ptr, xplasma)
   cont_ext_ptr2 = cont_ptr;     //external cont pointer
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+  if ((H_OVER_K * (flast-fthresh) / temp_ext2) > ALPHA_MATOM_NUMAX_LIMIT)
+    {
+      //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+      flast = fthresh + temp_ext2 * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+    }
+
 
   gamma_value = qromb (gamma_integrand, fthresh, flast, 1e-4);
 
@@ -1090,6 +1096,12 @@ get_gamma_e (cont_ptr, xplasma)
   cont_ext_ptr2 = cont_ptr;     //external cont pointer
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+  if ((H_OVER_K * (flast-fthresh) / temp_ext2) > ALPHA_MATOM_NUMAX_LIMIT)
+    {
+      //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+      flast = fthresh + temp_ext2 * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+    }
+
 
   gamma_e_value = qromb (gamma_e_integrand, fthresh, flast, 1e-4);
 
@@ -1164,7 +1176,16 @@ get_alpha_st (cont_ptr, xplasma)
   cont_ext_ptr2 = cont_ptr;     //"
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+
+  if ((H_OVER_K * (flast-fthresh) / temp_ext2) > ALPHA_MATOM_NUMAX_LIMIT)
+    {
+      //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+      flast = fthresh + temp_ext2 * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+    }
+
+  
   alpha_st_value = qromb (alpha_st_integrand, fthresh, flast, 1e-4);
+
 
   /* The lines above evaluate the integral in alpha_sp. Now we just want to multiply 
      through by the appropriate constant. */
@@ -1251,6 +1272,14 @@ get_alpha_st_e (cont_ptr, xplasma)
   cont_ext_ptr2 = cont_ptr;     //"
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+
+  if ((H_OVER_K * (flast-fthresh) / temp_ext2) > ALPHA_MATOM_NUMAX_LIMIT)
+    {
+      //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+      flast = fthresh + temp_ext2 * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+    }
+
+  
   alpha_st_e_value = qromb (alpha_st_e_integrand, fthresh, flast, 1e-4);
 
   /* The lines above evaluate the integral in alpha_sp. Now we just want to multiply 

--- a/source/matom.c
+++ b/source/matom.c
@@ -497,7 +497,8 @@ matom (p, nres, escape)
       /* continuua are indicated by nres > NLINES */
 //      p->freq = phot_top[config[uplvl].bfd_jump[n - nbbd]].freq[0] - (log (1. - (rand () + 0.5) / MAXRAND) * xplasma->t_e / H_OVER_K); //DONE
       p->freq = phot_top[config[uplvl].bfd_jump[n - nbbd]].freq[0] - (log (1. -  random_number(0.0,1.0)) * xplasma->t_e / H_OVER_K);
-	  
+
+      
       /* Co-moving frequency - changed to rest frequency by doppler */
       /*Currently this assumed hydrogenic shape cross-section - Improve */
     }
@@ -609,6 +610,11 @@ alpha_sp (cont_ptr, xplasma, ichoice)
   cont_ext_ptr = cont_ptr;      //"
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+  if ((H_OVER_K * (flast-fthresh) / temp_ext) > ALPHA_MATOM_NUMAX_LIMIT)
+    {
+      //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+      flast = fthresh + temp_ext * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+    }
   alpha_sp_value = qromb (alpha_sp_integrand, fthresh, flast, 1e-4);
 
   /* The lines above evaluate the integral in alpha_sp. Now we just want to multiply 
@@ -652,6 +658,7 @@ alpha_sp_integrand (freq)
   x = sigma_phot (cont_ext_ptr, freq);  //this is the cross-section
   integrand = x * freq * freq * exp (H_OVER_K * (fthresh - freq) / tt);
 
+  
   if (temp_choice == 1)
     return (integrand * freq / fthresh);        //energy weighed case
   if (temp_choice == 2)
@@ -996,11 +1003,10 @@ kpkt (p, nres, escape)
 
         /* Now (as in matom) choose a frequency for the new packet. */
 
-//        p->freq = phot_top[i].freq[0] - (log (1. - (rand () + 0.5) / MAXRAND) * xplasma->t_e / H_OVER_K); //DONE
         p->freq = phot_top[i].freq[0] - (log (1. - random_number(0.0,1.0)) * xplasma->t_e / H_OVER_K);
 		
         /* Co-moving frequency - changed to rest frequency by doppler */
-        /*Currently this assumed hydrogenic shape cross-section - Improve */
+        /* Currently this assumed hydrogenic shape cross-section - Improve */
 
         /* k-packet is now eliminated. All done. */
         return (0);
@@ -1471,7 +1477,7 @@ emit_matom (w, p, nres, upper)
     *nres = config[uplvl].bfd_jump[n - nbbd] + NLINES + 1;
     /* continuua are indicated by nres > NLINES */
 //    p->freq = phot_top[config[uplvl].bfd_jump[n - nbbd]].freq[0] - (log (1. - (rand () + 0.5) / MAXRAND) * t_e / H_OVER_K); DONE
-    p->freq = phot_top[config[uplvl].bfd_jump[n - nbbd]].freq[0] - (log (1. - random_number(0.0,1.0)) * t_e / H_OVER_K);
+    p->freq = phot_top[config[uplvl].bfd_jump[n - nbbd]].freq[0] - (log (1. - random_number(0.0,1.0)) * t_e / H_OVER_K);    
 	
     /* Co-moving frequency - changed to rest frequency by doppler */
     /*Currently this assumed hydrogenic shape cross-section - Improve */
@@ -1588,3 +1594,4 @@ matom_emit_in_line_prob (WindPtr one, struct lines *line_ptr_emit)
   //Return probability that the matom in this cell de-excites into this line
   return (eprbs_line / penorm);
 }
+

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -137,7 +137,8 @@ get_matom_f (mode)
 
 
 
-    Log ("Calculating macro atom emissivities- this might take a while...\n");
+    Log ("Calculating macro-atom and k-packet emissivities- this might take a while...\n");
+    Log ("Number of macro-atom levels: %d\n", nlevels_macro);
 
     /* For MPI parallelisation, the following loop will be distributed over multiple tasks. 
        Note that the mynmim and mynmax variables are still used even without MPI on */
@@ -283,6 +284,9 @@ get_matom_f (mode)
                 ppp.nres = nres;
                 ppp.grid = plasmamain[n].nwind;
                 ppp.w = 0;
+                /* this needs to be initialised because we set to istat to P_ADIABATIC
+                   for adiabatic destruction */
+                ppp.istat = P_INWIND; 
 
                 macro_gov (&ppp, &nres, 1, &which_out);
 
@@ -300,6 +304,9 @@ get_matom_f (mode)
                 ppp.nres = nres;
                 ppp.grid = plasmamain[n].nwind;
                 ppp.w = 0;
+                /* this needs to be initialised because we set to istat to P_ADIABATIC
+                   for adiabatic destruction */
+                ppp.istat = P_INWIND;
 
                 macro_gov (&ppp, &nres, 2, &which_out);
 
@@ -307,7 +314,7 @@ get_matom_f (mode)
               }
 
 
-              if (ppp.freq > em_rnge.fmin && ppp.freq < em_rnge.fmax)
+              if (ppp.freq > em_rnge.fmin && ppp.freq < em_rnge.fmax && ppp.istat != P_ADIABATIC)
               {
                 if (which_out == 1)
                 {

--- a/source/python.h
+++ b/source/python.h
@@ -919,7 +919,6 @@ typedef struct photon_store
 PhotStorePtr photstoremain;
 
 
-
 typedef struct macro
 {
   double *jbar;
@@ -1410,6 +1409,8 @@ files;
 #define CALCULATE_MATOM_EMISSIVITIES 0
 #define USE_STORED_MATOM_EMISSIVITIES 1
 
+/* Variable introducted to cut off macroatom / estimator integrals when exponential function reaches extreme values. Effectivevly a max limit imposed on x = hnu/kT terms */
+#define ALPHA_MATOM_NUMAX_LIMIT 30 /* maximum value for h nu / k T to be considered in integrals */
 
 
 /* DIAGNOSTIC for understanding problems imported models


### PR DESCRIPTION
This change limits the integral range for matom estimators (fixes #417). This involves changes to the 
estimators gamma_e, gamma, alpha_sp, alpha_sp_e, alpha_st, alpha_st_e (Lucy 2003 notation). See issue for more details.

An additional change here is that we now use istat to check if a photon was destroyed by adiabatic cooling in get_matom_f() - this ensures that adiabatic cooling photons are not added to the kpkt emissivity count. 