### PR TITLE
Changes to exiting py_wind and windsave2table

### DIFF
--- a/source/agn.c
+++ b/source/agn.c
@@ -54,8 +54,9 @@
 
 double
 agn_init (r, lum, alpha, freqmin, freqmax, ioniz_or_final, f)
-     double r, lum, alpha, freqmin, freqmax, *f;
+     double r, lum, alpha, freqmin, freqmax;
      int ioniz_or_final;
+     double *f;
 {
 
   double t;

--- a/source/corona.c
+++ b/source/corona.c
@@ -214,6 +214,7 @@ corona_velocity (ndom, x, v)
 
 double
 corona_rho (ndom, x)
+     int ndom;
      double x[];
 {
   double rho;

--- a/source/cylindrical.c
+++ b/source/cylindrical.c
@@ -647,6 +647,7 @@ cylind_get_random_location (n, x)
 
 int
 cylind_extend_density (ndom, w)
+     int ndom;
      WindPtr w;
 {
 

--- a/source/disk.c
+++ b/source/disk.c
@@ -782,7 +782,7 @@ read_non_standard_disk_profile (tprofile)
 {
 
   FILE *fopen (), *fptr;
-  int n;
+  int n, result;
   float dumflt1, dumflt2;
   int dumint;
 
@@ -792,11 +792,11 @@ read_non_standard_disk_profile (tprofile)
     Exit (0);
   }
 
-  fscanf (fptr, "%d\n", &dumint);
+  result = fscanf (fptr, "%d\n", &dumint);
   blmod.n_blpts = dumint;
   for (n = 0; n < blmod.n_blpts; n++)
   {
-    fscanf (fptr, "%g %g", &dumflt1, &dumflt2);
+    result = fscanf (fptr, "%g %g", &dumflt1, &dumflt2);
     blmod.r[n] = dumflt1 * 1.e11;
     blmod.t[n] = dumflt2 * 1.e3;
   }

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -246,8 +246,8 @@ matrix_ion_populations (xplasma, mode)
     /* Replaced inline array allocaation with calloc, which will work with older version of c compilers calloc also sets the
        elements to zero, which is required */
 
-    b_data = (double *) calloc (sizeof (double), nrows);
-    populations = (double *) calloc (sizeof (double), nrows);
+    b_data = (double *) calloc (nrows, sizeof (double));
+    populations = (double *) calloc (nrows, sizeof (double));
 
     /* This b_data column matrix is the total number density for each element, placed into the row which relates to the neutral
        ion. This matches the row in the rate matrix which is just 1 1 1 1 for all stages. NB, we could have chosen any line for

--- a/source/parse.c
+++ b/source/parse.c
@@ -52,13 +52,14 @@ parse_command_line (argc, argv)
   char dummy[LINELENGTH];
   int mkdir ();
   double time_max;
+  char *fgets_result;
 
   restart_stat = 0;
 
   if (argc == 1)
   {
     printf ("Parameter file name (e.g. my_model.pf, or just my_model):");
-    fgets (dummy, LINELENGTH, stdin);
+    fgets_result = fgets (dummy, LINELENGTH, stdin);
     get_root (files.root, dummy);
     strcpy (files.diag, files.root);
     strcat (files.diag, ".diag");

--- a/source/py_wind.c
+++ b/source/py_wind.c
@@ -152,6 +152,7 @@ main (argc, argv)
   char windradfile[LINELENGTH], windsavefile[LINELENGTH];
   char parameter_file[LINELENGTH];
   char photfile[LINELENGTH];
+  char *fgets_result;
   double freq;
   int interactive;
 
@@ -172,7 +173,7 @@ main (argc, argv)
   if (argc == 1)
   {
     printf ("Root for wind file :");
-    fgets (input, LINELENGTH, stdin);
+    fgets_result = fgets (input, LINELENGTH, stdin);
     get_root (root, input);
   }
   else
@@ -247,7 +248,7 @@ I did not change this now.  Though it could be done.  02apr ksl */
   if (wind_read (windsavefile) < 0)
   {
     Error ("py_wind: Could not open %s", windsavefile);
-    Exit (0);
+    exit (0);
   }
 
 /* aaa is used to store variable for writing to files for the purpose of plotting*/
@@ -270,7 +271,7 @@ I did not change this now.  Though it could be done.  02apr ksl */
     zoom (1);                   /* This affects the logfile */
     ochoice = 1;
     complete_file_summary (wmain, root, ochoice);
-    Exit (0);
+    exit (0);
   }
   else if (interactive == -1)
   {
@@ -296,7 +297,7 @@ I did not change this now.  Though it could be done.  02apr ksl */
       sprintf (windsavefile, "python%02d.wind_save", i);
       i++;
     }
-    Exit (0);
+    exit (0);
   }
 
 
@@ -630,7 +631,7 @@ one_choice (choice, root, ochoice)
   case 'q':                    /* quit */
     /* Write out a parameterfile that gives all of the commands used in this run */
     cpar ("py_wind.pf");
-    Exit (0);
+    exit (0);
     break;
 
   }
