### PR TITLE
Removal of many //OLD statements in preparation for public release.

### DIFF
--- a/source/bands.c
+++ b/source/bands.c
@@ -193,8 +193,6 @@ bands_init (imode, band)
     mode =
       rdchoice ("Photon_sampling.approach(T_star,cv,yso,AGN,min_max_freq,user_bands,cloudy_test,wide,logarithmic)", "0,2,3,7,1,4,5,6,8",
                 answer);
-    //OLD mode = 2;
-    //OLD rdint ("Photon_sampling.approach(0=T,1=(f1,f2),2=cv,3=yso,4=user_defined,5=cloudy_test,6=wide,7=AGN,8=logarithmic)", &mode);
   }
   else
   {

--- a/source/continuum.c
+++ b/source/continuum.c
@@ -21,48 +21,6 @@
 
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD
-//OLD double one_continuum(spectype,t,g,freqmin,freqmax) gets a photon frequency
-//OLD from a continuum grid
-//OLD
-//OLD Arguments:
-//OLD
-//OLD   spectype                                An index to the continum grid which one wants
-//OLD                                           to use for obtaining a photon
-//OLD   double t,g,                             Two parameters defining the model for which
-//OLD                                           a photon is requried, often temperature and
-//OLD                                           gravity, though this is not required
-//OLD   freqmin,freqmax;                        minimum and maximum frequency of interest
-//OLD
-//OLD
-//OLD Returns:
-//OLD
-//OLD
-//OLD Description:
-//OLD
-//OLD
-//OLD Notes:
-//OLD   In versions of python prior to python_52, different routines
-//OLD   were used to read kurucz models and hubeny models.  This was
-//OLD   historical, since the routines ksl had to read the kurucz models
-//OLD   read binary files (from a time when compputers were very slow).
-//OLD
-//OLD   The new routines are much more general, and are based on routines
-//OLD   ksl had written for his fitting program kslfit.  The underlying
-//OLD   routines can interpolate between grids of more than two dimensions
-//OLD   although here we assume that all of the continuum grids are two
-//OLD   dimensional.
-//OLD
-//OLD History:
-//OLD   04aug   ksl     created from hub.c usied in all versions
-//OLD                   of python prior to python_52.
-//OLD
-//OLD **************************************************************/
-
 double old_t, old_g, old_freqmin, old_freqmax;
 double jump[] = { 913.8 };
 
@@ -94,13 +52,15 @@ double jump[] = { 913.8 };
  *
  * ### Notes ###
  *
- * @bug  The model structure is general in the sense that it was intended
+ * The model structure is general in the sense that it was intended
  * for situation with any number of variables.
  * However what is written here
  * is specific to the case of two variables. This is a problem, as we have
  * found in trying to use this in other situations.  A more general routine is needed.
  * The first step in doing this is to replace much of the code here with
  * a call to the routine model (spectype, par) in models.c
+ * This issue #539
+ *
  *
  **********************************************************/
 
@@ -157,7 +117,6 @@ one_continuum (spectype, t, g, freqmin, freqmax)
 
     for (n = 0; n < comp[spectype].nwaves; n++)
     {
-//OLD      if (comp[spectype].xmod.w[n] > lambdamin && comp[spectype].xmod.w[n] <= lambdamax)
       if (comp[spectype].xmod.w[n] > lambdamin && comp[spectype].xmod.w[n] < lambdamax)
       {
         w_local[nwave] = comp[spectype].xmod.w[n];
@@ -272,7 +231,6 @@ emittance_continuum (spectype, freqmin, freqmax, t, g)
   int nwav;
   double x, lambdamin, lambdamax;
 
-//  double dlambda;
   double par[2];
   int model ();
 

--- a/source/cooling.c
+++ b/source/cooling.c
@@ -91,40 +91,6 @@ cooling (xxxplasma, t)
 
 
 
-//OLD /***********************************************************
-//OLD              Space Telescope Science Institute
-//OLD
-//OLD Synopsis:  xtotal_emission (one, f1, f2) Calculate the total cooling of a single cell
-//OLD                   due to free free - line and recombination processes.
-//OLD
-//OLD Arguments:
-//OLD
-//OLD
-//OLD Returns:
-//OLD
-//OLD Description:
-//OLD
-//OLD
-//OLD Notes:
-//OLD   xtotal_emission gives the total enery loss due to photons.  It does
-//OLD   not include other coooling sources, e. g. adiabatic expansion.
-//OLD
-//OLD   It returns the total cooling, but also stores the luminosity due
-//OLD   to various types of emssion, e.g ff and  lines into the
-//OLD   Plasms cells. The fb cooling calculated here is *not* equal to
-//OLD   the fb lumniosity and so this value is stored in cool_rr.
-//OLD
-//OLD   Comment: The call to this routine was changed when PlasmaPtrs
-//OLD   were introduced, but it appears that the various routines
-//OLD   that were called were not changed.
-//OLD
-//OLD History:
-//OLD   2017 - copied from total_emission and modified for use in calculatingh
-//OLD                   cooling alone.
-//OLD
-//OLD
-//OLD **************************************************************/
-
 
 
 /**********************************************************/

--- a/source/cv.c
+++ b/source/cv.c
@@ -92,11 +92,8 @@ diskrad (m1, m2, period)
   double rlobe1, q;
   double roche2 ();
 
-//OLD  m1 *= MSOL;  In python, the mass is stored in grm
-//OLD  m2 *= MSOL;
   q = m2 / m1;
 
-//OLD  period *= 3600;  In Python the period is stored in seconds
   t2p = period / (2 * PI);
   x = GRAV * t2p * t2p * (m1 + m2);
 

--- a/source/cylind_var.c
+++ b/source/cylind_var.c
@@ -34,39 +34,6 @@
 #include "python.h"
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylin_ds_in_cell calculates the distance to the far
-//OLD         boundary of the cell in which the photon bundle resides.
-//OLD
-//OLD  Arguments:
-//OLD   p       Photon pointer
-//OLD
-//OLD
-//OLD  Returns:
-//OLD   Distance to the far boundary of the cell in which the photon
-//OLD   currently resides.  Negative numbers (and zero) should be
-//OLD   regarded as errors.
-//OLD
-//OLD Description:
-//OLD
-//OLD Notes:
-//OLD
-//OLD
-//OLD History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jun   ksl     56d -- modified so that search for top and
-//OLD                   bottom of each cell is determined using
-//OLD                   the cones that define each cell.
-//OLD   15aug   ksl     Updates to use with domains
-//OLD
-//OLD **************************************************************/
-
-
-
 
 /**********************************************************/
 /**
@@ -107,7 +74,7 @@ cylvar_ds_in_cell (ndom, p)
 
 
   // XXX  Next lines are just a check and one can probbly delette
-  // them but one shcoul check.  For now have just tried to get this working
+  // them but one should check.  For now have just tried to get this working
   //
   if ((p->grid = n = where_in_grid (ndom, p->x)) < 0)
   {
@@ -161,35 +128,6 @@ cylvar_ds_in_cell (ndom, p)
 }
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylvar_make_grid defines the cells in a cylindrical grid
-//OLD   when the disk is vertically extended.
-//OLD
-//OLD Arguments:
-//OLD   WindPtr w;      The structure which defines the wind in Python
-//OLD
-//OLD Returns:
-//OLD
-//OLD Description:
-//OLD   The cylvar coordinate system basically adds and off determined
-//OLD   by zdisk(r) to each z position in the grid.  Beyond geo.diskrad
-//OLD   the coordinate system stays fixed in the z direction (on the
-//OLD   assumption that the forumula for the disk is not valid there.)
-//OLD
-//OLD   The coordinate system is adjusted so the last element in the
-//OLD   veritical direction of the grid is always the same.
-//OLD
-//OLD
-//OLD History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jun   ksl     56d -- Conversion for this routine appears
-//OLD                   complete.
-//OLD
-//OLD **************************************************************/
 
 
 
@@ -328,38 +266,6 @@ cylvar_make_grid (w, ndom)
 }
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylvar_wind_complete_grid completes the definition of some of
-//OLD   the positonal variables in the wind, and creates some subidiary
-//OLD   arrays.
-//OLD
-//OLD Arguments:
-//OLD   WindPtr w;      The structure which defines the wind in Python
-//OLD
-//OLD Returns:
-//OLD
-//OLD Description:
-//OLD   This routine defines the windcone structures for this coordinate
-//OLD   system and creates some arrays that are intended to aide
-//OLD   in determining what cell one is in.  The routine is specific
-//OLD   to cylvar coordinate system.
-//OLD
-//OLD
-//OLD Notes: In principle, one would like to fix problem that the cones
-//OLD   are only defined out to MDIM-1 and NDIM-1, as this has the
-//OLD   potential of wasting space.  However, volumes have the same problem
-//OLD History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   06jun   ksl     56d -- Completed models for cylvar
-//OLD   15aug   ksl     Adaptatations for domains
-//OLD
-//OLD **************************************************************/
-
-
 
 /**********************************************************/
 /**
@@ -448,39 +354,9 @@ cylvar_wind_complete (ndom, w)
   return (0);
 }
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylvar_volume(w) calculates the wind volume of a cylindrical cell
-//OLD   allowing for the fact that some cells
-//OLD
-//OLD  Arguments:
-//OLD   int ndom      the domain poiinter
-//OLD   WindPtr w;    the entire wind
-//OLD  Returns:
-//OLD
-//OLD  Description:
-//OLD
-//OLD   This is a brute_force integration of the volume.  The technique
-//OLD   is completely general.  It does not depend on the shape of the
-//OLD   cell, and could be used for most of the coodinate systems.
-//OLD
-//OLD  Notes:
-//OLD   Where_in grid does not tell you whether the photon is in the wind or not.
-//OLD  History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jul   ksl     56d -- Made the modifications needed.
-//OLD   06nov   kls     58b: Minor modifications to use W_ALL_INWIND, etc.
-//OLD                   instead of hardcoded values
-//OLD   11aug   ksl     70b - Added ability to get volumes for multiple
-//OLD                   components
-//OLD
-//OLD **************************************************************/
+
 
 #define RESOLUTION   1000
-
 
 
 /**********************************************************/
@@ -616,56 +492,6 @@ cylvar_volumes (ndom, w)
   return (0);
 }
 
-//OLD /***********************************************************
-//OLD                      Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylvar_where_in_grid locates the grid position of the vector,
-//OLD   when one is using cylindrical coordinates, with the z
-//OLD   positions varying.
-//OLD
-//OLD  Arguments:
-//OLD   double x[];
-//OLD   int ichoice     0 locates the grid cell using the normal cell boundaries
-//OLD                   1 is for the cell centers
-//OLD
-//OLD  Returns:
-//OLD   where_in_grid normally  returns the cell number associated with
-//OLD           a position.  If the position is in the grid this will be a positive
-//OLD           integer < NDIM*MDIM.
-//OLD   x is inside the grid        -1
-//OLD   x is outside the grid       -2
-//OLD
-//OLD   fx,fz are the fractional positions
-//OLD  Description:
-//OLD
-//OLD   cylvar_where_in_grid returns the grid cell, and (because
-//OLD   it has to be calculated) the fractional position).
-//OLD
-//OLD
-//OLD  Notes:
-//OLD   Where_in grid does not tell you whether the x is in the wind or not.
-//OLD
-//OLD   What one means by inside or outside the grid may well be different
-//OLD   for different coordinate systems.
-//OLD
-//OLD   The basic approach is to calculate the rho postion which should tell
-//OLD   you which "column" of the wind you are in, and then to calculate the
-//OLD   specific cell in the column.
-//OLD
-//OLD  History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jul   ksl     56d -- Actual modifications for cylvar added.
-//OLD                   This routine caused a lot of trouble, especially
-//OLD                   in cases where there were consequences when x
-//OLD                   was outside the grid.
-//OLD   13sep   nsh     76b -- Modified calls to fraction to take account
-//OLD                   of new modes
-//OLD   15aug   ksl     Modified for domains
-//OLD
-//OLD **************************************************************/
-
 
 int cylvar_n_approx;
 int ierr_cylvar_where_in_grid = 0;
@@ -719,11 +545,9 @@ cylvar_where_in_grid (ndom, x, ichoice, fx, fz)
   double z[3];
   double rho;
   int ndim, mdim;
-  //int ndim,mdim,nstart;
 
   ndim = zdom[ndom].ndim;
   mdim = zdom[ndom].mdim;
-  // nstart=zdom[ndom].nstart;
 
   /* copy x to a dummy vector z, so that the z[0] component is really rho */
   z[0] = rho = sqrt (x[0] * x[0] + x[1] * x[1]);
@@ -840,32 +664,6 @@ cylvar_where_in_grid (ndom, x, ichoice, fx, fz)
 
 }
 
