### PR TITLE
Changes to allow v0 flexibility for SV winds as non-advanced mode 

### DIFF
--- a/examples/basic/cv_standard.pf
+++ b/examples/basic/cv_standard.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/basic/reverb.pf
+++ b/examples/basic/reverb.pf
@@ -39,14 +39,16 @@ Thermal_balance_options(everything.on,no.adiabatic)   everything.on
 wind.radmax(cm)                            1e19
 wind.t.init                                1e5
 wind.mdot(msol/yr)                         5
-sv.diskmin(units_of_rstar)                 50
-sv.diskmax(units_of_rstar)                 100
-sv.thetamin(deg)                           70
-sv.thetamax(deg)                           82
-sv.mdot_r_exponent                         0
-sv.v_infinity(in_units_of_vescape          1
-sv.acceleration_length(cm)                 1e18
-sv.acceleration_exponent                   1.0
+SV.diskmin(units_of_rstar)                 50
+SV.diskmax(units_of_rstar)                 100
+SV.thetamin(deg)                           70
+SV.thetamax(deg)                           82
+SV.mdot_r_exponent                         0
+SV.v_infinity(in_units_of_vescape          1
+SV.acceleration_length(cm)                 1e18
+SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.filling_factor(1=smooth,<1=clumped)   1
 
 ### Parameters defining the spectra seen by observers

--- a/examples/beta/lamp_post.pf
+++ b/examples/beta/lamp_post.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e18
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e19
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/beta/ngc5548.pf
+++ b/examples/beta/ngc5548.pf
@@ -47,6 +47,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e16
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e17
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   0.01

--- a/examples/beta/ulx1.pf
+++ b/examples/beta/ulx1.pf
@@ -46,6 +46,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          2
 SV.acceleration_length(cm)                 1e8
 SV.acceleration_exponent                   0.2
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e10
 Wind.t.init                                1e6
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/extended/cv_macro_benchmark.pf
+++ b/examples/extended/cv_macro_benchmark.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/extended/m16_agn.pf
+++ b/examples/extended/m16_agn.pf
@@ -47,6 +47,8 @@ SV.mdot_r_exponent                         0.0
 SV.v_infinity(in_units_of_vescape          1.0
 SV.acceleration_length(cm)                 1e19
 SV.acceleration_exponent                   0.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+20
 Wind.t.init                                100000.0
 Wind.filling_factor(1=smooth,<1=clumped)   0.01

--- a/examples/extended/sv_detailedmode.pf
+++ b/examples/extended/sv_detailedmode.pf
@@ -49,6 +49,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/agn_short.pf
+++ b/examples/regress/agn_short.pf
@@ -47,6 +47,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e18
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e19
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/cv.pf
+++ b/examples/regress/cv.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/cv_boundary_layer.pf
+++ b/examples/regress/cv_boundary_layer.pf
@@ -51,6 +51,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/cv_kur.pf
+++ b/examples/regress/cv_kur.pf
@@ -50,6 +50,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/cv_reflect.pf
+++ b/examples/regress/cv_reflect.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/cv_reflect2.pf
+++ b/examples/regress/cv_reflect2.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/rtheta.pf
+++ b/examples/regress/rtheta.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/regress/two.pf
+++ b/examples/regress/two.pf
@@ -60,6 +60,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e+10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                30000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/cv_macro_benchmark.pf
+++ b/examples/travis/cv_macro_benchmark.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/cv_standard.pf
+++ b/examples/travis/cv_standard.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e+12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/fiducial_agn.pf
+++ b/examples/travis/fiducial_agn.pf
@@ -47,6 +47,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e18
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e19
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/lamp_post.pf
+++ b/examples/travis/lamp_post.pf
@@ -48,6 +48,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e18
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e19
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/ngc5548.pf
+++ b/examples/travis/ngc5548.pf
@@ -47,6 +47,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          1
 SV.acceleration_length(cm)                 1e16
 SV.acceleration_exponent                   1.0
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e17
 Wind.t.init                                1e5
 Wind.filling_factor(1=smooth,<1=clumped)   0.01

--- a/examples/travis/sv_detailedmode.pf
+++ b/examples/travis/sv_detailedmode.pf
@@ -51,8 +51,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          3
 SV.acceleration_length(cm)                 7e10
 SV.acceleration_exponent                   1.5
-@SV.v_zero_mode(fixed,sound_speed)		   fixed 
-@SV.v_zero(cm/s)						   6e5
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						   	   6e5
 Wind.radmax(cm)                            1e12
 Wind.t.init                                40000
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/examples/travis/ulx1.pf
+++ b/examples/travis/ulx1.pf
@@ -46,6 +46,8 @@ SV.mdot_r_exponent                         0
 SV.v_infinity(in_units_of_vescape          2
 SV.acceleration_length(cm)                 1e8
 SV.acceleration_exponent                   0.2
+SV.v_zero_mode(fixed,sound_speed)		   fixed 
+SV.v_zero(cm/s)						       6e5
 Wind.radmax(cm)                            1e10
 Wind.t.init                                1e6
 Wind.filling_factor(1=smooth,<1=clumped)   1

--- a/source/sv.c
+++ b/source/sv.c
@@ -84,15 +84,14 @@ get_sv_wind_params (ndom)
   rddoub ("SV.acceleration_length(cm)", &zdom[ndom].sv_r_scale);        /*Accleration length scale for wind */
   rddoub ("SV.acceleration_exponent", &zdom[ndom].sv_alpha);    /* Accleration scale exponent */
 
-  if (modes.iadvanced)
-  {
-    strcpy (answer, "fixed");
-    zdom[ndom].sv_v_zero_mode = rdchoice ("@SV.v_zero_mode(fixed,sound_speed)", "0,1", answer);
-    if (zdom[ndom].sv_v_zero_mode == FIXED)
-      rddoub ("@SV.v_zero(cm/s)", &zdom[ndom].sv_v_zero);
-    else if (zdom[ndom].sv_v_zero_mode == SOUND_SPEED)
-      rddoub ("@SV.v_zero(multiple_of_sound_speed)", &zdom[ndom].sv_v_zero);
-  }
+  /* allow the user to pick whether they set v0 by a fixed value or by the sound speed */
+  strcpy (answer, "fixed");
+  zdom[ndom].sv_v_zero_mode = rdchoice ("SV.v_zero_mode(fixed,sound_speed)", "0,1", answer);
+  if (zdom[ndom].sv_v_zero_mode == FIXED)
+    rddoub ("SV.v_zero(cm/s)", &zdom[ndom].sv_v_zero);
+  else if (zdom[ndom].sv_v_zero_mode == SOUND_SPEED)
+    rddoub ("SV.v_zero(multiple_of_sound_speed)", &zdom[ndom].sv_v_zero);
+
 /* Assign the generic parameters for the wind the generic parameters of the wind */
 
   zdom[ndom].rmin = geo.rstar;


### PR DESCRIPTION
This change allows the user to choose whether the initial velocity for SV winds as a non-advanced mode. It can be either fixed, in which case it asks for a value, or sound_speed, in which case it asks for a multiple of the sound speed.

All example files updates so travis should pass. 

This involves two new keywords so could mess up people's runs. So someone should decide when the best time to merge is @kslong @smangham @saultyevil 