### PR TITLE
First attempt to prevent python from crashing on Macro errors. See #486

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -1,30 +1,16 @@
 # This is the makefile for the python related programs
 #
 # usage      make [CC=...] [D] python
+# 			 make [CC=...] [D] all to remake all of the routines, and assure they
+# 			 					are properly indented.
 #
 # Adding D causes the routine to be run in a way that profiling and ddd can be used.
 # Otherwise the run will be optimized to run as fast as possible. CC is an option to choose
 # a different compiler other than mpicc.
 #
-# History
-# 05jan	ksl	54f  Modified Makefile so that the Version number is automatically
-# 		copied to version.h  Also fixed so that one does not need to put
-# 		a new filename in two separate places, and so that the latest
-# 		compile version automatically becomve shte
-# 05apr	ksl	55c   Modified in a way that implies that one must have gsl as part
-# 		of the Python directory tree.  This is because I was having problems
-# 		with gsl after we went to Redhat Enterprise at the Institute, and
-# 		so that Stuart and I could standardise on the distribution.
-# 08jul	ksl	Removed pfop from routines so no need to complile with g77
-# 13jun jm      Added capability to switch to use debugger routne
-#
-# 13jun jm/ss	SS added parallel flag -DMPI_ON and mpicc wrapper for gcc
-#		is now used as C compiler
-# 13jul jm	can now compiled with gcc using 'make CC=gcc python'
-# 13jul jm	kpar is now integrated into python and compiled here
 
 
-#MPICC is now default compiler- currently code will not compile with gcc
+#MPICC is now default compiler
 CC = mpicc
 # CC = gcc	can use GCC either from command line or by uncommenting this
 FC = g77
@@ -84,31 +70,6 @@ endif
 GIT_DIFF_STATUS := $(shell expr `git status --porcelain 2>/dev/null| grep "^ M" | wc -l`)
 GIT_COMMIT_HASH := $(shell expr `git rev-parse HEAD`)
 
-# Test if indent is installed. We use a different version on mac and linux.
-# OS_TYPE := $(shell uname -s)
-# ifeq ($(OS_TYPE), Darwin)
-# 	INDENT_PATH := $(shell which gnuindent)
-# 	INDENT_VERSION = $(shell gnuindent -version)
-# else
-# 	INDENT_PATH := $(shell which indent)
-# 	INDENT_VERSION := $(shell indent -version)
-# endif
-
-# ifeq (, $(INDENT_PATH))
-# 	#If indent is not installed, error
-# 	INDENT_STRING = Gnuindent not installed so not indenting code
-# 	INDENT_CMD =
-# else
-# 	ifeq (GNU,$(firstword $(INDENT_VERSION)))
-# 		INDENT_STRING = Indenting code with $(INDENT_VERSION)
-# 		# this command runs indent with GNU styling
-# 		INDENT_CMD = $(INDENT_PATH) -gnu -l140 -bli0 -nut *.c *.h
-# 	else
-# 		# if it is not GNU indent then do not run
-# 		INDENT_STRING = $(INDENT_PATH) is not the GNU version
-# 		INDENT_CMD =
-# 	endif
-# endif
 
 
 INCLUDE = ../include
@@ -139,7 +100,7 @@ LDFLAGS+= -L$(LIB) -lm -lgsl -lgslcblas
 
 #Note that version should be a single string without spaces.
 
-VERSION = 83
+VERSION = 83x
 
 startup:
 	@echo $(COMPILER_PRINT_STRING)			# prints out compiler information