-//OLD /***********************************************************
-//OLD                      Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD
-//OLD   cylvar_get_random_location
-//OLD
-//OLD  Arguments:
-//OLD   int n -- Cell in which random position is to be generated
-//OLD  Returns:
-//OLD   double x -- the position
-//OLD  Description:
-//OLD
-//OLD
-//OLD  Notes:
-//OLD   The encapsulation steps should probably put into a separate
-//OLD   routine since this is used several times
-//OLD
-//OLD  History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jul   ksl     56d -- Updated to work for cylvar coords
-//OLD   11aug   ksl     70b - Updated to include more than one
-//OLD                   component
-//OLD
-//OLD **************************************************************/
 
 
 /**********************************************************/
@@ -946,24 +744,20 @@ cylvar_get_random_location (n, x)
   inwind = incell = -1;
   while (inwind != W_ALL_INWIND || incell != 0)
   {
-//    r = sqrt (rmin * rmin + (rand () / (MAXRAND - 0.5)) * (rmax * rmax - rmin * rmin)); //DONE
     r = sqrt (rmin * rmin + random_number (0.0, 1.0) * (rmax * rmax - rmin * rmin));
 // Generate the azimuthal location
-//    phi = 2. * PI * (rand () / MAXRAND);//DONE
     phi = 2. * PI * random_number (0.0, 1.0);
     x[0] = r * cos (phi);
     x[1] = r * sin (phi);
 
 
 
-//    x[2] = zmin + (zmax - zmin) * (rand () / (MAXRAND - 0.5));//DONE
     x[2] = zmin + (zmax - zmin) * random_number (0.0, 1.0);
     inwind = where_in_wind (x, &ndomain);       /* Some photons will not be in the wind
                                                    because the boundaries of the wind split the grid cell */
     incell = where_in_2dcell (ndom, x, n, &fx, &fz);
   }
 
-//  zz = rand () / MAXRAND - 0.5; //positions above are all at +z distances //DONE
   zz = random_number (-1.0, 1.0);       //positions above are all at +z distances
 
   if (zz < 0)
@@ -972,40 +766,6 @@ cylvar_get_random_location (n, x)
   return (inwind);
 }
 
-
-//OLD /***********************************************************
-//OLD                      Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   cylvar_extend_density  extends the density to
-//OLD   regions just outside the wind regiions so that
-//OLD   extrapolations of density can be made there
-//OLD
-//OLD  Arguments:
-//OLD  Returns:
-//OLD  Description:
-//OLD
-//OLD      We need to updated the densities immediately outside the wind so that the density interpolation in resonate will work.
-//OLD      In this case all we have done is to copy the densities from the cell which is just in the wind (as one goes outward) to the
-//OLD      cell that is just inside (or outside) the wind.
-//OLD
-//OLD      In cylindrical coordinates, the fast dimension is z; grid positions increase up in z, and then out in r.
-//OLD      In spperical polar coordinates, the fast dimension is theta; the grid increases in theta (measured)
-//OLD      from the z axis), and then in r.
-//OLD
-//OLD
-//OLD  Notes:
-//OLD
-//OLD   Instead of copying every thing is accomplished using pointers.
-//OLD
-//OLD  History:
-//OLD   05may   ksl     56a -- began modifications starting with same
-//OLD                   routine in cylindrical
-//OLD   05jul   ksl     56d -- Actually nothing was done to this
-//OLD                   routine. It should be OK as is.
-//OLD   06may   ksl     57+ -- Updated to extend by changing the mapping into the plasma structure.
-//OLD
-//OLD **************************************************************/
 
 
 
@@ -1082,79 +842,6 @@ cylvar_extend_density (ndom, w)
 }
 
 
-
-
-//OLD /***********************************************************
-//OLD            Space Telescope Science Institute
-//OLD
-//OLD Synopsis:  cylvar_coord_fraction() calculates the fractional
-//OLD   position of a position in the 2d grid in a coordinate
-//OLD   sytem independent way.
-//OLD
-//OLD
-//OLD
-//OLD Description:
-//OLD   ichoice=0 --> interpolate on vertices
-//OLD   ichoice=1 --> interpolate on centers
-//OLD
-//OLD   x --> the 3-vector position for which you want
-//OLD           the fractinal position
-//OLD Returns:
-//OLD   ii[] --> an array that contains the 1-d element
-//OLD           numbers that must be summed
-//OLD   frac[] --> the array that contains the fractional
-//OLD           contribution of the corresponding
-//OLD           element
-//OLD   nelem --> the number of elements that must be
-//OLD           summed, nominally 2 for a spherical grid
-//OLD           and 4 for a two dimensional grid.  (For
-//OLD           a 3 d grid it would be 6, but we have not
-//OLD           implemented this.
-//OLD
-//OLD    1 if  inside the grid
-//OLD   -2 if outside the grid
-//OLD   -1 if inside the grid
-//OLD
-//OLD Notes:
-//OLD   There are numerous times when one wants the value
-//OLD   of an interpoalted  variable in the wind.  There
-//OLD   is no easy way to interpolate the variable easily.
-//OLD   What this routine does is calculate the fractional
-//OLD   contributions of elements in the array to that
-//OLD   position.  Then one must sum up the actual variable
-//OLD   else where
-//OLD
-//OLD   If positions are outside the grid, coord_fraction
-//OLD   attempts to give you the value at the edge of teh
-//OLD   grid.
-//OLD
-//OLD   It's possible that coord_fraction could be used
-//OLD   to interpolate beyond the edge of the grid where
-//OLD   a variable is defined, although this is not done
-//OLD   at present!
-//OLD
-//OLD History:
-//OLD   04aug   ksl     52a -- Coded as a generic routine
-//OLD                   to get the location in the grid
-//OLD                   and the fractions that can be
-//OLD                   used for interpolation
-//OLD   04dec   ksl     54a -- Minor mod to exit if don't
-//OLD                   understand coord type
-//OLD   05apr   ksl     55d -- Made a significant change
-//OLD                   to the way coord_fraction works
-//OLD                   to concentrate variations due to different
-//OLD                   coordinate systems here. Note that the
-//OLD                   variables for coord_fraction were changed
-//OLD                   significantly
-//OLD   05jul   ksl     56d -- Modified so that for cylvar coords
-//OLD                   one simple calls the a special routine
-//OLD                   which is in cylindvar.c.  PROBABLY THIS ROUTINE
-//OLD                   SHOULD BE REWRITTEN SO THIS IS THE CASE
-//OLD                   FOR ALL COORDINATE SYSTEMS.
-//OLD   15aug   ksl     Modifications to allow for domains
-//OLD
-//OLD
-//OLD **************************************************************/
 
 
 

--- a/source/diag.c
+++ b/source/diag.c
@@ -125,14 +125,12 @@ get_standard_care_factors ()
   if (modes.iadvanced)
   {
     strcpy (answer, "no");
-    //OLD rdint ("@Diag.use_standard_care_factors(1=yes)", &istandard);
     istandard = rdchoice ("@Diag.use_standard_care_factors(yes,no)", "1,0", answer);
 
     if (!istandard)
     {
       rddoub ("@Diag.fractional_distance_photon_may_travel", &SMAX_FRAC);
       rddoub ("@Diag.lowest_ion_density_for_photoabs", &DENSITY_PHOT_MIN);
-      //OLD rdint ("@Diag.keep_photoabs_in_final_spectra(1=yes)", &modes.keep_photoabs);
       strcpy (answer, "no");
       modes.keep_photoabs = rdchoice ("@Diag.keep_photoabs_in_final_spectra(yes,no)", "1,0", answer);
     }
@@ -174,31 +172,24 @@ get_extra_diagnostics ()
 
   /* read the options. */
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.save_cell_statistics", &modes.save_cell_stats);
   modes.save_cell_stats = rdchoice ("@Diag.save_cell_statistics(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.keep_ioncycle_windsaves", &modes.keep_ioncycle_windsaves);
   modes.keep_ioncycle_windsaves = rdchoice ("@Diag.keep_ioncycle_windsaves(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.make_ioncycle_tables", &modes.make_tables);
   modes.make_tables = rdchoice ("@Diag.make_ioncycle_tables(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.save_photons", &modes.save_photons);
   modes.save_photons = rdchoice ("@Diag.save_photons(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.save_extract_photons", &modes.save_extract_photons);
   modes.save_extract_photons = rdchoice ("@Diag.save_extract_photons(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.print_dvds_info", &modes.print_dvds_info);
   modes.print_dvds_info = rdchoice ("@Diag.print_dvds_info(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  //OLD rdint ("@Diag.track_resonant_scatters", &modes.track_resonant_scatters);
   modes.track_resonant_scatters = rdchoice ("@Diag.track_resonant_scatters(yes,no)", "1,0", answer);
 
   if (modes.save_cell_stats || modes.save_photons || modes.save_extract_photons | modes.track_resonant_scatters)

--- a/source/dielectronic.c
+++ b/source/dielectronic.c
@@ -1,49 +1,13 @@
 
 /***********************************************************/
 /** @file  dielectronic.c
- * @author ksl
+ * @author Nick
  * @date   January, 2018
  *
- * @brief  ???
+ * @brief  The routines in this file all have to do with dielectronic recombination
  *
- * ???
  ***********************************************************/
 
-//OLD /**************************************************************************
-//OLD                     Southampton University
-//OLD
-//OLD
-//OLD   Synopsis:
-//OLD
-//OLD The routines in this file all have to do with dielectronic recombination.
-//OLD
-//OLD
-//OLD   Description:
-//OLD
-//OLD The first routine is compute_dr_coeffs
-//OLD It takes as its input a temperature, and it populates the fd_coeff array.
-//OLD This is an initial test, and it will be called every time a cell needs a set
-//OLD of DR coefficients. It could well be quicker in the future to generate one,
-//OLD temperature split array, and then sample it. Lets see...
-//OLD
-//OLD
-//OLD
-//OLD
-//OLD   Arguments:
-//OLD
-//OLD
-//OLD   Returns:
-//OLD
-//OLD   Notes:
-//OLD
-//OLD
-//OLD
-//OLD
-//OLD   History:
-//OLD   11aug   nsh     Began work
-//OLD
-//OLD
-//OLD  ************************************************************************/
 
 
 #include <stdio.h>
@@ -55,34 +19,6 @@
 #include "python.h"
 #include "recipes.h"
 
-
-
-
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: compute_dr_coeffs returns the volumetric dielectronic rate
-//OLD   coefficients for a given temperature.
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD   temperature
-//OLD
-//OLD
-//OLD   Returns:
-//OLD   nothing, but populates the array dr_coeffs
-//OLD
-//OLD   Notes:
-//OLD   the rates are associated with the ion being recombined into.
-//OLD
-//OLD
-//OLD
-//OLD   History:
-//OLD   11sep   nsh     Written as part of python70 effort to incorporate DR.
-//OLD
-//OLD  ************************************************************************/
 
 
 /**********************************************************/
@@ -146,34 +82,6 @@ compute_dr_coeffs (temp)
 }
 
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: total_dr calculates the total luminosity from DR.
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD   pointer to grid cell we are interested in
-//OLD   temperature
-//OLD
-//OLD
-//OLD
-//OLD   Returns:
-//OLD           the total luminosity of this cell due to dielectronic recombinaions
-//OLD
-//OLD   Notes:
-//OLD
-//OLD
-//OLD
-//OLD
-//OLD   History:
-//OLD   11sep   nsh     Written as part of python70 effort to incorporate DR. Initally we are just doing a ROM calculation by multiplying the volumetric rate be the ion density, the electron density and mean eelectron energy.
-//OLD         12jul     nsh     Changed to take account of the fact tha we are now assiciating a rate with the ion being recombined into, this means that for rate[nion] we need density [nion+1].
-//OLD
-//OLD  ************************************************************************/
-
 
 /**********************************************************/
 /**
@@ -184,15 +92,16 @@ compute_dr_coeffs (temp)
  * @return     the total luminosity of this cell due to dielectronic recombinaions - currently set to zero
  *
  * @details
- * This routine is a placeholder at the moment - it mirrors the other
- * routines which compute the luminosity due to various cooling routines.
- * However, as of the current time we do not know how to work out the luminosity
+ * This routine is a dummy routine at the moment - it mirrors the other
+ * routines which compute the luminosity due to various cooling routines, but
+ * currently always returns zero, because
+ * as of the current time we do not know how to work out the luminosity
  * from dielectronic recombination. We know the rate, which is used in ionization
  * calculations but the energy released by each recombination is complex and
  * depends on what happens to the excited ion.
  *
  * ### Notes ###
- * ??? NOTES ???
+ * This is issue #186
  *
  **********************************************************/
 
@@ -234,7 +143,7 @@ total_dr (one, t_e)
 		is absorbed, so a guess would be to just say its energy is re-radiated. This is clearly an over estimate
 		since some of the enegy is lost to binding energy 	*/
 //              x += xplasma->vol * xplasma->ne * xplasma->density[n + 1] * dr_coeffs[n] * meanke;
-/* A dfferent estimate is to use the ionization potential of the ion - this is order of magnitude at best */
+/* A different estimate is to use the ionization potential of the ion - this is order of magnitude at best */
 //              x += xplasma->vol * xplasma->ne * xplasma->density[n + 1] * dr_coeffs[n] * ion[n].ip;
       x += 0.0;                 //At present, we just set it to zero - obviously an underestimate!
     }

