### PR TITLE
k-packet changes for free-free cooling

### DIFF
--- a/source/matom.c
+++ b/source/matom.c
@@ -1244,9 +1244,9 @@ kpkt (p, nres, escape, mode)
 
   Error ("matom.c: Failed to select a destruction process in kpkt. Abort.\n");
   Error
-    ("matom.c: choice %8.4e norm %8.4e cooling_bftot %g, cooling_bbtot %g, cooling_ff %g, cooling_ff_lofreq %g, cooling_bf_coltot %g cooling_adiabatic %g\n",
+    ("matom.c: choice %8.4e norm %8.4e cooling_bftot %g, cooling_bbtot %g, cooling_ff %g, cooling_ff_lofreq %g, cooling_bf_coltot %g cooling_adiabatic %g cooling_adiabatic %g\n",
      destruction_choice, cooling_normalisation, mplasma->cooling_bftot, mplasma->cooling_bbtot, mplasma->cooling_ff,
-     mplasma->cooling_ff_lofreq, mplasma->cooling_bf_coltot, mplasma->cooling_adiabatic);
+     mplasma->cooling_ff_lofreq, mplasma->cooling_bf_coltot, mplasma->cooling_adiabatic, cooling_adiabatic);
 
   *escape = 1;
   p->istat = P_ERROR_MATOM;

--- a/source/matom.c
+++ b/source/matom.c
@@ -801,9 +801,9 @@ kpkt (p, nres, escape, mode)
   /* ksl This is a Bandaid for when the temperatures are very low */
   /* in this case cooling_ff should be low compared to cooling_ff_lofreq anyway */
   if (freqmax < 1.1 * freqmin)
-    {
-      freqmax = 1.1 * freqmin;
-    }
+  {
+    freqmax = 1.1 * freqmin;
+  }
 
   /* ksl 091108 - If the kpkt destruction rates for this cell are not known they are calculated here.  This happens
    * every time the wind is updated */
@@ -930,7 +930,7 @@ kpkt (p, nres, escape, mode)
        volume.  Recall however that vol is part of the windPtr */
     if (one->vol > 0)
     {
-      cooling_ff = mplasma->cooling_ff = total_free (one, xplasma->t_e, freqmin, freqmax) / xplasma->vol / xplasma->ne;    // JM 1411 - changed to use filled volume
+      cooling_ff = mplasma->cooling_ff = total_free (one, xplasma->t_e, freqmin, freqmax) / xplasma->vol / xplasma->ne; // JM 1411 - changed to use filled volume
       cooling_ff += mplasma->cooling_ff_lofreq = total_free (one, xplasma->t_e, 0.0, freqmin) / xplasma->vol / xplasma->ne;
     }
     else
@@ -1172,10 +1172,10 @@ kpkt (p, nres, escape, mode)
   }
   else if (destruction_choice < (mplasma->cooling_bftot + mplasma->cooling_bbtot + mplasma->cooling_ff + mplasma->cooling_ff_lofreq))
   {                             //this is ff at low frequency
-    *escape = 1;                
+    *escape = 1;
     *nres = -2;
     /* we don't bother tracking photons below 1e14 Hz, 
-      so record that this photon was lost to "low frequency free-free" */
+       so record that this photon was lost to "low frequency free-free" */
     p->istat = P_LOFREQ_FF;
     return (0);
   }
@@ -1183,7 +1183,8 @@ kpkt (p, nres, escape, mode)
 
 
   /* JM 1310 -- added loop to check if destruction occurs via adiabatic cooling */