@@ -692,7 +693,5 @@ This program reads a wind save file created by python and examine the wind struc
 
   printf ("Choices are indicated below\n%s\n", choice_options);
 
-  Exit (0);
-
-  return (0);
+  exit (0);
 }

--- a/source/py_wind_ion.c
+++ b/source/py_wind_ion.c
@@ -170,7 +170,7 @@ ion_summary (w, element, istate, iswitch, rootname, ochoice)
       else
       {
         Error ("ion_summary : Unknown switch %d \n", iswitch);
-        Exit (0);
+        exit (0);
       }
     }
   }
@@ -206,7 +206,7 @@ ion_summary (w, element, istate, iswitch, rootname, ochoice)
         else
         {
           Error ("ion_summary : Unknown switch %d \n", iswitch);
-          Exit (0);
+          exit (0);
         }
 
 
@@ -229,7 +229,7 @@ ion_summary (w, element, istate, iswitch, rootname, ochoice)
     else
     {
       Error ("ion_summary : Unknown switch %d \n", iswitch);
-      Exit (0);
+      exit (0);
     }
 
     strcat (choice, ele[nelem].name);
@@ -425,7 +425,7 @@ line_summary (w, rootname, ochoice)
     break;
   default:
     Error ("line_summary: Not a valid line.");
-    Exit (0);
+    exit (0);
 
   }
 
@@ -446,7 +446,7 @@ line_summary (w, rootname, ochoice)
     if (nline == nlines)
     {
       Error ("line_summary: Could not find line in linelist\n");
-      Exit (0);
+      exit (0);
     }
     nelem = 0;
     while (nelem < nelements && ele[nelem].z != element)
@@ -491,7 +491,7 @@ line_summary (w, rootname, ochoice)
     if (nline == nlines)
     {
       Error ("line_summary: Could not find line in linelist\n");
-      Exit (0);
+      exit (0);
     }
   }
 
@@ -616,6 +616,7 @@ int
 total_emission_summary (w, rootname, ochoice)
      WindPtr w;
      char rootname[];
