### PR TITLE
Ksl speedup

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -100,7 +100,7 @@ LDFLAGS+= -L$(LIB) -lm -lgsl -lgslcblas
 
 #Note that version should be a single string without spaces.
 
-VERSION = 83
+VERSION = 83x
 
 startup:
 	@echo $(COMPILER_PRINT_STRING)			# prints out compiler information

--- a/source/Makefile
+++ b/source/Makefile
@@ -100,7 +100,7 @@ LDFLAGS+= -L$(LIB) -lm -lgsl -lgslcblas
 
 #Note that version should be a single string without spaces.
 
-VERSION = 83x
+VERSION = 83
 
 startup:
 	@echo $(COMPILER_PRINT_STRING)			# prints out compiler information

--- a/source/parse.c
+++ b/source/parse.c
@@ -171,10 +171,9 @@ parse_command_line (argc, argv)
         Log ("Logarithmic photon stepping enabled\n");
         modes.photon_speedup = 1;
 
-        if (sscanf (argv[i + 1], "%i", &PHOT_STEPS) != 1)
+        if (sscanf (argv[i + 1], "%lf", &PHOT_RANGE) != 1)
         {
-          Log ("n_steps not provided, will search .pf for min and max NPHOT\n");
-          PHOT_STEPS = 0;
+          PHOT_RANGE = 1.;
           i++;
         }
         i++;
@@ -293,7 +292,9 @@ These are largely diagnostic or for special cases. These include\n\
  -e_write 	Change the maximum number of errors to print out before recording errors silently\n\
  -f             Invoke a fixed temperature mode, used for runs with Zeus \n\
  -z             Invoke a special mode for that causes Python to start with a run from Zeus\n\
- -p n_steps     Invoke the photon logarithmic stepping algorithm which in some cases can result in a speed up\n\
+ -p range       Invoke the photon logarithmic stepping algorithm which in some cases can result in a speed up\n\
+                Range is in powers of 10, the difference beween the number of photons in the first cycle \n\
+                compared to the last \n\
 \n\
 If one simply types py or pyZZ where ZZ is the version number, one is queried for a name \n\
 of the parameter file and inputs will be requested from the command line. \n\

--- a/source/python.h
+++ b/source/python.h
@@ -90,7 +90,7 @@ double DENSITY_PHOT_MIN;        /* This constant is a minimum density for the pu
                                    angle over which photons will be accepted must be defined */
 
 int PHOT_STEPS;                 /* The switch for turning on the photon increase algorithm */
-int NPHOT_MIN;                  /* The minimum number of photon bundles created per  */
+//DEL int NPHOT_MIN;                  /* The minimum number of photon bundles created per  */
 int NPHOT_MAX;                  /* The maximum number of photon bundles created per cycle */
 int NPHOT;                      /* The number of photon bundles created, defined in setup.c */
 int CURRENT_PHOT;               /* A diagnostic so that one can always determine what the current photon number being run is */

--- a/source/python.h
+++ b/source/python.h
@@ -89,11 +89,12 @@ double DENSITY_PHOT_MIN;        /* This constant is a minimum density for the pu
 #define DANG_LIVE_OR_DIE   2.0  /* If constructing photons from a live or die run of the code, the
                                    angle over which photons will be accepted must be defined */
 
-int PHOT_STEPS;                 /* The switch for turning on the photon increase algorithm */
-//DEL int NPHOT_MIN;                  /* The minimum number of photon bundles created per  */
+double PHOT_RANGE;              /* When a variable number of photons are called in different ionization
+                                   cycles this is the log of the difference between NPHOT_MAX
+                                   and the value in the first cycle
+                                 */
 int NPHOT_MAX;                  /* The maximum number of photon bundles created per cycle */
 int NPHOT;                      /* The number of photon bundles created, defined in setup.c */
-int CURRENT_PHOT;               /* A diagnostic so that one can always determine what the current photon number being run is */
 
 #define NWAVE  			  10000 //Increasing from 4000 to 10000 (SS June 04)
 #define MAXSCAT 			500

--- a/source/run.c
+++ b/source/run.c
@@ -63,12 +63,10 @@ calculate_ionization (restart_stat)
 
   char dummy[LINELENGTH];
 
-  double freqmin, freqmax;
-  long nphot_to_define;
+  double freqmin, freqmax, x;
+  long nphot_to_define, nphot_min;
   int iwind;
 
-//DEL  int nphot_steps = 0, nphot_next_cycle = geo.wcycles;
-//DEL  int nphot_cycle_gap = geo.wcycles;
 
 #ifdef MPI_ON
   int ioniz_spec_helpers;
@@ -128,18 +126,6 @@ calculate_ionization (restart_stat)
     delay_dump_prep (restart_stat);
   }
 
