### PR TITLE
catch negative densities and false pop inversions from density floors

### DIFF
--- a/source/estimators.c
+++ b/source/estimators.c
@@ -432,7 +432,7 @@ mc_estimator_normalise (n)
   double volume;
   int i, j;
   double stimfac, line_freq, stat_weight_ratio;
-  double heat_contribution;
+  double heat_contribution, lower_density, upper_density;
   WindPtr one;
   PlasmaPtr xplasma;
   MacroPtr mplasma;
@@ -524,14 +524,15 @@ mc_estimator_normalise (n)
     {
 
       /* The correction for stimulated emission is (1 - n_lower * g_upper / n_upper / g_lower) */
-
-      stimfac = den_config (xplasma, line[config[i].bbu_jump[j]].nconfigu) / den_config (xplasma, i);
+      lower_density =  den_config (xplasma, i);
+      upper_density = den_config (xplasma, line[config[i].bbu_jump[j]].nconfigu);
+      stimfac = upper_density / lower_density;
       stimfac = stimfac * config[i].g / config[line[config[i].bbu_jump[j]].nconfigu].g;
       if (stimfac < 1.0 && stimfac >= 0.0)
       {
         stimfac = 1. - stimfac; //all's well
       }
-      else
+      else if (upper_density > DENSITY_PHOT_MIN && lower_density > DENSITY_PHOT_MIN)
       {
         Error ("mc_estimator_normalise: bb stimulated correction factor is out of bound. Abort.\n");
         Error ("stimfac %g, i %d, line[config[i].bbu_jump[j]].nconfigu %d\n", stimfac, i, line[config[i].bbu_jump[j]].nconfigu);
@@ -540,6 +541,10 @@ mc_estimator_normalise (n)
            den_config (xplasma, i), den_config (xplasma, line[config[i].bbu_jump[j]].nconfigu));
         stimfac = 0.0;
         //Exit (0);
+      }
+      else
+      {
+        stimfac = 0.0;
       }
 
       //get the line frequency

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -524,7 +524,7 @@ mc_estimator_normalise (n)
     {
 
       /* The correction for stimulated emission is (1 - n_lower * g_upper / n_upper / g_lower) */
-      lower_density =  den_config (xplasma, i);
+      lower_density = den_config (xplasma, i);
       upper_density = den_config (xplasma, line[config[i].bbu_jump[j]].nconfigu);
       stimfac = upper_density / lower_density;
       stimfac = stimfac * config[i].g / config[line[config[i].bbu_jump[j]].nconfigu].g;

--- a/source/matom.c
+++ b/source/matom.c
@@ -320,17 +320,17 @@ matom (p, nres, escape)
         /* For bf ionization the jump probability is just gamma * energy
            gamma is the photoionisation rate. Stimulated recombination also included. */
         cont_ptr = &phot_top[config[uplvl].bfu_jump[n]];        //pointer to continuum
-        
+
         /* first let us take care of the situation where the lower level is zero or close to zero */
         lower_density = den_config (xplasma, cont_ptr->nlev);
-        if (lower_density >= DENSITY_PHOT_MIN) 
+        if (lower_density >= DENSITY_PHOT_MIN)
         {
           density_ratio = den_config (xplasma, cont_ptr->uplev) / lower_density;
         }
         else
           density_ratio = 0.0;
 
-        jprbs_known[uplvl][m] = jprbs[m] = (mplasma->gamma_old[config[uplvl].bfu_indx_first + n] - (mplasma->alpha_st_old[config[uplvl].bfu_indx_first + n] * xplasma->ne * density_ratio) + (q_ioniz (cont_ptr, t_e) * ne)) * config[uplvl].ex; //energy of lower state
+        jprbs_known[uplvl][m] = jprbs[m] = (mplasma->gamma_old[config[uplvl].bfu_indx_first + n] - (mplasma->alpha_st_old[config[uplvl].bfu_indx_first + n] * xplasma->ne * density_ratio) + (q_ioniz (cont_ptr, t_e) * ne)) * config[uplvl].ex;        //energy of lower state
 
         /* this error condition can happen in unconverged hot cells where T_R >> T_E.
            for the moment we set to 0 and hope spontaneous recombiantion takes care of things */

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -641,7 +641,7 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
      solution via gsl_linalg_LU_refine */
   double test_val;
   double lndet;
-  FILE *dptr;
+//OLD  FILE *dptr;
 
   gsl_permutation *p;
   gsl_matrix_view m;
@@ -685,14 +685,6 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   p = gsl_permutation_alloc (nrows);
 
 
-//WRONG  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
-
-
-//WRONG  if (lndet < log (DBL_MIN * 1e4))
-//WRONG  {
-//WRONG    Error ("Solve_matrix: rate matrix ln(Determinant) is %8.4e for cell %i, possibly OK\n", lndet, nplasma);
-//WRONG
-//WRONG  }
 
   /* This routine decomposes m into its LU Components.  It stores the L part in m and the
    * U part in s and p is modified.
@@ -708,6 +700,8 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   }
 
 
+//OLD  The next lines are a more conservative way to check for a possible falure 
+//OLD  and should be deleted if problems with this do not crop up
 //OLD  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
 
 
@@ -728,14 +722,13 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   {
     lndet = gsl_linalg_LU_lndet (&m.matrix);    // get the determinant to report to user
     Error ("Solve_matrix: gsl_linalg_LU_solve failure (%d %.3e) for cell %i \n", ierr, lndet, nplasma);
-    dptr = fopen ("lower.txt", "w");
-    gsl_matrix_fprintf (dptr, &m.matrix, "%.2e");
-    fclose (dptr);
+//OLD    dptr = fopen ("lower.txt", "w");
+//OLD    gsl_matrix_fprintf (dptr, &m.matrix, "%.2e");
+//OLD    fclose (dptr);
 
     return (4);
 
 
-//OLd    Exit (0);
 
   }
 

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -640,6 +640,7 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
      solution via gsl_linalg_LU_refine */
   double test_val;
   double lndet;
+  FILE *dptr;
 
   gsl_permutation *p;
   gsl_matrix_view m;
@@ -700,7 +701,7 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
 
   if (ierr)
   {
-    Error ("Rate Matrix gsl_linalg_LU_decomp failure %d for cell %i at point A\n", ierr, nplasma);
+    Error ("Rate Matrix gsl_linalg_LU_decomp failure %d for cell %i \n", ierr, nplasma);
     Exit(0);
 
   }
@@ -721,7 +722,12 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
 
   if (ierr)
   {
-    Error ("Rate Matrix gsl_linalg_LU_solve failure %d for cell %i at point B\n", ierr, nplasma);
+    Error ("Rate Matrix gsl_linalg_LU_solve failure %d for cell %i \n", ierr, nplasma);
+    dptr=fopen("lower.txt","w");
+    gsl_matrix_fprintf(dptr,&m.matrix,"%.2e");
+    fclose(dptr);
+
+
     Exit(0);
 
   }

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -685,14 +685,14 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   p = gsl_permutation_alloc (nrows);
 
 
-  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
+//WRONG  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
 
 
-  if (lndet < log (DBL_MIN * 1e4))
-  {
-    Error ("Solve_matrix: rate matrix ln(Determinant) is %8.4e for cell %i, possibly OK\n", lndet, nplasma);
-
-  }
+//WRONG  if (lndet < log (DBL_MIN * 1e4))
+//WRONG  {
+//WRONG    Error ("Solve_matrix: rate matrix ln(Determinant) is %8.4e for cell %i, possibly OK\n", lndet, nplasma);
+//WRONG
+//WRONG  }
 
   /* This routine decomposes m into its LU Components.  It stores the L part in m and the
    * U part in s and p is modified.
@@ -708,42 +708,34 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   }
 
 
-  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
+//OLD  lndet = gsl_linalg_LU_lndet (&m.matrix);      // get the determinant to report to user
 
 
-  if (lndet < log (DBL_MIN * 1e4))
-  {
-    Error ("Solve_matrix: LU ln(Determinant) is %8.4e for cell %i\n", lndet, nplasma);
-
-    // Perform zero check
-    double u;
-    for (mm = 0; mm < nrows; mm++)
-    {
-      u = gsl_matrix_get (&m.matrix, mm, mm);
-      if (u == 0)
-      {
-        Error ("Rate Matrix is singular for cell %i with %i photons (%i ionizing) \n", nplasma, plasmamain[nplasma].ntot,
-               plasmamain[nplasma].nioniz);
-//        return (4);
-      }
-    }
-
-    return (4);
-
-  }
+//OLD   if (lndet < log (DBL_MIN * 1e4))
+//OLD   {
+//OLD     Error ("Solve_matrix: LU ln(Determinant) is %8.4e for cell %i\n", lndet, nplasma);
+//OLD 
+//OLD     }
+//OLD 
+//OLD     return (4);
+//OLD 
+//OLD   }
 
 
   ierr = gsl_linalg_LU_solve (&m.matrix, p, &b.vector, populations);
 
   if (ierr)
   {
-    Error ("Solve_matrix: gsl_linalg_LU_solve failure %d for cell %i \n", ierr, nplasma);
+    lndet = gsl_linalg_LU_lndet (&m.matrix);    // get the determinant to report to user
+    Error ("Solve_matrix: gsl_linalg_LU_solve failure (%d %.3e) for cell %i \n", ierr, lndet, nplasma);
     dptr = fopen ("lower.txt", "w");
     gsl_matrix_fprintf (dptr, &m.matrix, "%.2e");
     fclose (dptr);
 
+    return (4);
 
-    Exit (0);
+
+//OLd    Exit (0);
 
   }
 

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <float.h>
 #include "atomic.h"
 #include "python.h"
 
@@ -710,7 +711,8 @@ solve_matrix (a_data, b_data, nrows, x, nplasma)
   lndet = gsl_linalg_LU_lndet (&m.matrix);  // get the determinant to report to user
 
 
-  if (lndet == 0)
+  if (lndet < log(DBL_MIN*1e4))
+//  if (lndet == 0)
   {
     Error ("Rate Matrix ln(Determinant) is %8.4e for cell %i\n", lndet, nplasma);
     return (4);

--- a/source/xlog.c
+++ b/source/xlog.c
@@ -826,7 +826,7 @@ Debug (char *format, ...)
  **********************************************************/
 
 #ifdef MPI_ON
-  #include <mpi.h>
+#include <mpi.h>
 #endif
 
 void


### PR DESCRIPTION
This change attempts to take care of situations where a density could be zero, 

The way it does this is use if statements involving DENSITY_PHOT_MIN (1e-10) to ensure that we only bother computing stimulated correction factors if the density of both levels is above this. It's possible this threshold is too high and should be DENSITY_MIN instead. 

@kslong - could you look at doing something similar with the Sobolev optical depth and perhaps push to this branch (macropops-fix), and also review my change, perhaps along with @ssim ?