--- a/source/estimators.c
+++ b/source/estimators.c
@@ -384,7 +384,6 @@ bb_estimators_increment (one, p, tau_sobolev, dvds, nn)
   {
     Error ("bb_estimators_increment: trying to add negative contribution to jbar. %e. See #436\n", y);
     return (0);
-//OLD    Exit (0);
   }
 
   /* Record contribution to energy absorbed by macro atoms. */

--- a/source/extract.c
+++ b/source/extract.c
@@ -16,69 +16,6 @@
 #include "atomic.h"
 #include "python.h"
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD 
-//OLD  Synopsis:
-//OLD 
-//OLD int extract(w,p,itype) is the supervisory routine which helps normally
-//OLD   builds detailed spectra as the photons are transit the wind.
-//OLD 
-//OLD Arguments:                
-//OLD   PhotPtr p;      The initial photon
-//OLD   WindPtr w;
-//OLD   int itype       
-//PTYPE_STAR->the photon came for the star 
-//OLD                   PTYPE_BL->the photon came from the boundary layer
-//OLD                   PTYPE_DISK->the photon being redirected arose in the disk,
-//OLD                   PTYPE_WIND->the photon being redirected arose in the wind,
-//OLD Returns:
-//OLD  
-//OLD  
-//OLD Description:      
-//OLD 
-//OLD extract is called when a photon begins it's flight and every time that photon
-//OLD scatters, unless the user has exercised the "live or die" option, in
-//OLD which case it is not called.  extract calls extract_one for each spectrum
-//OLD it wants to build, where the actual incrementing of the spectrum is done.
-//OLD 
-//OLD An option allows one to construct spectra which have undergone a certain
-//OLD number of scatters.  The parameters for this option all come in through
-//OLD python.h.  
-//OLD   If s[n].nscat>999; then one obtains the entire spectrum
-//OLD   if s[n].nscat is a positive number, then the spectrum is composed just 
-//OLD           of photons with that number of scatters
-//OLD   if s[n].nscat is a negative number, then the spectrum contains all photons
-//OLD           with >=  the absolute value of s[n].nscat
-//OLD Another option allows one to construct spectra from photons which have
-//OLD   scattered above or below the plane of the disk.  As for the number of
-//OLD   scatters this option comes through python.h, in this case from s[n].top_bot
-//OLD   s[n].top_bot=0 -> accept all photons
-//OLD                     >0  -> accept photons last above the disk
-//OLD                     <0  -> accept photons below the disk
-//OLD Notes:
-//OLD 
-//OLD History:
-//OLD   97march ksl     Coded and debugged as part of Python effort.  
-//OLD   97aug28 ksl     Added the option which allows one to construct spectra with a
-//OLD                   specific number of scatters.
-//OLD   97sep1  ksl     Added the option which allows one to construct spectra which
-//OLD                   originate from a specific position above or below the disk
-//OLD   02jan   ksl     Fixed problems with itypes. (Photons which were wind photons
-//OLD                   for the purpose of extract were not being properly labelled
-//OLD                   as such, and this meant they were not doppler shifted properly.
-//OLD                   This produced photons that were further from resonance in the
-//OLD                   local frame and made the wind more transmissive, especially
-//OLD                   in the blue wing of the line.  It suggests
-//OLD                   that a lot of the absorption in extract is fairly local and
-//OLD                   that the blue wing structure could be fairly sensitive to how
-//OLD                   the doppler shift is carried out.)
-//OLD   09feb   ksl     68b - Added hooks to track energy deposition of extracted photons
-//OLD                   in the wind 
-//OLD   15aug   ksl     Modifications to allow multiple domains.
-//OLD 
-//OLD **************************************************************/
-
 
 
 /**********************************************************/

--- a/source/levels.c
+++ b/source/levels.c
@@ -9,57 +9,6 @@
  *
  ***********************************************************/
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD 
-//OLD 
-//OLD   Synopsis:
-//OLD   levels (xplasma, mode) calculates the fractional occupation numbers of
-//OLD   the various levels of atomic configurations as designated in
-//OLD   the atomic data files
-//OLD 
-//OLD   Description:
-//OLD 
-//OLD   mode    0       LTE with t_r
-//OLD           1       LTE with t_e
-//OLD           2       Non-LTE (reduced by weighted BB)
-//OLD 
-//OLD   Arguments:
-//OLD 
-//OLD   Returns:
-//OLD 
-//OLD   Notes:
-//OLD 
-//OLD   0808 - ksl - levels populates the levden array in the Plasma pointer.  It
-//OLD           is called from ion_abundances in python, and is called directly
-//OLD           from my diagnostic routine balance.  It's closely related to
-//OLD           another but separate routine which calculates the partition
-//OLD           functions, callled partition
-//OLD 
-//OLD   History:
-//OLD   01sep23 ksl     Began work
-//OLD   01oct10 ksl     Modified so modes matched python ionization modes
-//OLD                   more exactly.
-//OLD   01dec03 ksl     Modified to simplify so modes match those of
-//OLD                   nebular concentrations
-//OLD   01dec12 ksl     Modified to react to changes which split "nlte"
-//OLD                   and "lte" levels.  Levels is explicitly for so-
-//OLD                   called "nlte" levels, which are tracked in the
-//OLD                   Wind structure
-//OLD   04Apr   SS      If statement added to avoid this routine changing
-//OLD                         macro atom level populations.
-//OLD         04May   SS      The if statment added above is modified for the case
-//OLD                         of all "simple" ions.
-//OLD   06may   ksl     57+ -- Modified to make use of plasma structue
-//OLD   080810  ksl     62 - Fixed problem with how the levden array was
-//OLD                   indexed.  The problem was that the index into the
-//OLD                   levden array is not the same as the index into
-//OLD                   the so called nlte configurations.
-//OLD                   Also made the actual use of variables
-//OLD                   like nion,n,m resemble that in partitions so the
-//OLD                   routine was easier to compae
-//OLD 
-//OLD  ************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/source/lines.c
+++ b/source/lines.c
@@ -419,44 +419,6 @@ line_nsigma (line_ptr, xplasma)
 
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD scattering fraction(line_ptr,ne,te,dd,dvds,w,tr) calculate the fraction of excited
-//OLD state atoms which correspond to scattered photons, i.e. the portion which are
-//OLD excited by radiation and return to the ground state via spontaneous emission.
-//OLD
-//OLD Description:
-//OLD
-//OLD In the radiative transfer equation for lines, we separate the fraction of photons
-//OLD which are "absorbed" and the fraction which are "scattered".
-//OLD
-//OLD If line_mode==0, the atomosphere is a completely absorbing and no photons
-//OLD           will be scattered.  In this mode, assuming the wind is a source
-//OLD           of emission, the emissivity will be the Einstein A coefficient
-//OLD If line_mode==1, the atmosphere is completely scattering, there will be no
-//OLD           interchange of energy between the photons and the electrons
-//OLD           as a result of radiation transfer
-//OLD If line_mode==2, then a simple single scattering approximation is applied in which
-//OLD           case the scattered flux is just  A21/(C21+A21*(1-exp(-h nu/k T_e).
-//OLD If line_mode==3, then radiation trapping is included as well.  The basic idea
-//OLD           is to calculate the average number of scatters in a single
-//OLD           interaction and there is heat lost in each of these scatters.
-//OLD Notes:
-//OLD   It may be more efficient to combine several of these routines in view
-//OLD   of the fact that the exp is calculated several times
-//OLD
-//OLD History:
-//OLD   98      ksl     Coded
-//OLD   98aug   ksl     Rewritten to allow for stimulated decays in a
-//OLD                   two-level atom population.  Also rewrote the
-//OLD                   radiative trapping section.  It was clearly not
-//OLD                   correct previously! But is it correct now???
-//OLD   98nov   ksl     Corrected scattering fraction to agree with Python notes.
-//OLD                   It was not correct previously
-//OLD   06may   ksl     57+ -- Modified to use plasma structure
-//OLD ************************************************/
-
 
 
 /**********************************************************/

--- a/source/matom.c
+++ b/source/matom.c
@@ -239,7 +239,6 @@ matom (p, nres, escape)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
         if (eprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
@@ -247,7 +246,6 @@ matom (p, nres, escape)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
 
         pjnorm += jprbs[m];
@@ -278,12 +276,10 @@ matom (p, nres, escape)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
         if (eprbs[m] < 0.)      //test (can be deleted eventually SS)
         {
           Error ("Negative probability (matom, 4). Abort.");
-          //OLD Exit (0);
         }
         pjnorm += jprbs[m];
         penorm += eprbs[m];
@@ -322,7 +318,6 @@ matom (p, nres, escape)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
         pjnorm += jprbs[m];
         m++;
@@ -382,7 +377,6 @@ matom (p, nres, escape)
       *escape = 1;
       p->istat = P_ERROR_MATOM;
       return (0);
-      //OLD Exit (0);
     }
 
     if (((pjnorm_known[uplvl] / (pjnorm_known[uplvl] + penorm_known[uplvl])) < threshold) || (pjnorm_known[uplvl] == 0))
@@ -434,7 +428,6 @@ matom (p, nres, escape)
       *escape = 1;
       p->istat = P_ERROR_MATOM;
       return (0);
-      //OLD Exit (0);
     }
 
 /* ksl: Check added to verify that the level actually changed */
@@ -455,7 +448,6 @@ matom (p, nres, escape)
     *escape = 1;
     p->istat = P_ERROR_MATOM;
     return (0);
-    //OLD Exit (0);
   }
 
 
@@ -548,7 +540,6 @@ matom (p, nres, escape)
     *escape = 1;
     p->istat = P_ERROR_MATOM;
     return (0);
-    //OLD Exit (0);
   }
 
   return (0);
@@ -742,7 +733,6 @@ alpha_sp_integrand (freq)
  *	
  *	* 180616  Updated so that one could force kpkt to deactivate via radiation
 ************************************************************/
-//OLD moved to python.h #define ALPHA_FF 100.           // maximum h nu / kT to create the free free CDF
 
 int
 kpkt (p, nres, escape, mode)
@@ -952,7 +942,6 @@ kpkt (p, nres, escape, mode)
       *escape = 1;
       p->istat = P_ERROR_MATOM;
       return (0);
-      //OLD Exit (0);
     }
 
 
@@ -962,7 +951,6 @@ kpkt (p, nres, escape, mode)
       *escape = 1;
       p->istat = P_ERROR_MATOM;
       return (0);
-      //OLD Exit (0);
     }
     else
     {
@@ -1081,7 +1069,6 @@ kpkt (p, nres, escape, mode)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
 
         /* If it gets here, all seems fine. Now set nres for the destruction process. */
@@ -1221,7 +1208,6 @@ kpkt (p, nres, escape, mode)
           *escape = 1;
           p->istat = P_ERROR_MATOM;
           return (0);
-          //OLD Exit (0);
         }
 
         /* Now set nres for the destruction process. */
@@ -1251,7 +1237,6 @@ kpkt (p, nres, escape, mode)
   *escape = 1;
   p->istat = P_ERROR_MATOM;
   return (0);
-  //OLD Exit (0);
 
   return (0);
 }

--- a/source/partition.c
+++ b/source/partition.c
@@ -25,55 +25,6 @@
 #include "python.h"
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD 
-//OLD Synopsis:
-//OLD   partition_functions calculates the partition functions
-//OLD   for a single cell in the grid
-//OLD 
-//OLD Arguments:
-//OLD 
-//OLD 
-//OLD Returns:
-//OLD   
-//OLD Description:
-//OLD 
-//OLD Mode here is identical to that used by nebular_concentrations, e.g
-//OLD 
-//OLD 0 = LTE using t_r
-//OLD 1 = LTE using t_e
-//OLD 2 = Lucy and Mazzali
-//OLD 
-//OLD 
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD   0800802 - This is a rewritten version of two routines, do_partitions
-//OLD   and partition.   It is still true that levels is almost identical
-//OLD   to some of the code here and therefore it is unclear why it is needed.
-//OLD   levels is always called from partition_functions
-//OLD 
-//OLD 
-//OLD History:
-//OLD   080802  ksl     60b -- Brought levels routine into
-//OLD                   do_partitions since they are always
-//OLD                   called one after the other.  The routines
-//OLD                   are almost identical and it remains
-//OLD                   unclear why this was coded twice
-//OLD   080802  ksl     Combined two routines do_partitions
-//OLD                   and partition into one in order to
-//OLD                   make this routine very similar to
-//OLD                   levels
-//OLD   080804  ksl     Removed hubeny calculation of g from
-//OLD                   this code.  The advantage of the 
-//OLD                   Hubeny calculation was that it had
-//OLD                   a correction for density that we
-//OLD                   no longer had, but it was not being
-//OLD                   accessed by the code at all.
-//OLD 
-//OLD **************************************************************/
-
 
 
 