-//DEL  /*
-//DEL   * EP: if the photon increment speed up is being used, figure out at which
-//DEL   * cycle NPHOT will be increased.
-//DEL   */
-
-//DEL  if (modes.photon_speedup)
-//DEL  {
-//DEL    nphot_steps = PHOT_STEPS + 1;
-//DEL    nphot_next_cycle = nphot_cycle_gap = geo.wcycles / nphot_steps;
-//DEL    Log ("NPHOT will increase %i times every %i cycles\n", nphot_steps - 1, nphot_cycle_gap);
-//DEL  }
-//DEL
 
   while (geo.wcycle < geo.wcycles)
   {                             /* This allows you to build up photons in bunches */
@@ -167,56 +153,22 @@ calculate_ionization (restart_stat)
     else
       iwind = 1;                /* Create wind photons and force a reinitialization of wind parms */
 
-//DEL    if (modes.photon_speedup && geo.wcycle == nphot_next_cycle)
-//DEL    {
-//DEL      /*
-//DEL       * EP: If photon incrementing is enabled, figure out the number of photons
-//DEL       * to use. When in multiprocessor mode, there is a bit of messing about with
-//DEL       * multiplying and division to ensure that NPHOT is set correctly across
-//DEL       * all processes for an arbitrary number of MPI processes. Previously,
-//DEL       * NPHOT would be increased incorrectly by a value of 10 / np_mpi_global
-//DEL       * leading to less photons than we wanted
-//DEL       */
-//DEL
-//DEL#ifdef MPI_ON
-//DEL      NPHOT *= np_mpi_global;
-//DEL#endif
-//DEL      NPHOT *= 10;
-//DEL#ifdef MPI_ON
-//DEL      NPHOT /= np_mpi_global;
-//DEL#endif
-//DEL
-//DEL      /*
-//DEL       * EP: we don't want NPHOT to become larger than NPHOT_MAX, which can
-//DEL       * happen with some values of ionisation cycles and values of NPHOT_MIN
-//DEL       * and NPHOT_MAX
-//DEL       */
-//DEL
-//DEL      if (NPHOT > NPHOT_MAX)
-//DEL        NPHOT = NPHOT_MAX;
-//DEL
-//DEL      /*
-//DEL       * EP: both p and photmain realloc'd otherwise photmain would end
-//DEL       * up not pointing to anything and segfault in make_spectra()
-//DEL       */
-//DEL
-//DEL      p = photmain = (PhotPtr) realloc (photmain, sizeof (p_dummy) * NPHOT);
-//DEL
-//DEL      if (!p)
-//DEL      {
-//DEL        Error ("Could not reallocate memory for %i photons for p and photmain\n", NPHOT);
-//DEL        Exit (1);
-//DEL      }
-//DEL
-//DEL      nphot_next_cycle += nphot_cycle_gap;
-//DEL
-//DEL      if (NPHOT * 10 <= NPHOT_MAX)
-//DEL        Log ("NPHOT will next increase to %e on cycle %i\n", (double) NPHOT * 10, nphot_next_cycle);
-//DEL    }
+
+    /* If we are using photon speed up mode then the number of photons varies by cycle in the
+     * ionization phase.  We set this up here
+     */
 
     if (modes.photon_speedup)
     {
-      NPHOT = ((geo.wcycle + 1.0) / geo.wcycles) * NPHOT_MAX;
+      nphot_min = NPHOT_MAX / pow (10., PHOT_RANGE);
+
+      x = log10 (NPHOT_MAX / nphot_min) / (geo.wcycles - 1);
+      NPHOT = nphot_min * pow (10., (x * geo.wcycle));
+      if (NPHOT > NPHOT_MAX)
+      {
+        NPHOT = NPHOT_MAX;
+      }
+      //OLD NPHOT = ((geo.wcycle + 1.0) / geo.wcycles) * NPHOT_MAX;
     }
 
     Log ("!!Python: %1.2e photons will be transported for cycle %i\n", (double) NPHOT, geo.wcycle);

--- a/source/setup.c
+++ b/source/setup.c
@@ -517,33 +517,33 @@ init_photons ()
     Exit (1);
   }
 
-  if (modes.photon_speedup)
-  {
-    Log ("Photon logarithmic stepping algorithm enabled\n");
-    if (!PHOT_STEPS)
-    {
-      rddoub ("Min_photons_per_cycle", &min_nphot);
-      rddoub ("Max_photons_per_cycle", &max_nphot);
-    }
-    else
-      min_nphot /= pow (10, PHOT_STEPS);
-
-    NPHOT_MAX = NPHOT;
-    NPHOT = NPHOT_MIN = (int) min_nphot;
-    Log ("NPHOT_MIN %e\n", (double) NPHOT_MIN);
-    Log ("NPHOT_MAX %e\n", (double) NPHOT_MAX);
-  }
+//DEL  if (modes.photon_speedup)
+//DEL  {
+//DEL    Log ("Photon logarithmic stepping algorithm enabled\n");
+//DEL    if (!PHOT_STEPS)
+//DEL    {
+//DEL      rddoub ("Min_photons_per_cycle", &min_nphot);
+//DEL      rddoub ("Max_photons_per_cycle", &max_nphot);
+//DEL    }
+//DEL    else
+//DEL      min_nphot /= pow (10, PHOT_STEPS);
+//DEL
+//DEL    NPHOT_MAX = NPHOT;
+//DEL    NPHOT = NPHOT_MIN = (int) min_nphot;
+//DEL    Log ("NPHOT_MIN %e\n", (double) NPHOT_MIN);
+//DEL    Log ("NPHOT_MAX %e\n", (double) NPHOT_MAX);
+//DEL  }
 
 #ifdef MPI_ON
   Log ("Photons per cycle per MPI task will be %d\n", NPHOT / np_mpi_global);
   NPHOT /= np_mpi_global;
