### PR TITLE
Fix to avoid compiler warnings

### DIFF
--- a/source/get_atomicdata.c
+++ b/source/get_atomicdata.c
@@ -979,6 +979,7 @@ the program working in both cases, and certainly mixed cases  04apr ksl  */
             Error ("get_atomic_data: file %s line %d: Level line incorrectly formatted\n", file, lineno);
             Error ("Get_atomic_data: %s\n", aline);
             Exit (0);
+            return (0);
           }
 // Now check that the ion for this level is already known.  If not break out
           n = 0;
@@ -1157,6 +1158,7 @@ is already incremented
             Error ("get_atomic_data: file %s line %d: Level line incorrectly formatted\n", file, lineno);
             Error ("Get_atomic_data: %s\n", aline);
             Exit (0);
+            return (0);
           }
 /* Check whether the ion for this level is known.  If not, skip the level */
 

--- a/source/import.c
+++ b/source/import.c
@@ -163,7 +163,8 @@ import_velocity (ndom, x, v)
      int ndom;
      double *x, *v;
 {
-  double speed;
+  double speed = 0.0;
+
   if (zdom[ndom].coord_type == SPHERICAL)
   {
     speed = velocity_1d (ndom, x, v);
@@ -181,6 +182,7 @@ import_velocity (ndom, x, v)
     Error ("import_velocity: Do not know how to create velocities from model of coor_type %d\n", zdom[ndom].coord_type);
     Exit (0);
   }
+
   return (speed);
 }
 
@@ -238,7 +240,8 @@ import_rho (ndom, x)
      int ndom;
      double *x;
 {
-  double rho;
+  double rho = 0.0;
+
   if (zdom[ndom].coord_type == SPHERICAL)
   {
     rho = rho_1d (ndom, x);
@@ -256,5 +259,6 @@ import_rho (ndom, x)
     Error ("import_rho:  Do not know how to create velocities from model of coor_type %d\n", zdom[ndom].coord_type);
     Exit (0);
   }
+
   return (rho);
 }

--- a/source/levels.c
+++ b/source/levels.c
@@ -110,6 +110,7 @@ levels (xplasma, mode)
   double kt;
   double z;
 
+  t = weight = 0.0;
   if (mode == NEBULARMODE_TR)   // LTE with t_r
   {
     t = xplasma->t_r;

--- a/source/lines.c
+++ b/source/lines.c
@@ -717,8 +717,8 @@ scattering_fraction (line_ptr, xplasma)
 
     Error ("scattering_fraction: Cannot handle %d line_mode\n", geo.line_mode);
     Exit (0);
+    return (0);
   }
-
 }
 
 
@@ -944,6 +944,7 @@ upsilon (n_coll, u0)
 
   /* first we compute x. This is the "reduced temperature" from
      Burgess & Tully 1992. */
