### PR TITLE
change to allow vzero to be set by sound speed in SV models

### DIFF
--- a/examples/travis/sv_detailedmode.pf
+++ b/examples/travis/sv_detailedmode.pf
@@ -51,6 +51,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+@SV.v_zero_mode(fixed,sound_speed)		   fixed 
+@SV.v_zero(cm/s)						   6e5
 Wind.radmax(cm)                            1e12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/source/python.h
+++ b/source/python.h
@@ -245,6 +245,9 @@ typedef struct domain
   double sv_lambda;             /* power law exponent describing from  what portion of disk wind is radiated */
   double sv_rmin, sv_rmax, sv_thetamin, sv_thetamax, sv_gamma;  /* parameters defining the goemetry of the wind */
   double sv_v_zero;             /* velocity at base of wind */
+  int sv_v_zero_mode;           /* use fixed initial velocity or multiple of sound speed */
+#define FIXED 0
+#define SOUND_SPEED 1
   double sv_r_scale, sv_alpha;  /* the scale length and power law exponent for the velocity law */
   double sv_v_infinity;         /* the factor by which the velocity at infinity exceeds the excape velocity */
 

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -1180,7 +1180,7 @@ scatter (p, nres, nnscat)
         if (prob_kpkt < 0)
         {
           /* only report an error for a negative prob_kpkt if it's large-ish in magnitude. see #436 discussion */
-          if (prob_kpkt < -1e-3) 
+          if (prob_kpkt < -1e-3)
           {
             Error ("scatter: kpkt probability (%8.4e) < 0, zeroing\n", prob_kpkt);
             Log ("scatter: photon edge frequency: %8.4e, comoving frequency %8.4e\n", phot_top[*nres - NLINES - 1].freq[0], freq_comoving);

--- a/source/sv.c
+++ b/source/sv.c
@@ -41,6 +41,7 @@ get_sv_wind_params (ndom)
      int ndom;
 {
   double windmin, windmax, theta_min, theta_max;
+  char answer[LINELENGTH];
 
   Log ("Creating an SV wind in domain %d\n", ndom);
 
@@ -54,7 +55,9 @@ get_sv_wind_params (ndom)
   zdom[ndom].sv_thetamin = 20. / RADIAN;
   zdom[ndom].sv_thetamax = 65. / RADIAN;
   zdom[ndom].sv_gamma = 1.;
-  zdom[ndom].sv_v_zero = 6e5;   /* velocity at base of wind */
+  /* JM -- this can be altered in advanced mode below */
+  zdom[ndom].sv_v_zero_mode = FIXED;
+  zdom[ndom].sv_v_zero = 6e5;
   zdom[ndom].sv_r_scale = 7e10; /*Accleration length scale for wind */
   zdom[ndom].sv_alpha = 1.5;    /* Accleration scale exponent */
   zdom[ndom].sv_v_infinity = 3; /* Final speed of wind in units of escape velocity */
@@ -82,6 +85,14 @@ get_sv_wind_params (ndom)
   rddoub ("SV.acceleration_length(cm)", &zdom[ndom].sv_r_scale);        /*Accleration length scale for wind */
   rddoub ("SV.acceleration_exponent", &zdom[ndom].sv_alpha);    /* Accleration scale exponent */
 
+  if (modes.iadvanced)
+  {
+    zdom[ndom].sv_v_zero_mode = rdchoice ("@SV.v_zero_mode(fixed,sound_speed)", "0,1", answer);
+    if (zdom[ndom].sv_v_zero_mode == FIXED)
+      rddoub ("@SV.v_zero(cm/s)", &zdom[ndom].sv_v_zero);
+    else if (zdom[ndom].sv_v_zero_mode == SOUND_SPEED)
+      rddoub ("@SV.v_zero(multiple_of_sound_speed)", &zdom[ndom].sv_v_zero);
+  }
 /* Assign the generic parameters for the wind the generic parameters of the wind */
 
   zdom[ndom].rmin = geo.rstar;
@@ -135,9 +146,9 @@ sv_velocity (x, v, ndom)
   struct photon ptest;
   double xtest[3];
   double s;
-  double ds_to_disk ();
+  double vzero;
 
-  zzz = v_escape = -99.;
+  zzz = v_escape = vzero = -99.;
 
 
   rzero = sv_find_wind_rzero (ndom, x);
@@ -164,8 +175,12 @@ sv_velocity (x, v, ndom)
     ldist = length (x);
   }
 
+  /* Depending on the mode, we can set the initial velocity as fixed or by the sound speed. See #482. */
+  if (zdom[ndom].sv_v_zero_mode == FIXED)
+    vzero = zdom[ndom].sv_v_zero;
+  else
+    vzero = kn_vzero (rzero) * zdom[ndom].sv_v_zero;
 
-  vl = zdom[ndom].sv_v_zero;
   if (ldist > 0)
   {
     zzz = pow (ldist / zdom[ndom].sv_r_scale, zdom[ndom].sv_alpha);
@@ -175,7 +190,7 @@ sv_velocity (x, v, ndom)
     else
       v_escape = sqrt (2. * G * geo.mstar / rzero);
 
-    vl = zdom[ndom].sv_v_zero + (zdom[ndom].sv_v_infinity * v_escape - zdom[ndom].sv_v_zero) * zzz / (1. + zzz);
+    vl = vzero + (zdom[ndom].sv_v_infinity * v_escape - vzero) * zzz / (1. + zzz);
   }
 
   v[0] = vl * sin (theta);

--- a/source/sv.c
+++ b/source/sv.c
@@ -87,6 +87,7 @@ get_sv_wind_params (ndom)
 
   if (modes.iadvanced)
   {
+    strcpy (answer, "fixed");
     zdom[ndom].sv_v_zero_mode = rdchoice ("@SV.v_zero_mode(fixed,sound_speed)", "0,1", answer);
     if (zdom[ndom].sv_v_zero_mode == FIXED)
       rddoub ("@SV.v_zero(cm/s)", &zdom[ndom].sv_v_zero);

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -823,8 +823,8 @@ wind_div_v ()
   double xxx[3];
   int ndom;
   double scaling;
-  
-  scaling=1e-3; //The scaling factor applied to 'delta' the distance away from the central point that the div_v calcs are done
+
+  scaling = 1e-3;               //The scaling factor applied to 'delta' the distance away from the central point that the div_v calcs are done
 
 
   for (icell = 0; icell < NDIM2; icell++)
@@ -835,18 +835,18 @@ wind_div_v ()
     ndom = wmain[icell].ndom;
 
 //    delta = 0.01 * x_zero[2];   //delta is the distance across which we measure e.g. dv_x/dx
-	
-	if (x_zero[1]!=0)
-	{
-	    delta=fabs(fmin(wmain[icell].x[0]-x_zero[0],fmin(wmain[icell].x[1]-x_zero[1],wmain[icell].x[2]-x_zero[2])));
-	}
-	else
-	{
-	    delta=fabs(fmin(wmain[icell].x[0]-x_zero[0],wmain[icell].x[2]-x_zero[2]));		
-	}
-	delta=delta*scaling;
-	
-	
+
+    if (x_zero[1] != 0)
+    {
+      delta = fabs (fmin (wmain[icell].x[0] - x_zero[0], fmin (wmain[icell].x[1] - x_zero[1], wmain[icell].x[2] - x_zero[2])));
+    }
+    else
+    {
+      delta = fabs (fmin (wmain[icell].x[0] - x_zero[0], wmain[icell].x[2] - x_zero[2]));
+    }
+    delta = delta * scaling;
+
+
     if (delta == 0)
     {
       Error ("wind_div_v: Cell %d has xcen[2]==0.  This is surprising\n", icell);
@@ -888,7 +888,7 @@ wind_div_v ()
     div += xxx[2] = (v2[2] - v1[2]) / delta;
 
 
-//	printf ("BLAH cell %i div=%e\n",icell,div);
+//      printf ("BLAH cell %i div=%e\n",icell,div);
 
 
     /* we have now evaluated the divergence, so can store in the wind pointer */


### PR DESCRIPTION
This is a possible solution to #482 which would allow the initial velocity to be set by the sound speed in SV models. This involves an extra variable to control this mode in the domain structure. At the moment this is only accessible in advanced mode. 

Possible improvements:
* could combine some variables to do with KWD and SV models 
* could rename kn_v_zero
* could make this a standard question for all disc wind models, rather than just advanced mode.

I suggest we test a bit first in advanced mode as part of mine and Ed's work, then maybe incorporate as a required parameter later. 