@@ -214,49 +165,6 @@ partition_functions (xplasma, mode)
 
 
 
-//OLD /***********************************************************
-//OLD                                        Southampton university
-//OLD 
-//OLD Synopsis:
-//OLD   partition_functions_2 calculates the partition functions
-//OLD   for a pair of states for a given temperature. This is needed
-//OLD   to support the pairwise ioinization state calculations where 
-//OLD   the saha equation is applied to a pair of states at a
-//OLD   useful temperature, then corrected. Part of this is 
-//OLD   a requirement to get the partition functions at that 
-//OLD   temperature for just tow two states of interest. It is 
-//OLD   wasteful to calculate all of the states at each temperature.
-//OLD 
-//OLD Arguments:
-//OLD 
-//OLD   xplasma - the cell we are interested in. Used to communicate back
-//OLD           the new partition functions.
-//OLD   xnion - the upper ion in the pair we are currently working on
-//OLD   temp - the temperature we are using for the saha equation. In the
-//OLD           original formulation of partition, this is got from xplasma,
-//OLD           in this case we don't want to use the cell temperature.
-//OLD 
-//OLD Returns:
-//OLD 
-//OLD   changes the partition functions of just two ions we are currently working on
-//OLD   
-//OLD Description:
-//OLD 
-//OLD 
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD   There is no need for the weight term in the calculation since this is only called when
-//OLD           we are making the assumption that we are in LTE for the saha equation. 
-//OLD 
-//OLD 
-//OLD 
-//OLD History:
-//OLD   2012Feb nsh - began coding
-//OLD   2012Sep nsh - added weight as a calling value - this allows one to produce gs 
-//OLD                 only with w=0, or LTE with w=1 or to produce a correction factor with W = the measured value      
-//OLD 
-//OLD **************************************************************/
 
 
 
@@ -288,6 +196,10 @@ partition_functions (xplasma, mode)
  * @bug According to the historical notes, there is no need for the weight term in the calculation 
  * since this is only called when
  * we are making the assumption that we are in LTE for the saha equation.
+ *
+ * However
+ * 2012Sep nsh - added weight as a calling value - this allows one to produce gs
+ *                only with w=0, or LTE with w=1 or to produce a correction factor with W = the measured value
  *
  * One of the ways in which this routine differs from partition_functions is that
  * here the temperature and weight are passed to the routing directly instead of

--- a/source/py_wind_ion.c
+++ b/source/py_wind_ion.c
@@ -10,61 +10,6 @@
  ***********************************************************/
 
 
-/**********************************************************/
-/** 
- * @brief      Import a gridded model
- *
- * @param [in] int  ndom   The domain for the model
- * @return   Always returns 0  
- *
- * @details
- *
- *
- * ### Notes ###
- *
- **********************************************************/
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD 
-//OLD  Synopsis:
-//OLD  
-//OLD   This file contains various subroutines of py_wind.  It is not part of python!
-//OLD   
-//OLD   ion_summary (w, element, istate, iswitch, rootname, ochoice) calculates and 
-//OLD   displays information for a specific element and ionization state.  The information
-//OLD   displayed depends upon the value of iswitch  
-
-
-//OLD Arguments:                
-//OLD   WindPtr w;
-//OLD   int element,istate;
-//OLD   char filename[]                 Output file name, if "none" then nothing is written;
-//OLD   int iswitch                     0 = ion fraction
-//OLD                                   1 = ion density
-//OLD                                   2 = number of scatters 
-//OLD           char rootname[];                rootname of the output file
-//OLD           int ochoice;                    The screen display is always the actual value. If ochoice
-//OLD                                   is non-zere an output file is written.
-//OLD 
-//OLD Returns:
-//OLD  
-//OLD Description:      
-//OLD   
-//OLD           
-//OLD Notes:
-//OLD 
-//OLD History:
-//OLD   97jun   ksl     Coding on py_wind began.
-//OLD   01sep   ksl     Added switch to ion summary so that ion density rather than ion fraction could
-//OLD                   be printed out.  iswitch==0 --> fraction, otherwise density
-//OLD   01dec   ksl     Updated for new calling structure for two_level_atom & scattering_fraction.
-//OLD   04nov   ksl     Updated for multiple coordinate systems, i.e to use the routine display. 
-//OLD                   Note that many of these summaries seem quite dated, and I have really not 
-//OLD                   checked what they are supposed to do.
-//OLD   05apr   ksl     Eliminated MDIM references
-//OLD   090125  ksl     Added capability to display the number of scatters of an ion taking
-//OLD                   place in a cell.
-//OLD **************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/source/py_wind_write.c
+++ b/source/py_wind_write.c
@@ -23,42 +23,6 @@
 
 
 
-
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD 
-//OLD 
-//OLD   Synopsis:  write_array writes out the arrays in a way which can be read easily
-//OLD    into a routine which can do contouring or to make a fits file 
-//OLD 
-//OLD 
-//OLD 
-//OLD   Description:
-//OLD 
-//OLD   Arguments:              
-//OLD           choice          0-> don't write array 
-//OLD                   1--> write without interpolation
-//OLD                   2-> interpolate to linear array
-//OLD 
-//OLD   Returns:
-//OLD 
-//OLD   Notes:
-//OLD 
-//OLD   History:
-//OLD   02feb   ksl     Fixed to allow different values of NDIM and MDIM.  This
-//OLD                   is tricky, but I believe that ain is defined such that
-//OLD                   the second axis is in the z direction so that the proper
-//OLD                   dimension is ain {NDIM] [MDIM]
-//OLD   05apr   ksl     56 -- Completely rewritten to enable a variety of 
-//OLD                   coordinate systems and to produce tecplot type 
-//OLD                   output files.
-//OLD   1111    ksl     71 -- Modified format of files to ease ability
-//OLD                   to plot the data in a variety of formats
-//OLD   1111    ksl     71 - Tecplot dependencies removed
-//OLD 
-//OLD   
-//OLD 
-//OLD  ************************************************************************/
 #define ODIM 256
 int init_write_array = 1;
 float aout[ODIM][ODIM];
@@ -250,52 +214,6 @@ are linear, and x otherwise.  This is not particularly transparent ?? ksl */
 }
 
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD 
-//OLD 
-//OLD   Synopsis:
-//OLD 
-//OLD   Description:
-//OLD   This is a generalized display routine, intended to allow various
-//OLD   simplifications of py_wind
-//OLD 
-//OLD   Arguments:              
-//OLD 
-//OLD   Returns:
-//OLD 
-//OLD   Notes:
-//OLD 
-//OLD   For cylindrical coordinates, one goes up in z, and over in x. To cylindrical coordinates
-//OLD   we want to display so that each colum represents a constant line on the axis
-//OLD   w[mdim][ndim].  So for a system with mdim=20 and ndim=25.  There are 25 elements
-//OLD   in the z axis and 20 elements in the xaxis
-//OLD 
-//OLD   Therefore a row, constant z, is displayed by by incrementing by 20 or mdim
-//OLD 
-//OLD   For rtheta coordinates, one goes around in theta, up in r.  The fasted moving
-//OLD   coordinate is r (when thinking of 1-d versions of the array.  Unless we
-//OLD   are going to write a separate routine, the simplest thing to do
-//OLD   is to make each column represent a constant r
-//OLD 
-//OLD   w[mdim][ndim]  So, in spherical polar coorcinates, a system with mdim 20 has
-//OLD   20 angles, and 25 radii.  
-//OLD 
-//OLD   So for spherical polar, constant r is displayed by incrementing by 1.  As a result
-//OLD   it is unclear that one can easily use the same routine for the two situations
-//OLD   since you seem to be incrementing the opposite axes, since in the one case one 
-//OLD   wants MDIM rows and other case one wants NDIM rows.  
-//OLD 
-//OLD   It would be possible if you plot theta lines in each row, but what this means
-//OLD   is that the first row is closest to the z axis
-//OLD 
-//OLD 
-//OLD   History:
-//OLD           111125  ksl     Put standard headers before routine prior to updating slightly
-//OLD   
-//OLD 
-//OLD  ************************************************************************/
-
 
 
 
@@ -307,8 +225,8 @@ are linear, and x otherwise.  This is not particularly transparent ?? ksl */
  * @return     Always returns 0
  *
  * @details
- * This is a generalized display routine, intended to allow various
- *  	simplifications of py_wind
+ * This is a generalized display routine that outputs the results of a query
+ * to the screen for inspection by the user.
  *
  * ### Notes ###
  * For cylindrical coordinates, one goes up in z, and over in x. To cylindrical coordinates