-  else if (destruction_choice < (mplasma->cooling_bftot + mplasma->cooling_bbtot + mplasma->cooling_ff + mplasma->cooling_ff_lofreq + cooling_adiabatic))
+  else if (destruction_choice <
+           (mplasma->cooling_bftot + mplasma->cooling_bbtot + mplasma->cooling_ff + mplasma->cooling_ff_lofreq + cooling_adiabatic))
   {
 
     if (geo.adiabatic == 0 || mode != KPKT_MODE_ALL)
@@ -1203,7 +1204,9 @@ kpkt (p, nres, escape, mode)
   else
   {
     /* We want destruction by collisional ionization in a macro atom. */
-    destruction_choice = destruction_choice - mplasma->cooling_bftot - mplasma->cooling_bbtot - mplasma->cooling_ff - mplasma->cooling_ff_lofreq - cooling_adiabatic;
+    destruction_choice =
+      destruction_choice - mplasma->cooling_bftot - mplasma->cooling_bbtot - mplasma->cooling_ff - mplasma->cooling_ff_lofreq -
+      cooling_adiabatic;
 
     for (i = 0; i < nphot_total; i++)
     {
@@ -1241,8 +1244,9 @@ kpkt (p, nres, escape, mode)
 
   Error ("matom.c: Failed to select a destruction process in kpkt. Abort.\n");
   Error
-    ("matom.c: cooling_bftot %g, cooling_bbtot %g, cooling_ff %g, cooling_bf_coltot %g cooling_adiabatic %g\n",
-     mplasma->cooling_bftot, mplasma->cooling_bbtot, mplasma->cooling_ff, mplasma->cooling_bf_coltot, mplasma->cooling_adiabatic);
+    ("matom.c: choice %8.4e norm %8.4e cooling_bftot %g, cooling_bbtot %g, cooling_ff %g, cooling_ff_lofreq %g, cooling_bf_coltot %g cooling_adiabatic %g\n",
+     destruction_choice, cooling_normalisation, mplasma->cooling_bftot, mplasma->cooling_bbtot, mplasma->cooling_ff,
+     mplasma->cooling_ff_lofreq, mplasma->cooling_bf_coltot, mplasma->cooling_adiabatic);
 
   *escape = 1;
   p->istat = P_ERROR_MATOM;

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -307,16 +307,16 @@ matrix_ion_populations (xplasma, mode)
       {
         newden[nn] = xplasma->density[nn] / elem_dens[ion[nn].z];
       }
-      
+
       /* if the ion is "simple" then find it's calculated ionization state in populations array */
-      else 
+      else
       {
 
-        for (mm = 0; mm < nrows; mm++)    // inner loop over the elements of the population array
+        for (mm = 0; mm < nrows; mm++)  // inner loop over the elements of the population array
         {
-          if (xion[mm] == nn)     // if this element contains the population of the ion is question
+          if (xion[mm] == nn)   // if this element contains the population of the ion is question
           {
-            newden[nn] = populations[mm]; // get the population
+            newden[nn] = populations[mm];       // get the population
           }
         }
       }

--- a/source/matrix_ion.c
+++ b/source/matrix_ion.c
@@ -307,15 +307,19 @@ matrix_ion_populations (xplasma, mode)
       {
         newden[nn] = xplasma->density[nn] / elem_dens[ion[nn].z];
       }
-
-      for (mm = 0; mm < nrows; mm++)    // inner loop over the elements of the population array
+      
+      /* if the ion is "simple" then find it's calculated ionization state in populations array */
+      else 
       {
-        if (xion[mm] == nn)     // if this element contains the population of the ion is question
+
+        for (mm = 0; mm < nrows; mm++)    // inner loop over the elements of the population array
         {
-          newden[nn] = populations[mm]; // get the population
+          if (xion[mm] == nn)     // if this element contains the population of the ion is question
+          {
+            newden[nn] = populations[mm]; // get the population
+          }
         }
       }
-
 
       if (newden[nn] < DENSITY_MIN)     // this wil also capture the case where population doesnt have a value for this ion
         newden[nn] = DENSITY_MIN;

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -376,7 +376,7 @@ communicate_matom_estimators_para ()
   gamma_helper = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
   alpha_helper = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);
   level_helper = calloc (sizeof (double), NPLASMA * nlevels_macro);
-  cell_helper = calloc (sizeof (double), 7 * NPLASMA);
+  cell_helper = calloc (sizeof (double), 8 * NPLASMA);
   cooling_bf_helper = calloc (sizeof (double), NPLASMA * 2 * nphot_total);
   cooling_bb_helper = calloc (sizeof (double), NPLASMA * nlines);
 
@@ -384,7 +384,7 @@ communicate_matom_estimators_para ()
   gamma_helper2 = calloc (sizeof (double), NPLASMA * 4 * size_gamma_est);
   alpha_helper2 = calloc (sizeof (double), NPLASMA * 2 * size_alpha_est);
   level_helper2 = calloc (sizeof (double), NPLASMA * nlevels_macro);
-  cell_helper2 = calloc (sizeof (double), 7 * NPLASMA);
+  cell_helper2 = calloc (sizeof (double), 8 * NPLASMA);
   cooling_bf_helper2 = calloc (sizeof (double), NPLASMA * 2 * nphot_total);
   cooling_bb_helper2 = calloc (sizeof (double), NPLASMA * nlines);
 
@@ -407,7 +407,8 @@ communicate_matom_estimators_para ()
     cell_helper[mpi_i + 3 * NPLASMA] = macromain[mpi_i].cooling_bf_coltot / np_mpi_global;
     cell_helper[mpi_i + 4 * NPLASMA] = macromain[mpi_i].cooling_bbtot / np_mpi_global;
     cell_helper[mpi_i + 5 * NPLASMA] = macromain[mpi_i].cooling_ff / np_mpi_global;
-    cell_helper[mpi_i + 6 * NPLASMA] = macromain[mpi_i].cooling_adiabatic / np_mpi_global;
+    cell_helper[mpi_i + 6 * NPLASMA] = macromain[mpi_i].cooling_ff_lofreq / np_mpi_global;
+    cell_helper[mpi_i + 7 * NPLASMA] = macromain[mpi_i].cooling_adiabatic / np_mpi_global;
 
 
 
@@ -490,7 +491,8 @@ communicate_matom_estimators_para ()
     macromain[mpi_i].cooling_bf_coltot = cell_helper2[mpi_i + 3 * NPLASMA];
     macromain[mpi_i].cooling_bbtot = cell_helper2[mpi_i + 4 * NPLASMA];
     macromain[mpi_i].cooling_ff = cell_helper2[mpi_i + 5 * NPLASMA];
-    macromain[mpi_i].cooling_adiabatic = cell_helper2[mpi_i + 6 * NPLASMA];
+    macromain[mpi_i].cooling_ff_lofreq = cell_helper2[mpi_i + 6 * NPLASMA];
+    macromain[mpi_i].cooling_adiabatic = cell_helper2[mpi_i + 7 * NPLASMA];
 
 
     for (n = 0; n < nlevels_macro; n++)

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -327,8 +327,8 @@ get_matom_f (mode)
 
                 if (nres > NLINES + nphot_total)
                 {
-                  Error ("Problem in get_matom_f (1). Abort. nres is %d, NLINES %d, nphot_total %d m %d %8.4e\n", 
-                          nres, NLINES, nphot_total, m, macromain[n].matom_abs[m]);
+                  Error ("Problem in get_matom_f (1). Abort. nres is %d, NLINES %d, nphot_total %d m %d %8.4e\n",
+                         nres, NLINES, nphot_total, m, macromain[n].matom_abs[m]);
                   Exit (0);
                 }
 

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -327,7 +327,8 @@ get_matom_f (mode)
 
                 if (nres > NLINES + nphot_total)
                 {
-                  Error ("Problem in get_matom_f (1). Abort. \n");
+                  Error ("Problem in get_matom_f (1). Abort. nres is %d, NLINES %d, nphot_total %d m %d %8.4e\n", 
+                          nres, NLINES, nphot_total, m, macromain[n].matom_abs[m]);
                   Exit (0);
                 }
 

--- a/source/python.h
+++ b/source/python.h
@@ -1002,7 +1002,7 @@ typedef struct macro
      and used to select destruction rates for kpkts */
   double cooling_normalisation;
   double cooling_bbtot, cooling_bftot, cooling_bf_coltot;
-  double cooling_ff;
+  double cooling_ff, cooling_ff_lofreq;
   double cooling_adiabatic;     // this is just cool_adiabatic / vol / ne
 
 

--- a/source/python.h
+++ b/source/python.h
@@ -1071,7 +1071,8 @@ typedef struct photon
     P_HIT_DISK = 7,             //Banged into disk
     P_SEC = 8,                  //Photon hit secondary
     P_ADIABATIC = 9,            //records that a photon created a kpkt which was destroyed by adiabatic cooling
-    P_ERROR_MATOM = 10          //Some kind of error in processing of a photon which excited a macroattom
+    P_ERROR_MATOM = 10,         //Some kind of error in processing of a photon which excited a macroattom
+    P_LOFREQ_FF = 11            //records a photon that had too low a frequency  
   } istat;                      /*status of photon. */
 
   int nscat;                    /*number of scatterings */

--- a/source/run.c
+++ b/source/run.c
@@ -227,7 +227,7 @@ calculate_ionization (restart_stat)
     trans_phot (w, p, 0);
 
     /*Determine how much energy was absorbed in the wind */
-    zze = zzz = zz_adiab = zz_abs = zz_scat = zz_star = zz_disk = zz_err = zz_else = zz_lofreq= 0.0;
+    zze = zzz = zz_adiab = zz_abs = zz_scat = zz_star = zz_disk = zz_err = zz_else = zz_lofreq = 0.0;
     nn_adiab = nn_lofreq = 0;
     for (nn = 0; nn < NPHOT; nn++)
     {

--- a/source/run.c
+++ b/source/run.c
@@ -500,6 +500,15 @@ make_spectra (restart_stat)
 
   kbf_need (freqmin, freqmax);
 
+  /* force recalculation of kpacket rates */
+  if (geo.rt_mode == RT_MODE_MACRO) 
+  {
+    for (n == 0; n < NPLASMA; n++)
+    {
+      macromain[n].kpkt_rates_known = -1;
+    }
+  }
+
   /* BEGIN CYCLES TO CREATE THE DETAILED SPECTRUM */
 
   /* the next section initializes the spectrum array in two cases, for the

--- a/source/run.c
+++ b/source/run.c
@@ -54,10 +54,10 @@ calculate_ionization (restart_stat)
      int restart_stat;
 {
   int n, nn;
-  double zz, zzz, zze, ztot, zz_adiab;
+  double zz, zzz, zze, ztot, zz_adiab, zz_lofreq;
   double zz_abs, zz_scat, zz_star, zz_disk;
   double zz_err, zz_else;
-  int nn_adiab;
+  int nn_adiab, nn_lofreq;
   WindPtr w;
   PhotPtr p;
 
@@ -227,8 +227,8 @@ calculate_ionization (restart_stat)
     trans_phot (w, p, 0);
 
     /*Determine how much energy was absorbed in the wind */
-    zze = zzz = zz_adiab = zz_abs = zz_scat = zz_star = zz_disk = zz_err = zz_else = 0.0;
-    nn_adiab = 0;
+    zze = zzz = zz_adiab = zz_abs = zz_scat = zz_star = zz_disk = zz_err = zz_else = zz_lofreq= 0.0;
+    nn_adiab = nn_lofreq = 0;
     for (nn = 0; nn < NPHOT; nn++)
     {
       zzz += p[nn].w;
@@ -240,6 +240,11 @@ calculate_ionization (restart_stat)
       {
         zz_adiab += p[nn].w;
         nn_adiab++;
+      }
+      else if (p[nn].istat == P_LOFREQ_FF)
+      {
+        zz_lofreq += p[nn].w;
+        nn_lofreq++;
       }
       else if (p[nn].istat == P_ABSORB)
       {
@@ -271,7 +276,10 @@ calculate_ionization (restart_stat)
       ("!!python: Total photon luminosity after transphot  %18.12e (absorbed/lost  %18.12e). Radiated luminosity %18.12e\n",
        zzz, zzz - zz, zze);
     if (geo.rt_mode == RT_MODE_MACRO)
+    {
       Log ("!!python: luminosity lost by adiabatic kpkt destruction %18.12e number of packets %d\n", zz_adiab, nn_adiab);
+      Log ("!!python: luminosity lost to low-frequency free-free    %18.12e number of packets %d\n", zz_lofreq, nn_lofreq);
+    }
     Log ("!!python: luminosity lost by being completely absorbed  %18.12e \n", zz_abs);
     Log ("!!python: luminosity lost by too many scatters          %18.12e \n", zz_scat);
     Log ("!!python: luminosity lost by hitting the star           %18.12e \n", zz_star);

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -616,7 +616,7 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
       break;
     }
 
-    if (pp.istat == P_ADIABATIC)
+    if (pp.istat == P_ADIABATIC || pp.istat == P_LOFREQ_FF)
     {
       istat = pp.istat = p->istat = P_ADIABATIC;
       stuff_phot (&pp, p);

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -616,16 +616,9 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
       break;
     }
 
-    if (pp.istat == P_ADIABATIC || pp.istat == P_LOFREQ_FF)
+    if (pp.istat == P_ERROR_MATOM || pp.istat == P_LOFREQ_FF || pp.istat == P_ADIABATIC)
     {
-      istat = pp.istat = p->istat = P_ADIABATIC;
-      stuff_phot (&pp, p);
-      break;
-    }
-
-    if (pp.istat == P_ERROR_MATOM)
-    {
-      istat = pp.istat = p->istat = P_ERROR_MATOM;
+      istat = p->istat = pp.istat;
       stuff_phot (&pp, p);
       break;
     }

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -888,9 +888,6 @@ wind_div_v ()
     div += xxx[2] = (v2[2] - v1[2]) / delta;
 
 
-//      printf ("BLAH cell %i div=%e\n",icell,div);
-
-
     /* we have now evaluated the divergence, so can store in the wind pointer */
     wmain[icell].div_v = div;
 


### PR DESCRIPTION
These are changes to deal with errors in how I'd coded the free-free cooling channel in kpkt(). The main changes are:

* a fix for #498 so that macro_pops ion populations are not overwritten when they shouldn't be
* fixes to do with #492 - kpkt() always calls one_ff with a wide frequency range, from 0 to (100 * k T / h).
if the photon is less than the global minimum frequency, we discard the photon with an istate set to P_LOFREQ_FF, in the same way we do for adiabatic cooling. 
* some streamlining of istat code
* some extra reporting of cooling rates

IMPORTANT: There is still one outstanding caveat here, which is that I have to set kpkt_rates_known to -1 (i.e. not known) when restarting a run in the spectral cycles to avoid errors to do with kpkt destruction rates. It's not clear why this is, because once the model is converged the kpkt rates should be the same.  It suggests a bug to me and should be investigated or discussed. 

I'm opening the pull request now because this should be merged before southampton. 