+  x = 0.0;
   if (coll_stren[n_coll].type == 1 || coll_stren[n_coll].type == 4)
   {
     x = 1. - (log (coll_stren[n_coll].scaling_param) / log (u0 + coll_stren[n_coll].scaling_param));
@@ -965,6 +966,7 @@ upsilon (n_coll, u0)
 
   /*  now we extract upsilon from y  - there are four different parametrisations */
 
+  upsilon = 0.0;
   if (coll_stren[n_coll].type == 1)
   {
     upsilon = y * (log (u0 + exp (1)));

--- a/source/matom.c
+++ b/source/matom.c
@@ -153,7 +153,7 @@ matom (p, nres, escape)
 
   /* The first step is to identify the configuration that has been excited. */
 
-
+  uplvl = 0;
   if (*nres < NLINES)           //this means that it was a line excitation CHECK
   {
     uplvl = lin_ptr[*nres]->nconfigu;

--- a/source/parse.c
+++ b/source/parse.c
@@ -222,7 +222,7 @@ parse_command_line (argc, argv)
  *
  **********************************************************/
 
-int
+void
 help ()
 {
   char *some_help;

--- a/source/partition.c
+++ b/source/partition.c
@@ -118,7 +118,7 @@ partition_functions (xplasma, mode)
   int m_ground;                 /* added by SS Jan 05 */
   double z, kt;
 
-
+  t = weight = 0.0;
   if (mode == NEBULARMODE_TR)
   {
     //LTE using t_r

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -658,6 +658,7 @@ return and record an error */
   {
     Error ("ds_in_cell: Don't know how to find ds_in_cell in this coord system %d\n", zdom[ndom].coord_type);
     Exit (0);
+    return (0);
   }
 
   return (smax);

--- a/source/py_wind.c
+++ b/source/py_wind.c
@@ -663,7 +663,7 @@ one_choice (choice, root, ochoice)
  *
  **********************************************************/
 
-int
+void
 py_wind_help ()
 {
 

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -481,6 +481,7 @@ string_process_from_command_line (question, dummy)
   {
     printf ("Exiting since rdpar got EOF in interactive mode\n");
     Exit (0);
+    return (0);
   }
   else if (tdummy[0] == '\n')
   {                             //Use the current value

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -341,7 +341,7 @@ integ_fb (t, f1, f2, nion, fb_choice, mode)
 
   Error ("integ_fb: Unknown mode(%d)\n", mode);
   Exit (0);
-
+  return (0);
 }
 
 
@@ -836,8 +836,7 @@ fb (xplasma, t, freq, ion_choice, fb_choice)
   int nmin, nmax;               // These are the photo-ionization xsections that are used
   int nion, nion_min, nion_max;
 
-
-
+  nion_min = nion_max = 0;
   if (ion_choice < nions)       //Get emissivity for this specific ion_number
   {
     nion_min = ion_choice;
@@ -1240,6 +1239,7 @@ xinteg_fb (t, f1, f2, nion, fb_choice)
 
   dnu = 0.0;                    //Avoid compilation errors.
 
+  nmin = nmax = 0;
   if (-1 < nion && nion < nions)        //Get emissivity for this specific ion_number
   {
     if (ion[nion].phot_info > 0)        // topbase or hybrid

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -1101,6 +1101,7 @@ scatter (p, nres, nnscat)
            gamma_twiddles are negative then something has gone wrong.
          */
 
+        prob_kpkt = 0.0;        // initialise value
         if (gamma_twiddle > 0 && gamma_twiddle_e > 0)
         {
           prob_kpkt = 1. - gamma_twiddle / gamma_twiddle_e;

--- a/source/saha.c
+++ b/source/saha.c
@@ -118,7 +118,7 @@ nebular_concentrations (xplasma, mode)
   {
     Error ("nebular_concentrations: Unknown mode %d\n", mode);
     Exit (0);
-
+    return (0);
   }
 
 
@@ -210,6 +210,7 @@ concentrations (xplasma, mode)
   {
     Error ("Concentrations: Unknown mode %d\n", mode);
     Exit (0);
+    return (0);
   }
 
   nh = xplasma->rho * rho2nh;   //LTE

--- a/source/templates.h
+++ b/source/templates.h
@@ -38,7 +38,7 @@ double bl_init (double lum_bl, double t_bl, double freqmin, double freqmax, int 
 int photon_checks (PhotPtr p, double freqmin, double freqmax, char *comment);
 /* parse.c */
 int parse_command_line (int argc, char *argv[]);
-int help (void);
+void help (void);
 /* saha.c */
 int nebular_concentrations (PlasmaPtr xplasma, int mode);
 int concentrations (PlasmaPtr xplasma, int mode);
@@ -621,7 +621,7 @@ int level_tauoverview (int nlev, WindPtr w, char rootname[], int ochoice);
 /* py_wind.c */
 int main (int argc, char *argv[]);
 int one_choice (int choice, char *root, int ochoice);
-int py_wind_help (void);
+void py_wind_help (void);
 /* windsave2table.c */
 int main (int argc, char *argv[]);
 /* windsave2table_sub.c */

--- a/source/util.c
+++ b/source/util.c
@@ -139,6 +139,7 @@ to reflect the behavior of the search routine in where_in_grid. */
   {
     Error ("Fraction - unknown mode %i\n", mode);
     Exit (0);
+    return (0);
   }
 
   *ival = imin;
@@ -198,7 +199,7 @@ linterp (x, xarray, yarray, xdim, y, mode)
      double *y;
      int mode;                  //0 = linear, 1 = log
 {
-  int nelem;
+  int nelem = 0;
   double frac;
 
 
@@ -308,7 +309,6 @@ coord_fraction (ndom, ichoice, x, ii, frac, nelem)
    * one wants to interpolate on vertex points (0) or
    * midpoints (1)
    */
-
   if (ichoice == 0)
   {
     xx = zdom[ndom].wind_x;
@@ -321,6 +321,7 @@ coord_fraction (ndom, ichoice, x, ii, frac, nelem)
   }
 
   /* Now convert x to the appropriate coordinate system */
+  r = z = 0.0;
   if (zdom[ndom].coord_type == CYLIND)
   {
     r = sqrt (x[0] * x[0] + x[1] * x[1]);

--- a/source/wind.c
+++ b/source/wind.c
@@ -233,7 +233,7 @@ model_velocity (ndom, x, v)
      double x[], v[];
      int ndom;
 {
-  double speed;
+  double speed = 0;
 
   if (zdom[ndom].wind_type == SV)
   {
@@ -375,7 +375,7 @@ model_rho (ndom, x)
      int ndom;
      double x[];
 {
-  double rho;
+  double rho = 0;
 
   if (zdom[ndom].wind_type == SV)
   {

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -589,6 +589,7 @@ where_in_grid (ndom, x)
     {
       Error ("where_in_grid: Unknown coord_type %d for domain %d\n", zdom[ndom].coord_type, ndom);
       Exit (0);
+      return (0);
     }
 
 

--- a/source/xlog.c
+++ b/source/xlog.c
@@ -826,7 +826,7 @@ Debug (char *format, ...)
  **********************************************************/
 
 #ifdef MPI_ON
-  #include <mpi.h>
+#include <mpi.h>
 #endif
 
 void


### PR DESCRIPTION
Initialised variables and added extra returns in order to avoid compiler warnings due to new exit wrapper  function.