--- a/source/python.c
+++ b/source/python.c
@@ -8,224 +8,6 @@
  * that are central to the operation of Python
  *
  ***********************************************************/
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   Python is a program designed to simulate the transfer of radiation in a wind.  It uses the
-//OLD   Sobolev approximation.  It models a wind as a biconical flow.
-//OLD
-//OLD   This is the "main" routine for Python.  It's basic purpose is to gather the input variables
-//OLD   and to control the flow of the program
-//OLD
-//OLD Arguments:
-//OLD
-//OLD   Usage:  py [-h] [-r] [-d] [-f] [-t time_max] xxx  or simply py
-//OLD
-//OLD   where xxx is the rootname or full name of a parameter file, e. g. test.pf
-//OLD
-//OLD   and the switches have the following meanings
-//OLD
-//OLD   -h      to get this help message
-//OLD   -r      restart a run of the program reading the file xxx.windsave
-//OLD
-//OLD   -t time_max     limit the total time to approximately time_max seconds.  Note that the program checks
-//OLD           for this limit somewhat infrequently, usually at the ends of cycles, because it
-//OLD           is attempting to save the program outputs so that the program can be restarted with
-//OLD           -r if theat is desired.
-//OLD   -v num  determines the amount of information that is printed out.  If num is small, then
-//OLD           less information is printed out; if num is large more is printed out.  Setting
-//OLD           v to 5 causes the routine to print out all the information which outputs have
-//OLD           included previously.  The current default is set to 3 which suppresses Debug, Log_silent
-//OLD           and Error_silent
-//OLD   -e nnn  The program stops normally stops after 1e6 errors of any type.  This switch allows one to
-//OLD           adjust this number
-//OLD   -d      Enters detailed or advanced mode. Allows one to access extra diagnositics and some
-//OLD           other advanced commands
-//OLD     -f    Fixed temperature mode - does not attempt to change the temperature of cells.
-//OLD   -i      Diagnostic mode which quits after reading in inputs. Used for Travis test suite.
-//OLD     --dry-run     Create a new .pf file and stop (equivalent to -i)
-//OLD   -z      Mode to connect with zeus - it either runs two cycles in this is the first call - in order
-//OLD           to obtain a good starting state, else it runs just one cycle. In both cases, it does
-//OLD                   not attempt to seek a new temperature, but it does output heating and cooling rates
-//OLD     --version     print out python version, commit hash and if there were files with uncommitted
-//OLD           changes
-//OLD       --rseed     set the random number seed to be time based, rather than fixed.
-//OLD
-//OLD
-//OLD   if one simply types py or pyZZ where ZZ is the version number one is queried for a name
-//OLD   of the parameter file.
-//OLD
-//OLD   NOTE - If this is modified, please also modify the help message in help() below
-//OLD Returns:
-//OLD
-//OLD Description:
-//OLD   Python is far too complicated to describe.  Basically it simulates the radiative transfer
-//OLD   of photons through the wind of a cataclysmic variable or a star.  The kinematic formulation for
-//OLD   the CV wind is due to Schlossman and Vitello while that of the star is due to Castor & Larmors.
-//OLD
-//OLD    Radiation from an optically thick disk, the WD star, a boundary layer and the wind itself
-//OLD    may be included
-//OLD
-//OLD   There are 3 basic portions to the program which are easy to see in the main program.
-//OLD
-//OLD   1. A data gathering stage
-//OLD
-//OLD   2. A calculation of the state of ionization of the wind.
-//OLD
-//OLD   3. A calculation of a detailed spectrum in which the ionization is held fixed.
-//OLD
-//OLD
-//OLD Notes:
-//OLD   The program has been designed and tested both on Suns and MacIntoshes (with Symentec's
-//OLD   C compiler).  Some of its peculiarities are due to memory limitations and relatively small
-//OLD   stack sizes on the Mac.  When compiling, check to see that the global varible MAC is
-//OLD   set properly in python.h.
-//OLD
-//OLD History:
-//OLD   97jan   ksl     Coding on python began.
-//OLD   97jul   ksl     Added capability model the spectrum as a function of orbital phase.
-//OLD   97aug   ksl     Added boundary layer as additional source of radiation
-//OLD   97aug   ksl     Added capability to extract spectra with a specific number of scatters
-//OLD   97nov   ksl     Changed error and diagnostic logging
-//OLD   98july  ksl     Added radiation from the wind itself
-//OLD   98nov   ksl     Added spherical winds and greatly modified I/O
-//OLD   99jan   ksl     Added ability to enter parameter file (w/out) root on command line
-//OLD   99jul   ksl     Begin eliminating MAC dependencies
-//OLD   00sep   ksl     Began work on adding a new coronal possibility
-//OLD   01mar   ksl     Added a knigge wind
-//OLD         01sept    ksl     Added a thierry wind
-//OLD   01dec   ksl     Incorporated improved atomic data reading codes, and
-//OLD                   made a variety of other major changes to the way in
-//OLD                   which many of the subroutines operate.
-//OLD   01dec   ksl     Revised way in which old windfile option works.  It
-//OLD                   was not working at all originally, because of a
-//OLD                   change I made in April.  The new method is a bit dangerous
-//OLD                   because it does change a good bit of geo, since all of the
-//OLD                   input data is read in.  In principle, his can create an inconsistency
-//OLD                   between some of the info in geo and some in the wind array.
-//OLD                   But it keeps the wind the same, which is what was desired.
-//OLD   01dec   ksl     Added a general capability to python(40) so that during the
-//OLD                   the ionization cycle photons do not necessarily have identical
-//OLD                   weights.
-//OLD   02jan   ksl     Moved specific inputs for KWD wind to knigge.c
-//OLD   02feb   ksl     Added anisotropic wind scattering
-//OLD   02feb   ksl     41.1 -- Allowed user to chose between anisotropic and
-//OLD                   isotropic scattering in the wind.
-//OLD   02feb   ksl     41.2 -- Added aditional options for choosing what photons
-//OLD                   to count
-//OLD   02apr   ksl     43.1 -- Added additional radiative transfer options.  Modified main
-//OLD                   so that a spectrum is printed out after each cycle
-//OLD   02jul   ksl     43.7 -- Considerable changes associated with photoionization
-//OLD                   and recombination were made.  The initial attemps to allow
-//OLD                   for using a more accurate detailed balance approach were
-//OLD                   included in the ionizatio routines.
-//OLD   03dec   ksl     Added back some timing ability
-//OLD         04Mar   SS      Minor changes to set switch for macro atom method.
-//OLD                         geo.line_mode=6 switches geo.rt_mode=2 (macro method)
-//OLD                         and then geo.ine_mode back to =3. (SS)
-//OLD         04Apr   SS      Minor change to set a switch for geo.line_mode=7
-//OLD                         which is the same as 6 but with anisotropic scattering
-//OLD         04May   SS      geo.line_mode=8 added: this mode is the same as mode 6
-//OLD                         BUT will treat all ions as simple - it is for
-//OLD                         test purposes only.
-//OLD   04Jun   ksl     Added new disk + wind model for ysos.  In process, moved
-//OLD                   the variables describing the wind mdots to subroutines
-//OLD   04Aug   ksl     52 -- Modified input variables to allow a variety of input models
-//OLD                   all ascii-based.
-//OLD   04Aug   ksl     52 -- Modified input variables to allow for various disk illumination
-//OLD                   models
-//OLD   04Aug   ksl     52 -- Modified to allow for vertically extended disks. Note that some of
-//OLD                   the input variables were rearranged in the process.
-//OLD         04Aug   SS      Minor modifications to cope with finite disk thickness calculations.
-//OLD   04dec   ksl     54a -- Minor mod to calculation of fraction of luminosity that hits
-//OLD                   disk so that correct values are printed out in situation where there
-//OLD                   are multiple subcycles.
-//OLD   04dec   ksl     54e -- Minor mod to record master atomic file in geo, and, for the
-//OLD                   case of fixed concentration to store the file where the concentrations
-//OLD                   are contaned.
-//OLD   05apr   ksl     56 -- Added new variable geo.binary_system to avoid binary system
-//OLD                   questions in cases where one was modelling a single object.  Note
-//OLD                   that I did not remove seemingly superfluous quesions regarding
-//OLD                   phase because one can still extract photons in various azimuthal
-//OLD                   directions, and if we ever move to 3d situations one might want
-//OLD                   to deal with non-axially symmetric systems.
-//OLD   05jul   ksl     56d -- Updated to include new windcone definitions.
-//OLD   05jul   ksl     56d -- Completed basic work to allow vertically extended disk
-//OLD   06may   ksl     57g -- Began work on modifying structures to lower memory requirments
-//OLD                   At empty wind cells have mostly been eliminated, and macroatoms
-//OLD                   have been split off into a separate structure so this is not
-//OLD                   used.
-//OLD   06jul   ksl     57h -- Have contined work to speed program up as much as possible
-//OLD                   by giving more control over the parameters that govern the speed
-//OLD                   such as SMAX_FRAC.
-//OLD   06oct   ksl     58 -- This version is a cleaned up version of py57ib, which differs
-//OLD                   from 57h primarily in bb.c and pdf.c.   In addition, this version
-//OLD                   makes it possible to use the SV velocity law in what is otherwise
-//OLD                   a KWD description of the wind.
-//OLD   06nov   ksl     58c -- This version requires and updated version of kpar, that
-//OLD                   keeps track of all the errors.
-//OLD   07aug   ksl     58f -- Modified the way in which the program handles a situation
-//OLD                   in which one attempts to run with a non-existent .pf file.
-//OLD   08may   ksl     60a -- Significant modifications were made to the main routine
-//OLD                   to make sure we could restart models.  Unfortunaaely rhe point
-//OLD                   at which the user was asked for the atomic data needed to be changed,
-//OLD                   so earlier .pf files will need to be modified.
-//OLD   080808  ksl     62 -- Cleaned up wind ionization options
-//OLD   081110  ksl     67 -- Revised a number of portions of the main python.c routine
-//OLD                   to enable restarts.  There are still inconsistencies in the
-//OLD                   way one reads information from the .pf file after having read
-//OLD                   in the windsave files that could be cleaned up.
-//OLD   081218  ksl     67c -- Added a switch -h to provide information about usage.
-//OLD   090202  ksl     68b -- Added switch -v  to control the level of verbosity.  Updated
-//OLD                   Plasma to allow routine to track scatters and absorption during
-//OLD                   generation of detailed spectrum
-//OLD   090402  ksl     NSPEC has been moved to the main routine, as its only remaining
-//OLD                   purpose is to define some arrays in the main routine.  Note that
-//OLD                   MSPEC still has meaning as the number of spectra of various types
-//OLD                   that are construced without going through types.
-//OLD   1108    ksl/nsh Adding code to keep track of gross spectra in a cell though xbands,
-//OLD                   xj and xave_freq.  Just set up the frequence limits here.
-//OLD   1112    ksl     Moved everything associated with frequency bands into bands_init
-//OLD   1212    nsh     changed the way DFUDGE is defined.
-//OLD         1302      jm      74b5 introduced double precision variable for photon number for calling
-//OLD                   define_phot. Fixes Bug JM130302 in photon weights. It has been suggested
-//OLD                   that we should make NPHOT a long integer- at the moment I have not done
-//OLD                   this and simply comverted to double before calling define_phot (otherwise
-//OLD                   I believe rdint would have to be redone for long integers).
-//OLD   1304    ksl     75 rewrote the fix above to use a long, instead of double.
-//OLD                   This has plenty of range.  Notge that there is no need to make NPHOT
-//OLD                   a long, as suggested above.  We do not expect it to exceed 2e9,
-//OLD                   although some kind of error check might be reasonble.
-//OLD   1306    ksl     Modified to allow a power law component to a stellar spectrum.  Made
-//OLD                   some changes use DEF variables instead of numbers to make choices
-//OLD   1307    jm      SS Parallelized Python in June 2013, for release 76a. I have now introduced
-//OLD                   slightly altered reporting to allow more succinct reporting in parallel mode.
-//OLD   1307    ksl     Removed the Thierry & Hubeny O-star models as an option from the code.
-//OLD                   This was never tested, and never really used.  Knox no longer even has the
-//OLD                   models.  Note that Stuart is replacing this with a homologous expansion
-//OLD                   model
-//OLD   1308    nsh     Added a call to generate rtheta wind cones - issue #41
-//OLD   1309    nsh     Changed the loop around where disk parameters are read in - issue #44
-//OLD   1309    nsh     Added commands to write out warning summary - relating to issue #47
-//OLD           1312    nsh     Added a new parameter file command to turn off heating and cooling mechanisms
-//OLD                   at the moment it only does adiabatc
-//OLD                   Also some modifications to the parallel communiactions to deal with some new
-//OLD                   plasma variabales, and the min and max frequency photons seen in bands.
-//OLD   1409    ksl     Added new switch -d to enable use of a new Debug logging feature
-//OLD   1411    JM removed photons per cycle in favour of NPHOT. subcycles are now eliminated
-//OLD   1501    JM moved some parallelization stuff to subroutines in para_update.c
-//OLD                   functions are communicate_estimators_para, communicate_matom_estimators_para,
-//OLD                   and gather_spectra_para
-//OLD   1502            Major reorganisation of input gathering and setup. See setup.c, #136 and #139
-//OLD   1508    ksl     Instroduction of the concept of domains to handle the disk and wind as separate
-//OLD                   domains
-//OLD     1711    ksl Removed the Elvis wind option
-//OLD
-//OLD   Look in Readme.c for more text concerning the early history of the program.
-//OLD
-//OLD **************************************************************/
-
 
 
 #include <stdio.h>
@@ -437,8 +219,6 @@ main (argc, argv)
     strcpy (answer, "star");
     geo.system_type = rdchoice ("System_type(star,binary,agn,previous)", "0,1,2,3", answer);
 