-  if (modes.photon_speedup)
-  {
-    NPHOT_MIN /= np_mpi_global;
-    NPHOT_MAX /= np_mpi_global;
-    Log ("MPI NPHOT_MIN = %e\n", (double) NPHOT_MIN);
-    Log ("MPI NPHOT_MAX = %e\n", (double) NPHOT_MAX);
-  }
+//DEL  if (modes.photon_speedup)
+//DEL  {
+//DEL    NPHOT_MIN /= np_mpi_global;
+//DEL    NPHOT_MAX /= np_mpi_global;
+//DEL    Log ("MPI NPHOT_MIN = %e\n", (double) NPHOT_MIN);
+//DEL    Log ("MPI NPHOT_MAX = %e\n", (double) NPHOT_MAX);
+//DEL  }
 #endif
 
   rdint ("Ionization_cycles", &geo.wcycles);
@@ -558,6 +558,13 @@ init_photons ()
   /* Allocate the memory for the photon structure now that NPHOT is established */
 
   photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT);
+  /* If the number of photons per cycle is changed, NPHOT can be less, so we define NPHOT_MAX 
+   * to the maximum number of photons that one can create.  NPHOT is used extensively with 
+   * Python.  It is the NPHOT in a particular cycle, in a given thread.
+   */
+
+  NPHOT_MAX = NPHOT;
+
 
   if (p == NULL)
   {

--- a/source/setup.c
+++ b/source/setup.c
@@ -508,8 +508,8 @@ init_photons ()
      read in as a double so it is easier for input
      (in scientific notation) */
 
-  double nphot = 1e5, min_nphot = 1e5, max_nphot = 1e7;
 
+  double nphot = 1e5;
   rddoub ("Photons_per_cycle", &nphot); // NPHOT is photons/cycle
   if ((NPHOT = (int) nphot) <= 0)
   {
@@ -517,33 +517,10 @@ init_photons ()
     Exit (1);
   }
 
-//DEL  if (modes.photon_speedup)
-//DEL  {
-//DEL    Log ("Photon logarithmic stepping algorithm enabled\n");
-//DEL    if (!PHOT_STEPS)
-//DEL    {
-//DEL      rddoub ("Min_photons_per_cycle", &min_nphot);
-//DEL      rddoub ("Max_photons_per_cycle", &max_nphot);
-//DEL    }
-//DEL    else
-//DEL      min_nphot /= pow (10, PHOT_STEPS);
-//DEL
-//DEL    NPHOT_MAX = NPHOT;
-//DEL    NPHOT = NPHOT_MIN = (int) min_nphot;
-//DEL    Log ("NPHOT_MIN %e\n", (double) NPHOT_MIN);
-//DEL    Log ("NPHOT_MAX %e\n", (double) NPHOT_MAX);
-//DEL  }
 
 #ifdef MPI_ON
   Log ("Photons per cycle per MPI task will be %d\n", NPHOT / np_mpi_global);
   NPHOT /= np_mpi_global;
-//DEL  if (modes.photon_speedup)
-//DEL  {
-//DEL    NPHOT_MIN /= np_mpi_global;
-//DEL    NPHOT_MAX /= np_mpi_global;
-//DEL    Log ("MPI NPHOT_MIN = %e\n", (double) NPHOT_MIN);
-//DEL    Log ("MPI NPHOT_MAX = %e\n", (double) NPHOT_MAX);
-//DEL  }
 #endif
 
   rdint ("Ionization_cycles", &geo.wcycles);

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -106,7 +106,6 @@ trans_phot (WindPtr w, PhotPtr p, int iextract)
 
   for (nphot = 0; nphot < NPHOT; nphot++)
   {
-    CURRENT_PHOT = nphot;       /* A diagnostic to make it easier to determine what photon is causing a problem */
     /* This is just a watchdog method to tell the user the program is still running */
 
     if (nphot % nreport == 0)


### PR DESCRIPTION
I have changed the way the -p option works.  Now invoking the -p option with no follow-on simple sets up a logarithmicly increasing numbers of photons going from nphot/10 to nphot.  If you provide a range, say 2, then it will go from nphot/100 to nphot.

I made the change for two reasons (a) I found with the previous approach that there were times when it never actually got to phot max, and (b) I think this is really a more useful way to proceed where in every cycle the number of photons increases some.    
