### PR TITLE
Improvements to kpacket photon generation

### DIFF
--- a/source/ionization.c
+++ b/source/ionization.c
@@ -196,7 +196,7 @@ convergence (xplasma)
   {
     if ((xplasma->converge_t_e = fabs (xplasma->t_e_old - xplasma->t_e) / (xplasma->t_e_old + xplasma->t_e)) > epsilon)
       xplasma->techeck = techeck = 1;
-    if ((xplasma->converge_hc = fabs (xplasma->heat_tot - xplasma->cool_tot) / fabs (xplasma->heat_tot + xplasma->cool_tot)) > epsilon)
+    if ((xplasma->converge_hc = fabs (xplasma->heat_tot + xplasma->heat_shock - xplasma->cool_tot) / fabs (xplasma->heat_tot + xplasma->heat_shock + xplasma->cool_tot)) > epsilon)
       xplasma->hccheck = hccheck = 1;
   }
   else                          //If the cell has reached the maximum temperature

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -210,7 +210,9 @@ convergence (xplasma)
     if ((xplasma->converge_t_e = fabs (xplasma->t_e_old - xplasma->t_e) / (xplasma->t_e_old + xplasma->t_e)) > epsilon)
       xplasma->techeck = techeck = 1;
 
-    if ((xplasma->converge_hc = fabs (xplasma->heat_tot + xplasma->heat_shock - xplasma->cool_tot) / fabs (xplasma->heat_tot + xplasma->heat_shock + xplasma->cool_tot)) > epsilon)
+    if ((xplasma->converge_hc =
+         fabs (xplasma->heat_tot + xplasma->heat_shock - xplasma->cool_tot) / fabs (xplasma->heat_tot + xplasma->heat_shock +
+                                                                                    xplasma->cool_tot)) > epsilon)
       xplasma->hccheck = hccheck = 1;
   }
   else                          // If the cell has reached the maximum temperature we mark it as over-limit

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -605,6 +605,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
 
     while (test > fmax || test < fmin)
     {
+      pp.w = p[n].w;
       kpkt (&pp, &nres, &esc_ptr, kpkt_mode); 
 
       if (esc_ptr == 0 && kpkt_mode == KPKT_MODE_CONTINUUM)

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -80,9 +80,9 @@ get_kpkt_heating_f ()
 
     /* what we do depends on how the "net heating mode" is defined */
     if (KPKT_NET_HEAT_MODE)
-      shock_kpkt_luminosity = (shock_heating(one) - plasmamain[n].cool_adiabatic);
+      shock_kpkt_luminosity = (shock_heating (one) - plasmamain[n].cool_adiabatic);
     else
-      shock_kpkt_luminosity = shock_heating(one);
+      shock_kpkt_luminosity = shock_heating (one);
 
     if (shock_kpkt_luminosity > 0)
     {
@@ -606,7 +606,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
     while (test > fmax || test < fmin)
     {
       pp.w = p[n].w;
-      kpkt (&pp, &nres, &esc_ptr, kpkt_mode); 
+      kpkt (&pp, &nres, &esc_ptr, kpkt_mode);
 
       if (esc_ptr == 0 && kpkt_mode == KPKT_MODE_CONTINUUM)
       {

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -555,7 +555,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
   double fmin, fmax;
 
   photstop = photstart + nphot;
-  Log ("photo_gen_kpkt creates nphot %5d photons from %5d to %5d \n", nphot, photstart, photstop);
+  Log ("photo_gen_kpkt creates nphot %5d photons from %5d to %5d, weight %8.4e \n", nphot, photstart, photstop, weight);
 
   if (geo.ioniz_or_extract)
   {
@@ -606,6 +606,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
     while (test > fmax || test < fmin)
     {
       kpkt (&pp, &nres, &esc_ptr, kpkt_mode); 
+
       if (esc_ptr == 0 && kpkt_mode == KPKT_MODE_CONTINUUM)
       {
         test = 0.0;
@@ -623,6 +624,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
     p[n].freq = pp.freq;
     p[n].nres = nres;
     p[n].w = pp.w;
+
 
     /* The photon frequency is now known. */
 

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -65,8 +65,7 @@ get_kpkt_f ()
  **********************************************************/
 
 double
-get_kpkt_heating_f (fraction)
-  double fraction;
+get_kpkt_heating_f ()
 {
   int n, nwind;
   double lum, shock_kpkt_luminosity;
@@ -81,9 +80,9 @@ get_kpkt_heating_f (fraction)
 
     /* what we do depends on how the "net heating mode" is defined */
     if (KPKT_NET_HEAT_MODE)
-      shock_kpkt_luminosity = fraction * (shock_heating(one) - plasmamain[n].cool_adiabatic);
+      shock_kpkt_luminosity = (shock_heating(one) - plasmamain[n].cool_adiabatic);
     else
-      shock_kpkt_luminosity = fraction * shock_heating(one);
+      shock_kpkt_luminosity = shock_heating(one);
 
     if (shock_kpkt_luminosity > 0)
     {
@@ -161,7 +160,7 @@ get_matom_f (mode)
 #endif
 
     /* add the non-radiative k-packet heating to the kpkt_abs quantity */
-    get_kpkt_heating_f (1.0);
+    get_kpkt_heating_f ();
 
     which_out = 0;
     n_tries = 5000000;

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -87,14 +87,16 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
   double ftot;
   int n;
   int iphot_start, nphot_rad, nphot_k;
-  long nphot_tot_rad;
+  long nphot_tot_rad, nphot_tot_k;
 
-  /* if we are generate nonradiative kpackets, then we need to subtract 
+  /* if we are generating nonradiative kpackets, then we need to subtract 
      off the fraction reserved for k-packets */
   if (geo.nonthermal && (geo.rt_mode == RT_MODE_MACRO) && (ioniz_or_final == 0))
   {
-    nphot_rad = NPHOT - (geo.frac_extra_kpkts * NPHOT);
-    nphot_tot_rad = nphot_tot - (geo.frac_extra_kpkts * nphot_tot);
+    nphot_k = (geo.frac_extra_kpkts * NPHOT);
+    nphot_rad = NPHOT - nphot_k;
+    nphot_tot_k = (geo.frac_extra_kpkts * nphot_tot);
+    nphot_tot_rad = nphot_tot - nphot_tot_k; 
   }
   else
   {
@@ -167,14 +169,17 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     geo.f_kpkt = get_kpkt_heating_f (); 
 
     /* get the number of photons we have reserved in the photon structure */
-    nphot_k = geo.frac_extra_kpkts * NPHOT; 
-    weight = (geo.f_kpkt) / (nphot_k);
+    //nphot_k = geo.frac_extra_kpkts * NPHOT; 
+    weight = (geo.f_kpkt) / (nphot_tot_k);
 
     /* throw an error if the k-packet weight is too high or low */
-    if ( weight > (100.0 * natural_weight) || weight < (0.01 * natural_weight) )
+    if ( weight > (100.0 * natural_weight) || weight < (0.01 * natural_weight))
     {
       Error("define_phot: kpkt weight is %8.4e compared to characteristic photon weight %8.4e\n", weight, natural_weight);
     }
+    if (sane_check(weight))
+      Error("define_phot: kpkt weight is %8.4e!\n", weight);
+
     Log ("!! xdefine_phot: total & banded kpkt luminosity due to non-radiative heating: %8.2e %8.2e \n", geo.heat_shock, geo.f_kpkt);
 
 

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -96,7 +96,7 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     nphot_k = (geo.frac_extra_kpkts * NPHOT);
     nphot_rad = NPHOT - nphot_k;
     nphot_tot_k = (geo.frac_extra_kpkts * nphot_tot);
-    nphot_tot_rad = nphot_tot - nphot_tot_k; 
+    nphot_tot_rad = nphot_tot - nphot_tot_k;
   }
   else
   {
@@ -166,19 +166,19 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
   if (geo.nonthermal && (geo.rt_mode == RT_MODE_MACRO) && (ioniz_or_final == 0))
   {
     /* calculate the non-radiative kpkt luminosity throughout the wind */
-    geo.f_kpkt = get_kpkt_heating_f (); 
+    geo.f_kpkt = get_kpkt_heating_f ();
 
     /* get the number of photons we have reserved in the photon structure */
     //nphot_k = geo.frac_extra_kpkts * NPHOT; 
     weight = (geo.f_kpkt) / (nphot_tot_k);
 
     /* throw an error if the k-packet weight is too high or low */
-    if ( weight > (100.0 * natural_weight) || weight < (0.01 * natural_weight))
+    if (weight > (100.0 * natural_weight) || weight < (0.01 * natural_weight))
     {
-      Error("define_phot: kpkt weight is %8.4e compared to characteristic photon weight %8.4e\n", weight, natural_weight);
+      Error ("define_phot: kpkt weight is %8.4e compared to characteristic photon weight %8.4e\n", weight, natural_weight);
     }
-    if (sane_check(weight))
-      Error("define_phot: kpkt weight is %8.4e!\n", weight);
+    if (sane_check (weight))
+      Error ("define_phot: kpkt weight is %8.4e!\n", weight);
 
     Log ("!! xdefine_phot: total & banded kpkt luminosity due to non-radiative heating: %8.2e %8.2e \n", geo.heat_shock, geo.f_kpkt);
 
@@ -193,7 +193,7 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     p[n].w_orig = p[n].w;
     p[n].freq_orig = p[n].freq;
     p[n].origin_orig = p[n].origin;
-    if (geo.reverb != REV_NONE && p[n].path < 0.0) // SWM - Set path lengths for disk, star etc.
+    if (geo.reverb != REV_NONE && p[n].path < 0.0)      // SWM - Set path lengths for disk, star etc.
       simple_paths_gen_phot (&p[n]);
   }
   return (0);
@@ -287,8 +287,8 @@ populate_bands (ioniz_or_final, iwind, band)
   }
 
   /* Because of roundoff errors nphot may not sum to the desired value, namely NPHOT less kpackets.  
-  So add a few more photons to the band with most photons already. It should only be a few, at most
-  one photon for each band.*/
+     So add a few more photons to the band with most photons already. It should only be a few, at most
+     one photon for each band. */
 
   if (nphot < nphot_rad)
   {

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -163,7 +163,7 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
   }
 
   /* deal with k-packets generated from nonradiative heating */
-  if (geo.nonthermal && (geo.rt_mode == RT_MODE_MACRO))
+  if (geo.nonthermal && (geo.rt_mode == RT_MODE_MACRO) && (ioniz_or_final == 0))
   {
     /* calculate the non-radiative kpkt luminosity throughout the wind */
     geo.f_kpkt = get_kpkt_heating_f (); 

--- a/source/python.h
+++ b/source/python.h
@@ -498,6 +498,8 @@ struct geometry
 
   double shock_factor;          /* A scaling factor used for including an extra heating term (for FU Ori stars
                                  */
+  double frac_extra_kpkts;      /* in the case that we have extra heating and macro-atoms, the fraction of 
+                                   photons to reserve for those generated directly by k-packets */
 
   int auger_ionization;         /*0 -> Do not include innershell photoionization /Auger effects; 1-> include them */
 

--- a/source/setup.c
+++ b/source/setup.c
@@ -625,8 +625,7 @@ init_ionization ()
 
   thermal_opt = 0;
 
-  rdchoice("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)","0,1,2,3"
-            &thermal_opt);
+  rdchoice("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)","0,1,2,3",&thermal_opt);
 
   if (thermal_opt == 0)
     {
@@ -671,6 +670,12 @@ init_ionization ()
       rddoub ("Thermal_balance_options.extra_heating", &geo.shock_factor);
       geo.shock_factor /= (4*PI*pow(geo.rstar,3));
       Log("The non_thermal emissivity at the base is %.2e\n", geo.shock_factor);
+
+      if (geo.rt_mode = RT_MODE_MACRO)
+      {
+        geo.frac_extra_kpkts = 0.1;
+        rddoub ("Thermal_balance_options.extra_kpacket_frac", &geo.frac_extra_kpkts);
+      }
     }
 
 

--- a/source/setup.c
+++ b/source/setup.c
@@ -625,7 +625,7 @@ init_ionization ()
 
   thermal_opt = 0;
 
-  rdchoice("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)","0,1,2,3",&thermal_opt);
+  thermal_opt = rdchoice("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)", "0,1,2,3", answer);
 
   if (thermal_opt == 0)
     {

--- a/source/setup.c
+++ b/source/setup.c
@@ -646,7 +646,7 @@ init_ionization ()
 
   thermal_opt = 0;
 
-  thermal_opt = rdchoice("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)", "0,1,2,3", answer);
+  thermal_opt = rdchoice ("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)", "0,1,2,3", answer);
 
   if (thermal_opt == 0)
   {
@@ -677,27 +677,27 @@ init_ionization ()
   }
 
   if (geo.nonthermal)
+  {
+    /* The shock heating is defined initally as a luminosity to be added to wind
+     * but is immediately converted to a luminosity per unit volumne
+     *
+     * Since nearly all systems that we are dealing with have a star we initialize
+     * the amount of extra heating as a fraction of the stellar luminosity
+     *
+     * See cooling.c shock_heating
+     */
+
+    geo.shock_factor = 0.001 * 4 * PI * pow (geo.rstar, 2) * STEFAN_BOLTZMANN * pow (geo.tstar, 4.);
+    rddoub ("Thermal_balance_options.extra_heating", &geo.shock_factor);
+    geo.shock_factor /= (4 * PI * pow (geo.rstar, 3));
+    Log ("The non_thermal emissivity at the base is %.2e\n", geo.shock_factor);
+
+    if (geo.rt_mode = RT_MODE_MACRO)
     {
-        /* The shock heating is defined initally as a luminosity to be added to wind
-         * but is immediately converted to a luminosity per unit volumne
-         *
-         * Since nearly all systems that we are dealing with have a star we initialize
-         * the amount of extra heating as a fraction of the stellar luminosity
-         *
-         * See cooling.c shock_heating
-         */
-
-      geo.shock_factor=0.001*4*PI*pow(geo.rstar,2)*STEFAN_BOLTZMANN*pow(geo.tstar,4.);
-      rddoub ("Thermal_balance_options.extra_heating", &geo.shock_factor);
-      geo.shock_factor /= (4*PI*pow(geo.rstar,3));
-      Log("The non_thermal emissivity at the base is %.2e\n", geo.shock_factor);
-
-      if (geo.rt_mode = RT_MODE_MACRO)
-      {
-        geo.frac_extra_kpkts = 0.1;
-        rddoub ("Thermal_balance_options.extra_kpacket_frac", &geo.frac_extra_kpkts);
-      }
+      geo.frac_extra_kpkts = 0.1;
+      rddoub ("Thermal_balance_options.extra_kpacket_frac", &geo.frac_extra_kpkts);
     }
+  }
 
   /* Prevent bf calculation of macro_estimators when no macro atoms are present.   */
 

--- a/source/spectra.c
+++ b/source/spectra.c
@@ -558,17 +558,17 @@ spectrum_create (p, f1, f2, nangle, select_extract)
     }
   }
 
-  Log ("\nNo. of photons which have scattered n times.     The max number of scatters seen was %d\n", max_scat);
-  for (i = 0; i <= max_scat; i++)
-  {
-      if (nscat[i]>0) {
-          maxscat=i;
-      }
-  }
+  Log ("\nNo. of photons which have scattered n times. The max number of scatters seen was %d\n", max_scat);
+  // for (i = 0; i <= max_scat; i++)
+  // {
+  //     if (nscat[i]>0) {
+  //         maxscat=i;
+  //     }
+  // }
 
 
   Log ("\nNo. of photons which have scattered n times\n");
-  for (i = 0; i <= maxscat; i++)
+  for (i = 0; i <= max_scat; i++)
   {
     Log ("%6d", nscat[i]);
     if ((i % 10) == 9)

--- a/source/templates.h
+++ b/source/templates.h
@@ -27,7 +27,7 @@ int walls (PhotPtr p, PhotPtr pold, double *normal);
 /* photon_gen.c */
 int define_phot (PhotPtr p, double f1, double f2, long nphot_tot, int ioniz_or_final, int iwind, int freq_sampling);
 double populate_bands (int ioniz_or_final, int iwind, struct xbands *band);
-int xdefine_phot (double f1, double f2, int ioniz_or_final, int iwind, int print_mode, double kpkt_fraction);
+int xdefine_phot (double f1, double f2, int ioniz_or_final, int iwind, int print_mode);
 int xmake_phot (PhotPtr p, double f1, double f2, int ioniz_or_final, int iwind, double weight, int iphot_start, int nphotons);
 int star_init (double freqmin, double freqmax, int ioniz_or_final, double *f);
 int photo_gen_star (PhotPtr p, double r, double t, double weight, double f1, double f2, int spectype, int istart, int nphot);
@@ -473,7 +473,7 @@ int setup_windcone (void);
 double get_disk_params (void);
 /* photo_gen_matom.c */
 double get_kpkt_f (void);
-double get_kpkt_heating_f (double fraction);
+double get_kpkt_heating_f (void);
 double get_matom_f (int mode);
 int photo_gen_kpkt (PhotPtr p, double weight, int photstart, int nphot);
 int photo_gen_matom (PhotPtr p, double weight, int photstart, int nphot);


### PR DESCRIPTION
Accidental duplicate of #478 - I have met my github match on two counts today.  

As discussed recently, we want k-packet photon generation to be non-banded and take place after the banded photon generation. This change implements this and has a new variable for the fraction of photons to reserve for k-packets.

@kslong - I have run some initial tests of this with the pf file on "FU Ori - 2018 - Shock heating with k-packets" - the results seem sensitive to banding and to the number of k-packet photons and it's not clear if it's really working yet. The model is a strange situation since most of the luminosity above 13.6eV comes from the shock heating, since the star is so cool.

I am not sure if convergence is being done the right way. I think heat_tot does not include heat_shock and so should have it added on, so I've done this, but I'm confused because I thought we already sorted this out.

I am also unclear as to exactly how we use the photon numbers in photon generation, even in dev. We have an nphot_tot variable that is passed to define_phot, but also an NPHOT variable. I had to change these so they had the kpacket photons subtracted, but it's not clear to me why we do it this way anyway. Probably worth a quick discussion at some point.

One more thing. Knox, there was some weird code in spectra.c which may have come about from an incorrect merge and didn't compile. I commented it out but it might be worth checking it still does what you want (sections using max_scat and so on).

Generally, it would be good if someone, probably @kslong , could review these changes.