-//OLD      rdint ("System_type(0=star,1=binary,2=agn,3=previous)",
-//OLD        &geo.system_type);
 
     if (geo.system_type == SYSTEM_TYPE_PREVIOUS)
     {
@@ -652,7 +432,7 @@ main (argc, argv)
  * number as one inputs. It' s not obvious that this is a good idea. */
 
   if (geo.pcycles > 0 && geo.pcycle == 0)
-  {                             //OLD: geo.run_type != RUN_TYPE_RESTART
+  {
     // This should only evaluate true for when no spectrum cycles have run (I hope)
 
     rdpar_comment ("Parameters defining the spectra seen by observers\n");
@@ -707,7 +487,6 @@ main (argc, argv)
     /* Do we require extra diagnostics or not */
     strcpy (answer, "no");
     modes.diag_on_off = rdchoice ("@Diag.extra(yes,no)", "1,0", answer);
-//OLD      rdint ("@Diag.extra(0=no,1=yes) ", &modes.diag_on_off);
     if (modes.diag_on_off)
     {
       get_extra_diagnostics ();

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -9,106 +9,6 @@
  *
  ***********************************************************/
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD 
-//OLD  Synopsis:
-//OLD    radiation(p,ds) updates the radiation field parameters in the wind and reduces 
-//OLD    the weight of the photon as a result of the effect free free and photoabsorption.
-//OLD    radiation also keeps track of the number of photoionizations of h and he in the
-//OLD    cell. 
-//OLD Arguments:
-//OLD 
-//OLD   PhotPtr p;      the photon
-//OLD   double ds       the distance the photon has travelled in the cell
-//OLD 
-//OLD Returns:
-//OLD   Always returns 0.  The pieces of the wind structure which are updated are
-//OLD   j,ave_freq,ntot, heat_photo, heat_ff, heat_h, heat_he1, heat_he2, heat_z,
-//OLD   nioniz, and ioniz[].
-//OLD  
-//OLD Description:       
-//OLD Notes:
-//OLD   
-//OLD   The # of ionizations of a specific ion = (w(0)-w(s))*n_i sigma_i/ (h nu * kappa_tot).  (The # of ionizations
-//OLD   is just given by the integral of n_i sigma_i w(s) / h nu ds, but if the density is assumed to
-//OLD   be constant and sigma is also constant [therefy ignoring velocity shifts in a grid cell], then
-//OLD   n_i sigma and h nu can be brought outside the integral.  Hence the integral is just over w(s),
-//OLD   but that is just given by (w(0)-w(smax))/kappa_tot.)  The routine calculates the number of ionizations per
-//OLD   unit volume.
-//OLD   
-//OLD   This routine is very time counsuming for our normal file which has a large number of x-sections.  The problem
-//OLD   is going through all the do loops, not insofar as I can determine anything else.  Trying to reduce the calucatiions
-//OLD   by using a density criterion is a amall effect.  One really needs to avoid the calculations, either by avoiding
-//OLD   the do loops altogether or by reducing the number of input levels.  It's possible that if one were clever about
-//OLD   the thresholds (as we are on the lines that one could figure out a wininning strategy as it is all brute force
-//OLD         do loops..  
-//OLD 
-//OLD   57h -- This routine was very time consuming.  The time spent is/was well out of proportion to
-//OLD   the affect free-bound processes have on the overall spectrum, and so signifincant changes have been made
-//OLD   to the earlier versions of the routine.  The fundamental problem before 57h was that every time one
-//OLD   entered the routine (which was every for every movement of a photon) in the code.  Basically there were
-//OLD   3  changes made:
-//OLD           1. During the detailed spectrum cycle, the code avoids the portions of the routine that are
-//OLD   only needed during the ionization cycles.
-//OLD           2. Switches have been installed tha skip the free-bound section altogether if PHOT_DEN_MIN is
-//OLD   less than zero.  It is very reasonable to do this for the detailed spectrum calculation if one is
-//OLD   doing a standard 
-//OLD   were to skip portions of when they were not needed 
-//OLD 
-//OLD   ?? Would it be more natural to include electron scattering here in Radiation as well ??
-//OLD   ?? Radiation needs a major overhaul.  A substantial portion of this routine is not needed in the extract 
-//OLD   ?? portion of the calculation.  In addition the do loops go through all of the ions checking one at a time
-//OLD   ?? whether they are above the frequencey threshold.  
-//OLD   ?? The solution I believe is to include some kind of switch that tells the routine when one is doing
-//OLD   ?? the ionization calculation and to skip the unnecessary sections when extract is being carried out.
-//OLD   ?? In addition, if there were a set of ptrs to the photionization structures that were orded by frequency,
-//OLD   ?? similar to the line list, one could then change to loops so that one only had to check up to the
-//OLD   ?? first x-section that had a threshold up to the photon frequency, and not all of the rest.
-//OLD   ?? At present, I have simply chopped the photoionizations being considered to include only thresholds
-//OLD         ?? shortward of the Lyman limit...e.g. 1 Rydberg, but this makes it impossible to discuss the Balmer jump
-//OLD History:
-//OLD   97jan   ksl     Coded as part of python effort
-//OLD   98jul   ksl     Almost entirely recoded to eliminate arbitrary split between
-//OLD                   the several preexisting routines.
-//OLD   98nov   ksl     Added back tracking of number of h and he ionizations
-//OLD   99jan   ksl     Increased COLMIN from 1.e6 to 1.e10 and added checks so
-//OLD                   that one does not attempt to calculate photoionization
-//OLD                   cross-sections below threshold.  Both of these changes
-//OLD                   are intended to speed this routine.
-//OLD     01oct   ksl     Modifications begun to incorporate Topbase photoionization
-//OLD                         x-sections.
-//OLD     01oct   ksl     Moved fb_cooling to balance_abso.  It's only used by
-//OLD                         balance and probably should not be there either.
-//OLD   02jun   ksl     Improved/fixed treatment of calculation of number of ionizations.
-//OLD   04apr   ksl     SS had modified this routine to allow for macro-atoms in python_47, but his modifications
-//OLD                   left very little for radiation to accomplish.  I have returned to the old version of 
-//OLD                   routine, and moved the little bit that needed to be done in this routine for
-//OLD                   the macro approach to the calling routine.  Once we abandon the old approach this
-//OLD                   routine can be deleted.
-//OLD   04aug   ksl     Fixed an error which had crept into the program between 51 and 51a that caused the
-//OLD                   disk models to be wrong.  The problem was that there are two places where the
-//OLD                   same frequency limit should have been used, but the limits had been set differently.
-//OLD   04dec   ksl     54a -- Miniscule change to eliminate -03 warnings.  Also eliminate some variables
-//OLD                   that were not really being used.
-//OLD   06may   ksl     57+ -- Began modifications to allow for splitting the wind and plasma structures
-//OLD   06jul   ksl     57h -- Made various changes intended to speed up this routine. These include
-//OLD                   skipping sections of the routine in the spectrum generation
-//OLD                   phase that are not used, allowing control over whether fb opacities
-//OLD                   are calculated at all, and using frequency ordered pointer arrays
-//OLD                   to shorten the loops.
-//OLD   11aug   nsh     70 changes made to radiation to allow compton cooling to be computed
-//OLD   11aug   nsh     70 Changed printout of spectra in selected regions so it is always
-//OLD                   the midpoint of the wind
-//OLD   12may   nsh     72 Added induced compton
-//OLD   12jun   nsh     72 Added lines to write out photon stats to a file dirung diagnostics. This is
-//OLD                   to allow us to see how well spectra are being modelled by power law W and alpha
-//OLD   1405    JM corrected error (#73) so that photon frequency is shifted to the rest frame of the 
-//OLD           cell in question. Also added check which checks if a photoionization edge is crossed
-//OLD           along ds.
-//OLD   1508    NSH slight modification to mean that compton scattering no longer reduces the weight of
-//OLD                   the photon in this part of the code. It is now done when the photon scatters.
-//OLD **************************************************************/
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -612,33 +512,6 @@ radiation (p, ds)
   return (0);
 }
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD 
-//OLD  Synopsis: 
-//OLD   double kappa_ff(w,freq) calculates the free-free opacity allowing for stimulated emission
-//OLD   
-//OLD Arguments:
-//OLD 
-//OLD Returns:
-//OLD   
-//OLD Description:       
-//OLD   Formula from Allen
-//OLD   Includes only singly ionized H and doubly ionized he    
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD History:
-//OLD   98aug   ksl     Coded as part of python effort
-//OLD         04Apr   SS      If statement added for cases with hydrogen only.
-//OLD                         Note: this routine assumes that H I is the first ion
-//OLD                         and that He II is the fourth ion.
-//OLD   05may   ksl     57+ -- Modified to eliminate WindPtr in favor
-//OLD                   of PlasmaPtr
-//OLD           12oct   nsh     73 -- Modified to use a prefector summed over all ions, calculated prior
-//OLD                   to the photon flight
-//OLD 
-//OLD **************************************************************/
 
 
 
@@ -702,37 +575,6 @@ kappa_ff (xplasma, freq)
   return (x);
 }
 
-
-
-//OLD /***********************************************************
-//OLD                                  Space Telescope Science Institute
-//OLD 
-//OLD  Synopsis:
-//OLD   double sigma_phot(x_ptr,freq)   calculates the
-//OLD   photionization crossection due to the transition associated with
-//OLD   x_ptr at frequency freq
-//OLD Arguments:
-//OLD      struct topbase_phot *x_ptr;
-//OLD      double freq;
-//OLD 
-//OLD Returns:
-//OLD 
-//OLD Description:
-//OLD   sigma_phot uses the Topbase x-sections to calculate the bound free
-//OLD   (or photoionization) xsection.  The data must have been into the
-//OLD   photoionization structures xphot with get_atomic_data and the
-//OLD   densities of individual ions must have been calculated previously.
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD History:
-//OLD   01Oct   ksl     Coded as part of general move to use Topbase data
-//OLD                   (especially partial xsections, which did not exist 
-//OLD                   in the Verner et al prescriptions
-//OLD   02jul   ksl     Fixed error in the way fraction being applied.
-//OLD                   Sigh! and then modified program to use linterp
-//OLD 
-//OLD **************************************************************/
 
 
 /**********************************************************/
@@ -801,34 +643,16 @@ sigma_phot (x_ptr, freq)
 
 }
 
-//OLD /***********************************************************
-//OLD 
-//OLD   Synopsis: 
-//OLD   double sigma_phot_verner(x_ptr,freq)    calculates the photionization crossection due to the transition 
-//OLD   associated with x_ptr at frequency freq
-//OLD  Arguments:
-//OLD  
-//OLD  Returns:
-//OLD  
-//OLD  Description:      
-//OLD         Same as sigma_phot but using the older compitation from Verner that includes inner shells
-//OLD  
-//OLD  Notes:
-//OLD  
-//OLD  History:
-//OLD   08dec   SS      Coded (actually mostly copied from sigma_phot)
-//OLD  
-//OLD **************************************************************/
 
 
 /**********************************************************/
 /** 
- * @brief      double (x_ptr,freq)	calculates the photionization crossection due to the transition 
+ * @brief      calculates the photionization crossection due to the transition 
  *  	associated with x_ptr at frequency freq (when the data is in the form of the Verner x-sections
  *
  * @param [in] struct innershell *  x_ptr   The stucture that contains information in the format of Verner for 
  * a particular ion level
- * @param [in,out] double  freq   The frequency where the x-section is calculated
+ * @param [in] double  freq   The frequency where the x-section is calculated
  * @return     The photoinization x-section
  *
  * @details
@@ -837,7 +661,7 @@ sigma_phot (x_ptr, freq)
  * ### Notes ###
  * 
  * I (NSH) think this routine has been largely superceeded by the new inner shell formulation of auger ionization.
- * At some poi nt we may wish to expunge the old augerion perts of python.
+ * At some point we may wish to expunge the old augerion perts of python.
  *
  **********************************************************/
 
@@ -868,34 +692,6 @@ sigma_phot_verner (x_ptr, freq)
     return (0.0);
 }
 
-
-//OLD /***********************************************************
-//OLD                                  Space Telescope Science Institute
-//OLD 
-//OLD Synopsis:
-//OLD 
-//OLD double den_config(one,nconf) returns the precalculated density
-//OLD   of a particular "nlte" level.   If levels are not defined for an ion it
-//OLD   assumes that all ions of are in the ground state.
-//OLD 
-//OLD Arguments:
-//OLD 
-//OLD Returns:
-//OLD 
-//OLD Description: The first case is when the density of the particular level
-//OLD is in the wind array The second caseis when the density of the levels
-//OLD for an ion are not tracked, and hence only the total density for the
-//OLD ion is known.  In that case, we assume the ion is in it's ground state.
-//OLD 
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD History:
-//OLD   01oct   ksl     Coded as part of effort to add topbase
-//OLD                   xsections and detailed balance to python
-//OLD   05may   ksl     57+ -- Recoded to use PlasmaPtr
-//OLD 
-//OLD **************************************************************/
 
 
 /**********************************************************/
@@ -952,36 +748,6 @@ in the ground state */
 
 
 }
-
-
-//OLD /***********************************************************
-//OLD                 Southampton University
-//OLD 
-//OLD Synopsis: pop_kappa_ff_array populates the multiplicative         
-//OLD           factor used in the FF calculation. This depends only
-//OLD           on the densities of ions in the cell, and the electron
-//OLD           temperature (which feeds into the gaunt factor) so it
-//OLD           saves time to calculate all this just the once. This
-//OLD           is called in python.c, just before the photons are 
-//OLD           sent thruogh the wind.
-//OLD 
-//OLD Arguments:                
-//OLD 
-//OLD Returns:
-//OLD  
-//OLD Description:      
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD 
-//OLD History:
-//OLD    12oct           nsh     coded 
-//OLD    1212   ksl     Added sane check; note that this routine
-//OLD                   is poorly documented.  Somewhere this 
-//OLD           should be discribed better.  
-//OLD    1407 nsh       changed loop to only go over NPLASMA cells not NPLASMA+1
-//OLD  
-//OLD **************************************************************/
 
 
 
@@ -1045,44 +811,6 @@ pop_kappa_ff_array ()
   return (0);
 }
 
-
-
-
-//OLD /***********************************************************
-//OLD                 Southampton University
-//OLD 
-//OLD Synopsis: 
-//OLD   update_banded_estimators updates the estimators required for
-//OLD   mode 7 ionization- the Power law, pairwise, modified saha ionization solver.
-//OLD   It also records the values of IP.
-//OLD 
-//OLD Arguments:        
-//OLD   xplasma         PlasmaPtr for the cell
-//OLD   p                       Photon pointer
-//OLD   ds                      ds travelled
-//OLD   w_ave           the weight of the photon. 
-//In non macro atom mode,
-//OLD               this is an average weight (passed as w_ave), but 
-//OLD               in macro atom mode weights are never reduced (so p->w 
-//OLD               is used).
-//OLD 
-//OLD Returns:
-//OLD   increments the estimators in xplasma in the following modes:
-//
-//
-//OLD  
-//OLD Description:      
-//OLD   This routine does not contain new code on initial writing, but instead 
-//OLD   moves duplicated code from increment_bf_estimators and radiation() 
-//OLD   to here, as duplicating code is bad practice.
-//OLD 
-//OLD Notes:
-//OLD 
-//OLD 
-//OLD History:
-//OLD    1402 JM                Coding began
-//OLD  
-//OLD **************************************************************/
 
 
 /**********************************************************/
@@ -1224,36 +952,6 @@ update_banded_estimators (xplasma, p, ds, w_ave)
 
   return (0);
 }