+     int ochoice;
 {
   double tot;
   int n;
@@ -671,6 +672,7 @@ int
 modify_te (w, rootname, ochoice)
      WindPtr w;
      char rootname[];
+     int ochoice;
 {
   int n;
   double x;
@@ -823,7 +825,7 @@ collision_summary (w, rootname, ochoice)
   int nline, int_te;
   double t_e, qup, qdown, A, wavelength;
   char filename[LINELENGTH], suffix[LINELENGTH];
-  FILE *fopen (), *fptr;
+  FILE *fopen (), *fptr = NULL;
 
   t_e = 10000.0;
 

--- a/source/py_wind_macro.c
+++ b/source/py_wind_macro.c
@@ -472,12 +472,12 @@ copy_plasma (x1, x2)
   if ((x2->density = calloc (sizeof (double), nions)) == NULL)
   {
     Error ("calloc_dyn_plasma: Error in allocating memory for density\n");
-    Exit (0);
+    exit (0);
   }
   if ((x2->partition = calloc (sizeof (double), nions)) == NULL)
   {
     Error ("calloc_dyn_plasma: Error in allocating memory for partition\n");
-    Exit (0);
+    exit (0);
   }
   for (i = 0; i < nions; i++)
   {
@@ -833,7 +833,7 @@ level_escapeoverview (nlev, w, rootname, ochoice)
   if (nline == nlines)
   {
     Error ("level_escapeoverview: Could not find line in linelist\n");
-    Exit (0);
+    exit (0);
   }
 
   nline--;
@@ -926,7 +926,7 @@ level_tauoverview (nlev, w, rootname, ochoice)
   if (nline == nlines)
   {
     Error ("level_tauoverview: Could not find line in linelist\n");
-    Exit (0);
+    exit (0);
   }
 
   nline--;

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -3377,7 +3377,7 @@ complete_ion_summary (w, rootname, ochoice)
 {
   char cell[5];
   PlasmaPtr xplasma;
-  FILE *fptr, *fopen ();
+  FILE *fptr = NULL, *fopen ();
   char filename[LINELENGTH];
 
 

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -1231,7 +1231,7 @@ string2int (word, string_choices, string_values, string_answer)
 
   if (ibest >= 0)
   {
-    printf ("XX %s %d\n", xs[ibest], ivalue);
+    // OLD printf ("XX %s %d\n", xs[ibest], ivalue);
     strcpy (string_answer, xs[ibest]);
   }
 
@@ -1339,7 +1339,7 @@ rdchoice (question, answers, answer)
     strcpy (dummy, &question[nstart + 1]);
     dummy[strlen (dummy) - 1] = ' ';
     ianswer = string2int (string_answer, dummy, answers, full_answer);
-    printf ("XXX the answer was %s\n", full_answer);
+    // OLD printf ("XXX the answer was %s\n", full_answer);
     if (ianswer == -99)
     {
       Error ("rdchoice: Could not match %s input to one of answers: %s\nTry again\n", string_answer, dummy);

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -556,7 +556,7 @@ string_process_from_file (question, dummy)
 {
 
   char firstword[LINELEN], secondword[LINELEN];
-  char *line;
+  char *line, *fgets_return;
   char *ccc, *index (), *fgets ();
   int nwords, wordlength;
   char old_question[LINELEN];
@@ -658,7 +658,7 @@ string_process_from_file (question, dummy)
 
     strcpy (secondword, dummy);
 
-    fgets (dummy, LINELEN, stdin);
+    fgets_return = fgets (dummy, LINELEN, stdin);
 
     if (strcmp (dummy, "\n") == 0)
     {                           /* Store the provided value since \n */

--- a/source/setup_star_bh.c
+++ b/source/setup_star_bh.c
@@ -192,7 +192,7 @@ get_bl_and_agn_params (lstar)
   }
   else
   {
-    Log ("Not Trying to make a start with a power law boundary layer %d\n", geo.bl_ion_spectype);
+    Log ("Not trying to make a start with a power law boundary layer %d\n", geo.bl_ion_spectype);
   }
 
 
@@ -231,10 +231,11 @@ get_bl_and_agn_params (lstar)
     /* if we have a "blackbody agn" the luminosity is set by Stefan Boltzmann law
        once the AGN blackbody temp is read in, otherwise set by user */
     if (geo.agn_ion_spectype != SPECTYPE_BB)
+    {
       rddoub ("lum_agn(ergs/s)", &geo.lum_agn);
+      Log ("OK, the agn lum will be about %.2e the disk lum\n", geo.lum_agn / xbl);
+    }
 
-
-    Log ("OK, the agn lum will be about %.2e the disk lum\n", geo.lum_agn / xbl);
     if (geo.agn_ion_spectype == SPECTYPE_POW || geo.agn_ion_spectype == SPECTYPE_CL_TAB)
     {
       geo.alpha_agn = (-1.5);
@@ -268,6 +269,7 @@ get_bl_and_agn_params (lstar)
       /* note that alpha_agn holds the temperature in the case of "blackbody agn" */
       rddoub ("AGN.blackbody_temp(K)", &geo.alpha_agn);
       geo.lum_agn = 4 * PI * geo.r_agn * geo.r_agn * STEFAN_BOLTZMANN * pow (geo.alpha_agn, 4.);
+      Log ("OK, the agn lum will be about %.2e the disk lum\n", geo.lum_agn / xbl);
     }
 
     /* JM 1502 -- lines to add a low frequency power law cutoff. accessible

--- a/source/windsave2table.c
+++ b/source/windsave2table.c
@@ -97,7 +97,7 @@ main (argc, argv)
 {
 
 
-
+  char *fgets_return;
   char root[LINELENGTH], input[LINELENGTH];
   char outputfile[LINELENGTH];
   char windsavefile[LINELENGTH];
@@ -115,7 +115,7 @@ main (argc, argv)
   if (argc == 1)
   {
     printf ("Root for wind file :");
-    fgets (input, LINELENGTH, stdin);
+    fgets_return = fgets (input, LINELENGTH, stdin);
     get_root (root, input);
   }
   else
@@ -141,7 +141,7 @@ main (argc, argv)
   if (wind_read (windsavefile) < 0)
   {
     Error ("py_wind: Could not open %s", windsavefile);
-    Exit (0);
+    exit (0);
   }
 
 

--- a/source/windsave2table_sub.c
+++ b/source/windsave2table_sub.c
@@ -934,7 +934,7 @@ get_ion (ndom, element, istate, iswitch)
       else
       {
         Error ("xion_summary : Unknown switch %d \n", iswitch);
-        Exit (0);
+        exit (0);
       }
     }
   }


### PR DESCRIPTION
I've changed the exit functions to the standard library exit as discussed in issue #439.  There are also a few changes to remove some of the easier to fix compiler warnings.