--- a/source/matom.c
+++ b/source/matom.c
@@ -168,7 +168,10 @@ matom (p, nres, escape)
   else
   {
     Error ("matom: upper level not identified. nres = %d\n", *nres);
-    Exit (0);
+    *escape = 1;
+    p->istat = P_ERROR_MATOM;
+    return (0);
+    //OLD Exit (0);
   }
 
   /* Now follows the main loop to govern the macro atom jumps. Keeps jumping until
@@ -233,12 +236,18 @@ matom (p, nres, escape)
         if (jprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 1). Abort.");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
         if (eprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 2). Abort.");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
 
         pjnorm += jprbs[m];
@@ -266,12 +275,15 @@ matom (p, nres, escape)
         if (jprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 3). Abort.");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
         if (eprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 4). Abort.");
-          Exit (0);
+          //OLD Exit (0);
         }
         pjnorm += jprbs[m];
         penorm += eprbs[m];
@@ -307,7 +319,10 @@ matom (p, nres, escape)
         if (jprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 5). Abort.");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
         pjnorm += jprbs[m];
         m++;
@@ -361,7 +376,10 @@ matom (p, nres, escape)
     if ((pjnorm_known[uplvl] + penorm_known[uplvl]) <= 0.0)
     {
       Error ("matom: macro atom level has no way out %d %g %g\n", uplvl, pjnorm_known[uplvl], penorm_known[uplvl]);
-      Exit (0);
+      *escape = 1;
+      p->istat = P_ERROR_MATOM;
+      return (0);
+      //OLD Exit (0);
     }
 
     if (((pjnorm_known[uplvl] / (pjnorm_known[uplvl] + penorm_known[uplvl])) < threshold) || (pjnorm_known[uplvl] == 0))
@@ -410,7 +428,10 @@ matom (p, nres, escape)
     else
     {
       Error ("Trying to jump but nowhere to go! Matom. Abort");
-      Exit (0);
+      *escape = 1;
+      p->istat = P_ERROR_MATOM;
+      return (0);
+      //OLD Exit (0);
     }
 
 /* ksl: Check added to verify that the level actually changed */
@@ -428,7 +449,10 @@ matom (p, nres, escape)
   if (njumps == MAXJUMPS)
   {
     Error ("Matom: jumped %d times with no emission. Abort.\n", MAXJUMPS);
-    Exit (0);
+    *escape = 1;
+    p->istat = P_ERROR_MATOM;
+    return (0);
+    //OLD Exit (0);
   }
 
 
@@ -518,7 +542,10 @@ matom (p, nres, escape)
   else
   {
     Error ("Trying to emitt from Macro Atom but no available route (matom). Abort.");
-    Exit (0);
+    *escape = 1;
+    p->istat = P_ERROR_MATOM;
+    return (0);
+    //OLD Exit (0);
   }
 
   return (0);
@@ -924,14 +951,20 @@ kpkt (p, nres, escape, mode)
       cooling_ff = mplasma->cooling_ff = 0.0;
       Error ("kpkt: A scattering event in cell %d with vol = 0???\n", one->nwind);
       //Diagnostic      return(-1);  //57g -- Cannot diagnose with an exit