-
-
-
-//OLD /*************************************************************
-//OLD Synopsis: 
-//OLD   mean_intensity returns a value for the mean intensity 
-//OLD 
-//OLD Arguments:        
-//OLD   xplasma                 PlasmaPtr for the cell - supplies spectral model
-//OLD   freq                    the frequency at which we want to get a value of J
-//OLD   mode                    mode 1=use BB if we have not yet completed a cycle
-//OLD                           and so dont have a spectral model, mode 2=never use BB
-//OLD 
-//OLD Returns:
-//OLD  
-//OLD Description:
-//OLD    This subroutine returns a value for the mean intensity J at a 
-//OLD    given frequency, using either a dilute blackbody model
-//OLD    or a spectral model depending on the value of geo.ioniz_mode. 
-//OLD    to avoid code duplication.
-//OLD 
-//OLD Notes:
-//OLD    This subroutine was produced
-//OLD    when we started to use a spectral model to populaste the upper state of a
-//OLD    two level atom, as well as to calculate induced compton heating. This was
-//OLD 
-//OLD History:
-//OLD    1407 NSH               Coding began
-//OLD  
-//OLD **************************************************************/
 
 
 

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -144,61 +144,6 @@ fb_topbase_partial (freq)
   return (partial);
 }
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: integ_fb calculates the integrated emissivity of the plasma, or the number of
-//OLD recombinations per second of a particular ion.
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD   t                   The temperature at which the emissivity
-//OLD                       or recombination rate is calculated
-//OLD   f1,f2           The frequency limits on the calculation
-//OLD                       of the emissivity (ignored if the number
-//OLD                       of recombinations is desired.
-//OLD   nion            The ion for which the emissivity is returned
-//OLD   fb_choice       A switch which determines exactly what is to
-//OLD                       be returned:
-//OLD                       0- the full emissivity including
-//OLD                       the energy associated associated with the
-//OLD                       threshold
-//OLD                       1- the (reduced) emissivity, e.g. excluding
-//OLD                       the threshold energy.  This is the energy
-//OLD                       associated with kinetic energy loss
-//OLD                       2- the specific recombination rate.
-//OLD mode      inner or outer shell
-//OLD
-//OLD
-//OLD
-//OLD   Returns:
-//OLD   The routine returns the specific emissivity, e.g. the emissivity and
-//OLD   or recombination rate per electron and per ion.
-//OLD
-//OLD   Notes:
-//OLD   As written, in July02, the idea is that if the recombination coefficients
-//OLD   have been calculated the program is going to return an interpolated
-//OLD   coefficient, if not, it will calculate it from scratch.  (The later is
-//OLD   much slower if one has to do it a lot of times.
-//OLD
-//OLD   ???? Error -- There is definitely an error because the program does
-//OLD   not support option 0, and this is needed for calculation of the
-//OLD   relative numbers of photons by fb vs free free photons.  ksl 02jul
-//OLD
-//OLD
-//OLD
-//OLD   History:
-//OLD   02jul   ksl     Modified to elimate need to include information about the cell.
-//OLD                   At this point integ_fb yields answers per electron and per ion.
-//OLD                   Moved DENSITY_PHOT_MIN test out of integ_fb
-//OLD   02jul   ksl     Original routines has been pushed down to xinteg_fb so
-//OLD                   that integ_fb can be modified to use stored values when
-//OLD                   desired.
-//OLD
-//OLD  ************************************************************************/
-
 
 
 /**********************************************************/
@@ -347,37 +292,6 @@ integ_fb (t, f1, f2, nion, fb_choice, mode)
 
 
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: total_fb returns the energy lost from the plasma due to fb emission in a
-//OLD   single wind cell at a temperature t between the frequncy limits f1 and f2.
-//OLD   The energy lost is just the kinetic energy lost from the plasma
-//OLD   because it does not include the ionization potential
-//OLD   associated with each recombination.  Python tracks effectively the kinetic energy
-//OLD   of the plasma (not the potential energy available if everything recombined.
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD
-//OLD
-//OLD   Returns:
-//OLD
-//OLD   Notes:
-//OLD
-//OLD
-//OLD   History:
-//OLD   02jul   ksl     Modified so computes fb contributions of individual ions, instead
-//OLD           of just h, he, and z, and so that one does not need to pass
-//OLD           the entire wind cell to integ_fb
-//OLD   02jul   ksl     Added call to init_freebound so that precalculated values would
-//OLD                   be used where possible.  This seemed the most conservative place
-//OLD           to put these calls since total_fb is always called whenever the
-//OLD           band-limited luminosities are needed.
-//OLD
-//OLD  ************************************************************************/
 
 
 
@@ -755,37 +669,6 @@ num_recomb (xplasma, t_e, mode)
 }
 
 
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: fb calculates the free_bound emissivity of the plasma at a specific frequency
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD
-//OLD   ion_choice      Either the total emissivity or the emissivity for a specific
-//OLD                   ion is caculated depending on whether ion_choice=nions, or
-//OLD                   a value less than the total number of ions
-//OLD     fb_choice determines whether what is returned is the emissivity a specific frecuency 0
-//OLD             the emissivity reduced by the ionization potential 1, or the number of photons per
-//OLD             unit Hz
-//OLD
-//OLD   Returns:
-//OLD
-//OLD   Notes:
-//OLD
-//OLD
-//OLD   History:
-//OLD   02jul   ksl     Modified to reflect desire to make fb_xtopbase and fb_verner
-//OLD                   independent of the wind cell.
-//OLD   06may   ksl     57+ -- Switched to plasma structure since no volume
-//OLD   06jul   ksl     57h -- Cleaned this routine up a bit, in part to avoid
-//OLD                   calling fb_verner_partial when it should not be called.
-//OLD
-//OLD  ************************************************************************/
-
 
 
 /**********************************************************/
@@ -1062,30 +945,6 @@ on the assumption that the fb information will be reused.
 
   return (0);
 }
-
-
-
-
-//OLD /**************************************************************************
-//OLD                     Space Telescope Science Institute
-//OLD
-//OLD
-//OLD   Synopsis: Return the recombination coefficient
-//OLD
-//OLD   Description:
-//OLD
-//OLD   Arguments:
-//OLD
-//OLD
-//OLD   Returns:
-//OLD
-//OLD   Notes:
-//OLD
-//OLD
-//OLD   History:
-//OLD           13sep   nsh     changed call to linterp to reflect new option
-//OLD
-//OLD  ************************************************************************/
 
 
 

--- a/source/run.c
+++ b/source/run.c
@@ -168,7 +168,6 @@ calculate_ionization (restart_stat)
       {
         NPHOT = NPHOT_MAX;
       }
-      //OLD NPHOT = ((geo.wcycle + 1.0) / geo.wcycles) * NPHOT_MAX;
     }
 
     Log ("!!Python: %1.2e photons will be transported for cycle %i\n", (double) NPHOT, geo.wcycle);

--- a/source/setup.c
+++ b/source/setup.c
@@ -407,7 +407,6 @@ init_observers ()
 
   strcpy (answer, "extract");
   geo.select_extract = rdchoice ("Spectrum.live_or_die(live.or.die,extract)", "0,1", answer);
