### PR TITLE
Made changes to brem to fix bug #443

### DIFF
--- a/source/brem.c
+++ b/source/brem.c
@@ -99,6 +99,7 @@ brem_d (alpha)
  changed (this will happen as we move thruogh the photon generation bands) */
 
 int ninit_brem = 0;             // This is a flag to say wether a cdf has already been made
+double old_brem_alpha_tiny =0;
 double old_brem_t = 0;          // This is the temperature last used to make a cdf
 double old_brem_freqmin = 0;    // This is the lower frequency last used to make a cdf
 double old_brem_freqmax = 0;    // This is the lower frequency last used to make a cdf
@@ -153,16 +154,18 @@ double
 get_rand_brem (freqmin, freqmax)
      double freqmin, freqmax;
 {
-  double freq, alpha, y;
+  double freq, alpha, y, brem_alpha_tiny;
   int echeck;
 
-
+    brem_alpha_tiny=H*xband.f1[0]/BOLTZMANN/geo.brem_temp;
+	
+	if (brem_alpha_tiny>BREM_ALPHAMIN) brem_alpha_tiny=BREM_ALPHAMIN/10.;
 
   /*The first time of calling this function we produce a CDF which runs from BREM_ALPHAMIN to BREM_ALPHAMAX
      the dmiensinless frequency range over which we cannot use the power law or exponential approximations.
      This only needs to be done one, ans so a flag is set once the CDF has been made */
 
-  if (ninit_brem == 0)
+  if (ninit_brem == 0 || brem_alpha_tiny != old_brem_alpha_tiny)
   {                             /* First time through p_alpha must be initialized */
     if ((echeck = cdf_gen_from_func (&cdf_brem, &brem_d, BREM_ALPHAMIN, BREM_ALPHAMAX, 10, brem_set)) != 0)
     {
@@ -171,13 +174,14 @@ get_rand_brem (freqmin, freqmax)
 
     /* We need the integral of the brem function outside of the regions of interest as well */
 
-    cdf_brem_tot = qromb (brem_d, 0.0, BREM_ALPHABIG, 1e-8);
-    cdf_brem_lo = qromb (brem_d, 0, BREM_ALPHAMIN, 1e-8) / cdf_brem_tot;        //position in the full cdf of low frequcny boundary
+    cdf_brem_tot = qromb (brem_d, brem_alpha_tiny, BREM_ALPHABIG, 1e-8);
+    cdf_brem_lo = qromb (brem_d, brem_alpha_tiny, BREM_ALPHAMIN, 1e-8) / cdf_brem_tot;        //position in the full cdf of low frequcny boundary
     cdf_brem_hi = 1. - qromb (brem_d, BREM_ALPHAMAX, BREM_ALPHABIG, 1e-8) / cdf_brem_tot;       //postion in fhe full hi frequcny boundary
 
 
 
     ninit_brem++;               //Set the flag to tell the code we have made the CDF.
+	old_brem_alpha_tiny=brem_alpha_tiny;
 
   }
 
@@ -203,13 +207,13 @@ get_rand_brem (freqmin, freqmax)
     cdf_brem_ylo = cdf_brem_yhi = 1.0;
     if (brem_alphamin < BREM_ALPHABIG)  //There is *some* emission
     {
-      cdf_brem_ylo = qromb (brem_d, 0.0, brem_alphamin, 1e-8) / cdf_brem_tot;   //The position in full CDF of the upper frequency bound
+      cdf_brem_ylo = qromb (brem_d, brem_alpha_tiny, brem_alphamin, 1e-8) / cdf_brem_tot;   //The position in full CDF of the upper frequency bound
       if (cdf_brem_ylo > 1.0)
         cdf_brem_ylo = 1.0;
     }
     if (brem_alphamax < BREM_ALPHABIG)
     {
-      cdf_brem_yhi = qromb (brem_d, 0.0, brem_alphamax, 1e-8) / cdf_brem_tot;   //position in the full cdf of currnt hi frequcny boundary
+      cdf_brem_yhi = qromb (brem_d, brem_alpha_tiny, brem_alphamax, 1e-8) / cdf_brem_tot;   //position in the full cdf of currnt hi frequcny boundary
       if (cdf_brem_yhi > 1.0)
         cdf_brem_yhi = 1.0;
     }

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -1140,10 +1140,6 @@ string2int (word, string_choices, string_values, string_answer)
   int ivalue, matched, ibest;
 
 
-  printf ("In string2int %s\n", word);
-  printf ("In string2int %s\n", string_choices);
-  printf ("In string2int %s length %lu\n", string_values, strlen (string_values));
-  printf ("In string2int %s\n", string_answer);
 
   /*Blank out the arrays we will be using here */
 
@@ -1153,13 +1149,11 @@ string2int (word, string_choices, string_values, string_answer)
     values[i] = ' ';
   }
 
-  printf ("1\n");
 
   for (i = 0; i < strlen (word); i++)
   {
     word[i] = tolower (word[i]);
   }
-  printf ("2\n");
 
 
   for (i = 0; i < strlen (string_choices); i++)
@@ -1167,17 +1161,11 @@ string2int (word, string_choices, string_values, string_answer)
     choices[i] = tolower (string_choices[i]);
   }
 
-  printf ("3\n");
 
   for (i = 0; i < strlen (string_values); i++)
   {
     values[i] = tolower (string_values[i]);
   }
-
-  printf ("4\n");
-
-
-
 
 
   ncommas = 0;
@@ -1190,7 +1178,6 @@ string2int (word, string_choices, string_values, string_answer)
     }
   }
 
-  printf ("5\n");
 
 
   vcommas = 0;
@@ -1204,7 +1191,6 @@ string2int (word, string_choices, string_values, string_answer)
   }
 
 
-  printf ("6\n");
 
 
   nchoices = sscanf (choices, "%s %s %s %s %s %s %s %s %s %s", xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8], xs[9]);
@@ -1224,7 +1210,6 @@ string2int (word, string_choices, string_values, string_answer)
     }
   }
   
-  printf ("ibest=%d\n",ibest);
   
   
   strcpy (string_answer, "none");
@@ -1234,7 +1219,6 @@ string2int (word, string_choices, string_values, string_answer)
     strcpy (string_answer, xs[ibest]);
   }
   
-  printf ("ivalue=%i\n",ivalue);
 
   return (ivalue);
 


### PR DESCRIPTION
The qromb calls in the code to make bremsstrahlung photons now run from the lowest band frequency/10. up to alpha-=100. (by which point the exponential is tiny). This fixes bug #443 which was caused by negative photon indices causing an unbounded integral when carried out from 0 to 100. 
Tested with thin shell, and for positive alpha gives identical brem spectrum, and apprears to do the correct thing for negative alpha