-      Exit (0);
+      *escape = 1;
+      p->istat = P_ERROR_MATOM;
+      return (0);
+      //OLD Exit (0);
     }
 
 
     if (cooling_ff < 0)
     {
       Error ("kpkt: ff cooling rate negative. Abort.");
-      Exit (0);
+      *escape = 1;
+      p->istat = P_ERROR_MATOM;
+      return (0);
+      //OLD Exit (0);
     }
     else
     {
@@ -1039,7 +1072,10 @@ kpkt (p, nres, escape, mode)
         if (i > nphot_total - 1)
         {
           Error ("kpkt (matom.c): trying to destroy k-packet in unknown process. Abort.\n");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
 
         /* If it gets here, all seems fine. Now set nres for the destruction process. */
@@ -1172,7 +1208,10 @@ kpkt (p, nres, escape, mode)
         if (i > nphot_total - 1)
         {
           Error ("kpkt (matom.c): trying to destroy k-packet in unknown process. Abort.\n");
-          Exit (0);
+          *escape = 1;
+          p->istat = P_ERROR_MATOM;
+          return (0);
+          //OLD Exit (0);
         }
 
         /* Now set nres for the destruction process. */
@@ -1198,7 +1237,10 @@ kpkt (p, nres, escape, mode)
     ("matom.c: cooling_bftot %g, cooling_bbtot %g, cooling_ff %g, cooling_bf_coltot %g cooling_adiabatic %g\n",
      mplasma->cooling_bftot, mplasma->cooling_bbtot, mplasma->cooling_ff, mplasma->cooling_bf_coltot, mplasma->cooling_adiabatic);
 
-  Exit (0);
+  *escape = 1;
+  p->istat = P_ERROR_MATOM;
+  return (0);
+  //OLD Exit (0);
 
   return (0);
 }

--- a/source/python.h
+++ b/source/python.h
@@ -1075,11 +1075,12 @@ typedef struct photon
     P_ESCAPE = 2,               //Escaped to reach the universe,
     P_HIT_STAR = 3,             //absorbed by photosphere of star,
     P_TOO_MANY_SCATTERS = 4,    //in wind after MAXSCAT scatters
-    P_ERROR = 5,                //Too many calls to translate without something happening
+    P_ERROR = 5,                //Tryint to scatter a photon in a location where it should not scatter
     P_ABSORB = 6,               //Photoabsorbed within wind
     P_HIT_DISK = 7,             //Banged into disk
     P_SEC = 8,                  //Photon hit secondary
-    P_ADIABATIC = 9             //records that a photon created a kpkt which was destroyed by adiabatic cooling
+    P_ADIABATIC = 9,            //records that a photon created a kpkt which was destroyed by adiabatic cooling
+    P_ERROR_MATOM = 10          //Some kind of error in processing of a photon which excited a macroattom
   } istat;                      /*status of photon. */
 
   int nscat;                    /*number of scatterings */

--- a/source/run.c
+++ b/source/run.c
@@ -300,7 +300,7 @@ calculate_ionization (restart_stat)
       {
         zz_disk += p[nn].w;
       }
-      else if (p[nn].istat == P_ERROR)
+      else if (p[nn].istat == P_ERROR || p[nn].istat == P_ERROR_MATOM)
       {
         zz_err += p[nn].w;
       }

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -111,7 +111,8 @@ trans_phot (WindPtr w, PhotPtr p, int iextract)
 
     if (nphot % nreport == 0)
     {
-      Log ("Cycle %d/%d of %s : Photon %10d of %10d or %6.1f per cent \n", geo.wcycle, geo.pcycle, basename, nphot, NPHOT, nphot * 100. / NPHOT);
+      Log ("Cycle %d/%d of %s : Photon %10d of %10d or %6.1f per cent \n", geo.wcycle, geo.pcycle, basename, nphot, NPHOT,
+           nphot * 100. / NPHOT);
     }
 
     Log_flush ();
@@ -617,6 +618,13 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
     if (pp.istat == P_ADIABATIC)
     {
       istat = pp.istat = p->istat = P_ADIABATIC;
+      stuff_phot (&pp, p);
+      break;
+    }
+
+    if (pp.istat == P_ERROR_MATOM)
+    {
+      istat = pp.istat = p->istat = P_ERROR_MATOM;
       stuff_phot (&pp, p);
       break;
     }

--- a/source/windsave2table.c
+++ b/source/windsave2table.c
@@ -147,7 +147,7 @@ main (argc, argv)
      int argc;
      char *argv[];
 {
-  char *fgets_return;
+  //OLD char *fgets_return;
   char root[LINELENGTH];
   char outputfile[LINELENGTH];
   char windsavefile[LINELENGTH];


### PR DESCRIPTION
These changes prevent various errors in macro atoms from halting python.  Instead, when one of these errors is encountered the photon is given a status P_ERROR_MATOM which causes that photon to be eliminated from further consideration.  At present in terms of photon statistics, this is bundled with photons which end up with status P_ERROR.  