-  //OLD rdint ("Spectrum.live_or_die(0=live.or.die,extract=anything_else)", &geo.select_extract);
   if (geo.select_extract != 0)
   {
     geo.select_extract = 1;
@@ -425,9 +424,6 @@ init_observers ()
     strcpy (answer, "no");
     ichoice = rdchoice ("@Spectrum.select_specific_no_of_scatters_in_spectra(yes,no)", ",1,0", answer);
 
-    //OLD strcpy (yesno, "n");
-    //OLD rdstr ("@Spectrum.select_specific_no_of_scatters_in_spectra(y/n)", yesno);
-    //OLD if (yesno[0] == 'y')
     if (ichoice)
 
     {
@@ -439,19 +435,14 @@ init_observers ()
     }
     strcpy (answer, "no");
     ichoice = rdchoice ("@Spectrum.select_photons_by_position(yes,no)", "1,0", answer);
-    //OLD strcpy (yesno, "n");
-    //OLD rdstr ("@Spectrum.select_photons_by_position(y/n)", yesno);
-    //OLD if (yesno[0] == 'y')
     if (ichoice)
     {
-      //OLD Log ("OK 0->all; -1 -> below; 1 -> above the disk, 2 -> specific location in wind\n");
       for (n = 0; n < geo.nangles; n++)
       {
         strcpy (answer, "all");
         geo.top_bot_select[n] = rdchoice ("@Spectrum.select_location(all,below_disk,above_disk,spherical_region)", "0,-1,1,2", answer);
 
 
-        //OLD rdint ("@Spectrum.select_location", &geo.top_bot_select[n]);
         if (geo.top_bot_select[n] == 2)
         {
           Log ("Warning: Make sure that position will be in wind, or no joy will be obtained\n");
@@ -473,7 +464,6 @@ init_observers ()
 
   strcpy (answer, "flambda");
   geo.select_spectype = rdchoice ("Spectrum.type(flambda,fnu,basic)", "1,2,3", answer);
-  //OLD rdint ("Spectrum.type(flambda(1),fnu(2),basic(other)", &geo.select_spectype);
 
   if (geo.select_spectype == 1)
   {
@@ -651,8 +641,6 @@ init_ionization ()
 
   strcpy (answer, "adiabatic");
 
-//OLD  thermal_opt = rdchoice ("Thermal_balance_options(adiabatic_only,all_off,nonthermal_only,all_on)", "0,1,2,3", answer);
-//  thermal_opt = rdchoice ("Thermal_balance_options(off,adiabatic_only,nonthermal_only,all_on)", "1,0,2,3", answer);
   thermal_opt = rdchoice ("Wind_heating.extra_processes(none,adiabatic,nonthermal,both)", "1,0,2,3", answer);
 
   if (thermal_opt == 0)
@@ -698,7 +686,6 @@ init_ionization ()
       ("Warning: Non-thermal heating has been selected.  This is a very special option put in place for modelling FU Ori stars, and should be used with extreme caution\n");
 
     geo.shock_factor = 0.001 * 4 * PI * pow (geo.rstar, 2) * STEFAN_BOLTZMANN * pow (geo.tstar, 4.);
-    //OLD rddoub ("Thermal_balance_options.extra_heating", &geo.shock_factor);
     rddoub ("Wind_heating.extra_luminosity", &geo.shock_factor);
     geo.shock_factor /= (4 * PI * pow (geo.rstar, 3));
     Log ("The non_thermal emissivity at the base is %.2e\n", geo.shock_factor);
@@ -706,7 +693,6 @@ init_ionization ()
     if (geo.rt_mode == RT_MODE_MACRO)
     {
       geo.frac_extra_kpkts = 0.1;
-      // OLD rddoub ("Thermal_balance_options.extra_kpacket_frac", &geo.frac_extra_kpkts);
       rddoub ("Wind_heating.kpacket_frac", &geo.frac_extra_kpkts);
 
     }

--- a/source/setup_domains.c
+++ b/source/setup_domains.c
@@ -59,13 +59,6 @@ get_domain_params (ndom)
 
   strcpy (answer, "SV");
   zdom[ndom].wind_type = rdchoice ("Wind.type(SV,star,hydro,corona,kwd,homologous,yso,shell,imported)", "0,1,3,4,5,6,7,9,10", answer);
-//OLD  rdint ("Wind_type(0=SV,1=Star,3=Hydro,4=corona,5=knigge,6=homologous,7=yso,9=shell,10=imported)", &zdom[ndom].wind_type);
-
-//OLD  if (zdom[ndom].wind_type == 2)
-//OLD  {
-//OLD    Error ("Wind_type 2, which was used to read in a previous model is no longer allowed! Use System_type instead!\n");
-//OLD    Exit (0);
-//OLD  }
 
 
   strcat (zdom[ndom].name, "Wind");
@@ -113,7 +106,6 @@ get_domain_params (ndom)
   {
     strcpy (answer, "no");
     modes.adjust_grid = rdchoice ("@Diag.adjust_grid(yes,no)", "1,0", answer);
-//OLD    rdint ("@Diag.adjust_grid(0=no,1=yes)", &modes.adjust_grid);
 
     if (modes.adjust_grid)
     {

--- a/source/setup_line_transfer.c
+++ b/source/setup_line_transfer.c
@@ -57,9 +57,6 @@ get_line_transfer_mode ()
   user_line_mode =
     rdchoice ("Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)",
               "0,1,2,3,5,6,7", answer);
-//OLD  rdint
-//OLD    ("Line_transfer(0=pure.abs,1=pure.scat,2=sing.scat,3=escape.prob,5=thermal_trapping,6=macro_atoms,7=macro_atoms+aniso.scattering)",
-//OLD     &user_line_mode);
 
   /* JM 1406 -- geo.rt_mode and geo.macro_simple control different things. geo.rt_mode controls the radiative
      transfer and whether or not you are going to use the indivisible packet constraint, so you can have all simple 
@@ -91,12 +88,6 @@ get_line_transfer_mode ()
     Log ("Line_transfer mode:  Simple, isotropic scattering, escape probabilities\n");
     geo.line_mode = user_line_mode;
   }
-//OLD  else if (user_line_mode == 4)
-//OLD  {
-//OLD    Error ("get_line_transfer_mode: Line transfer mode %d is deprecated\n", user_line_mode);
-//OLD    line_transfer_help_message ();
-//OLD    Exit (0);
-//OLD  }
   else if (user_line_mode == 5)
   {
     Log ("Line_transfer mode:  Simple, thermal trapping, Single scattering \n");
@@ -164,7 +155,6 @@ get_line_transfer_mode ()
     if (modes.iadvanced)
     {
 
-      //OLD  rdint ("@Diag.write_atomicdata(0=no,anything_else=yes)", &write_atomicdata);
 
       strcpy (answer, "no");
       write_atomicdata = rdchoice ("@Diag.write_atomicdata(yes,no)", "1,0", answer);

--- a/source/setup_star_bh.c
+++ b/source/setup_star_bh.c
@@ -170,7 +170,6 @@ get_bl_and_agn_params (lstar)
   {
     strcpy (answer, "no");
     geo.bl_radiation = rdchoice ("Boundary_layer.radiation(yes,no)", "1,0", answer);
-    //OLD rdint ("Boundary_layer.radiation(y=1)", &geo.bl_radiation);
     geo.agn_radiation = 0;      // So far at least, our star systems don't have a BH
   }
 
@@ -298,7 +297,6 @@ get_bl_and_agn_params (lstar)
     strcpy (answer, "sphere");
     geo.pl_geometry = rdchoice ("BH.geometry_for_pl_source(sphere,lamp_post)", "0,1", answer);
 
-    //OLD rdint ("AGN.geometry_for_pl_source(0=sphere,1=lamp_post)", &geo.pl_geometry);
 
     if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
     {

--- a/source/shell_wind.c
+++ b/source/shell_wind.c
@@ -211,12 +211,10 @@ shell_make_grid (w, ndom)
   nstart = zdom[ndom].nstart;
 
 
-//OLD  w[0].r = zdom[ndom].rmin - (zdom[ndom].rmax - zdom[ndom].rmin);
   w[nstart + 0].r = 0.95 * zdom[ndom].rmin;
   w[nstart + 1].r = zdom[ndom].rmin;
   w[nstart + 2].r = zdom[ndom].rmax;
   w[nstart + 3].r = 1.05 * zdom[ndom].rmax;
-//OLD  w[3].r = zdom[ndom].rmax + (zdom[ndom].rmax - zdom[ndom].rmin);
 
 
 

--- a/source/sv.c
+++ b/source/sv.c
@@ -51,8 +51,6 @@ get_sv_wind_params (ndom)
   zdom[ndom].wind_mdot *= MSOL / YR;
 
 
-//OLD  zdom[ndom].sv_rmin = 2.8e9;
-//OLD  zdom[ndom].sv_rmax = 8.4e9;
   zdom[ndom].sv_thetamin = 20. / RADIAN;
   zdom[ndom].sv_thetamax = 65. / RADIAN;
   zdom[ndom].sv_gamma = 1.;

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -500,8 +500,6 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
           track_scatters (&pp, wmain[n].nplasma, "Resonant");
 
 
-        //OLD scatters is an integer so next line has to be wrong - ksl
-        //OLD plasmamain[wmain[n].nplasma].scatters[line[nres].nion] += pp.w;
         plasmamain[wmain[n].nplasma].scatters[line[nres].nion] += 1;
 
         if (geo.rt_mode == RT_MODE_2LEVEL)      // only do next line for non-macro atom case

--- a/source/wind.c
+++ b/source/wind.c
@@ -466,7 +466,6 @@ wind_check (www, n)
      WindPtr www;
      int n;
 {
-//OLD  Log ("Got to wind_check\n");
   int i, j, k, istart, istop;
   if (n < 0)
   {
@@ -510,6 +509,5 @@ wind_check (www, n)
   }
 
   Log ("Wind_check: Punchthrough distance DFUDGE %e www[1].x[2] %e\n", DFUDGE, www[1].x[2]);
-//OLD  Log ("Finished wind check\n");
   return (0);
 }

--- a/source/wind2d.c
+++ b/source/wind2d.c
@@ -327,7 +327,6 @@ be optional which variables beyond here are moved to structures othere than Wind
     }
     else
     {
-//OLD     plasmamain[n].t_r = geo.twind_init;
       plasmamain[n].t_r = zdom[ndom].twind;
     }
 
@@ -491,44 +490,6 @@ be optional which variables beyond here are moved to structures othere than Wind
 }
 
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   where_in_grid locates the 1-d grid position of the photon.
-//OLD
-//OLD  Arguments:
-//OLD   ndom            The domain number for the search
-//OLD   double x[];     The position
-//OLD  Returns:
-//OLD   where_in_grid normally  returns element in wmain  associated with
-//OLD           a position.  If the photon is in the grid this will
-//OLD           be a positive integer.
-//OLD   photon is inside the grid        -1
-//OLD   photon is outside the grid       -2
-//OLD  Description:
-//OLD
-//OLD
-//OLD  Notes:
-//OLD   Where_in grid does not tell you whether the photon is in the wind!.
-//OLD
-//OLD   What one means by inside or outside the grid may well be different
-//OLD   for different coordinate systems..
-//OLD
-//OLD
-//OLD  History:
-//OLD   97jan   ksl     Coding on python began.
-//OLD   98jul   ksl     Removed WindPtr as one of arguments since not used
-//OLD   98dec   ksl     Modified so that the argument is simply a position
-//OLD   99jan   ksl     Modified to check that we are not trying to short
-//OLD                   circuit if we are asking for where_in_grid of same
-//OLD                   position as previously
-//OLD   04aug   ksl     52a -- Now almos a shell, as moved to allow
-//OLD                   multiple coordinate systems
-//OLD   05apr   ksl     55d -- Added spherical as a possiblity
-//OLD   15aug   ksl     Modified so that a domain number is requried
-//OLD
-//OLD **************************************************************/
 
 int wig_n;
 double wig_x, wig_y, wig_z;
@@ -611,66 +572,6 @@ where_in_grid (ndom, x)
   return (wig_n);
 }
 
-//OLD /***********************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD  Synopsis:
-//OLD   vwind_xyz(ndom,p,v) finds the velocity vector v for the wind in cartesian
-//OLD   coordinates at the position of the photon p.
-//OLD
-//OLD  Arguments:
-//OLD   int ndom;
-//OLD   PhotPtr p;
-//OLD   double v[];
-//OLD
-//OLD Returns:
-//OLD   0       on successful completion
-//OLD           the value of where in grid if the photon outside the wind grid.
-//OLD
-//OLD Description:
-//OLD   This routine carries out a bilinear interpolation of the wind velocity.  The velocities
-//OLD   at the edges of the grid cells must have been defined elsewhere (e.g in wind_define).
-//OLD
-//OLD   If the position is outside the wind grid, then the velocities will be returned as 0.
-//OLD
-//OLD Notes:
-//OLD   For all of the 2d coordinate systems, the positions in the WindPtr array are
-//OLD   caclulated in the xz plane.  As a result, the velocities in that array are
-//OLD   calcuated there as well.  Hence, to obtain the velocity in cartesion coordinates
-//OLD   one needs to do a simple rotation of the velocity vector.
-//OLD
-//OLD   For spherical (1d) coordinates the situation is complex, the philosopy that
-//OLD   has been adopted is to let the program run even if the wind model is intrinsically
-//OLD   2d.   The xyz positions of the grid are defined are defined so that
-//OLD   are in the xz plane at an angle of 45 degrees to the x axis.  This was done
-//OLD   so that if one used, say an sv wind, in spherical coordinates, one would select
-//OLD   the wind velocities at a plausible location.   But it implies that the velocities
-//OLD   that have been accepted are not purely radial as one might expect.  The choice
-//OLD   that has been made is to assume that v[1] is preserved as a non zero value in
-//OLD   making the projection.  An alternative might have been to preserve the angular
-//OLD   rotation rate.
-//OLD
-//OLD   Regardless, the fundamental challenge is to make sure the program works correctly
-//OLD   for the spherically symmetric case, e.g a simple stellar wind, which it did not
-//OLD   before 56b.
-//OLD
-//OLD   If we ever implement a real 3d coordinate system, one will need to look at
-//OLD   this routine again.
-//OLD
-//OLD History:
-//OLD   97jan   ksl     Coding on python began.
-//OLD   02feb   ksl     Modified to use new general purpose fraction routine.
-//OLD   04aug   ksl     52a -- Made a shell for choosing what coordinate
-//OLD                   system to calculate this in
-//OLD   05jun   ksl     56b -- Despite the note above nothing had been done
-//OLD                   to fix vwind_xyz to handle spherical coordinates
-//OLD                   properly.  It was OK for any two-d system.  This
-//OLD                   is now fixed, but see the notes above.
-//OLD   06may   ksl     57+ -- Changed call to elimatnate passing the
-//OLD                   Wind array.  Use wmain instead.
-//OLD   15aug   ksl     Added a variable for the domain
-//OLD
-//OLD **************************************************************/
 int ierr_vwind = 0;
 
 
@@ -1152,64 +1053,12 @@ zero_scatters ()
 }
 
 
-//OLD /*************************************************************
-//OLD                                        Space Telescope Science Institute
-//OLD
-//OLD   Check how many corners  of a wind cell are in the wind defined by this
-//OLD   particular domain
-//OLD
-//OLD Synopsis:
-//OLD
-//OLD   The routine basically just calls where_in_wind for each of the 4 corners
-//OLD   of the cell.
-//OLD
-//OLD
-//OLD Arguments:
-//OLD
-//OLD   int n where n is the cell number
-//OLD
-//OLD Returns:
-//OLD
-//OLD   The routine simply returns the number of corners of the cell that
-//OLD   is in the wind
-//OLD
-//OLD Description:
-//OLD   This is really just a driver routine for coordinate system specific
-//OLD   routines
-//OLD
-//OLD   It is intended to standardize this check so that one can
-//OLD   use such a routin in the volumes calculations.
-//OLD
-//OLD Notes:
-//OLD
-//OLD   It has not been implemented for a spherical (1d)
-//OLD   coordinate system.
-//OLD
-//OLD   The fact that none of the corners of a cell are in
-//OLD   the wind is not necessarily a guarantee that the wind
-//OLD   does not pass through the cell.  This is not only
-//OLD   a theoretical problem, because we generally use
-//OLD   a logarithmic spacing for the wind cells and thus
-//OLD   the dimensions of the cells get quite large as one
-//OLD   gets far from the center.
-//OLD
-//OLD   The only way to verify this is to check all four
-//OLD   surfaces of the wind.
-//OLD
-//OLD History
-//OLD   080403  ksl     68c - Added, or more correctly simply
-//OLD                   moved code into a separate routine so
-//OLD                   could be called from elsewhere
-//OLD   15sep   ksl     Modifidy so that it n_inwind is incremented
-//OLD                   only if we are in the domain associated with
-//OLD                   this particular cell.
-//OLD *****************************************************/
 
 
 /**********************************************************/
 /**
- * @brief      The routine basically just calls where_in_wind for each of the 4 corners
- * 	of the cell.
+ * @brief      The routine basically just calls where_in_wind for each of 
+ ' the 4 corners of a cell in one of the 2d coordinate systems.
  *
  * @param [in] int  n   the cell number in wmain
  * @return     the number of corners of the cell that
@@ -1219,12 +1068,14 @@ zero_scatters ()
  * This is really just a driver routine which calls coordinate system specific
  * routines
  *
- * It is intended to standardize this check so that one can
- * use such a routine in the volumes calculations.
+ * It is used to  standardize this check for calculations of 
+ * the volume of a cell that is in the wind in a domain.
  *
  * ### Notes ###
  * This is one of the routines that makes explicity assumptions
  * about guard cells, and it is not entirely clear why
+ *
+ * This rutine is not called for a spherical coordinate system
  *
  **********************************************************/
 

--- a/source/windsave.c
+++ b/source/windsave.c
@@ -334,7 +334,6 @@ wind_complete (w)
 
   /* JM Loop over number of domains */
 
-  //OLD printf ("geo.ndomain %d\n", geo.ndomain);
 
   for (ndom = 0; ndom < geo.ndomain; ndom++)
   {


### PR DESCRIPTION
Eliminates many //OLD statements to proper for the public release and hack week of 2019

There are a few routines, most notably phot_utils where OLD statements
were not removed, because their are some issues that need to be worked
out, given the comments in the routines.