### PR TITLE
fixes for macro-atom estimator errors, closes #583

### DIFF
--- a/source/macro_gov.c
+++ b/source/macro_gov.c
@@ -238,7 +238,7 @@ macro_pops (xplasma, xne)
   int index_bbu, index_bbd, index_bfu, index_bfd;
   int lower, upper;
   double this_ion_density, level_population;
-  double ionden_temp;
+  double ionden_temp, fractional_population;
   double inversion_test;
   double q_ioniz (), q_recomb ();
   double *a_data, *b_data;
@@ -556,8 +556,6 @@ macro_pops (xplasma, xne)
            which are never a good thing and most likely unphysical.
            Therefor let's follow Leon's procedure (Lucy 2003) and remove inversions. */
 
-
-
         for (index_ion = ele[index_element].firstion; index_ion < (ele[index_element].firstion + ele[index_element].nions); index_ion++)
         {
           for (index_lvl = ion[index_ion].first_nlte_level; index_lvl < ion[index_ion].first_nlte_level + ion[index_ion].nlte; index_lvl++)
@@ -661,10 +659,11 @@ macro_pops (xplasma, xne)
                  index_lvl++)
             {
               /* JM Nov 18 -- if statement to prevent nan in fractional populations */
-              if (this_ion_density <= DENSITY_MIN || populations[conf_to_matrix[index_lvl]] <= DENSITY_MIN)
+              fractional_population = populations[conf_to_matrix[index_lvl]] / this_ion_density;
+              if (this_ion_density <= DENSITY_MIN || fractional_population <= DENSITY_MIN)
                 xplasma->levden[config[index_lvl].nden] = DENSITY_MIN;
               else
-                xplasma->levden[config[index_lvl].nden] = populations[conf_to_matrix[index_lvl]] / this_ion_density;
+                xplasma->levden[config[index_lvl].nden] = fractional_population;
             }
           }
         }

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -162,9 +162,9 @@ communicate_estimators_para ()
     plasmamain[mpi_i].ip_direct = redhelper2[mpi_i + 12 * NPLASMA];
     plasmamain[mpi_i].ip_scatt = redhelper2[mpi_i + 13 * NPLASMA];
     plasmamain[mpi_i].heat_auger = redhelper2[mpi_i + 14 * NPLASMA];
-	plasmamain[mpi_i].rad_force_es[0] = redhelper2[mpi_i + 15 * NPLASMA];
-	plasmamain[mpi_i].rad_force_es[1] = redhelper2[mpi_i + 16 * NPLASMA];
-	plasmamain[mpi_i].rad_force_es[2] = redhelper2[mpi_i + 17 * NPLASMA];
+    plasmamain[mpi_i].rad_force_es[0] = redhelper2[mpi_i + 15 * NPLASMA];
+    plasmamain[mpi_i].rad_force_es[1] = redhelper2[mpi_i + 16 * NPLASMA];
+    plasmamain[mpi_i].rad_force_es[2] = redhelper2[mpi_i + 17 * NPLASMA];
 
     for (mpi_j = 0; mpi_j < NXBANDS; mpi_j++)
     {

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -151,7 +151,7 @@ translate_in_space (pp)
     stuff_phot (pp, &ptest);
     move_phot (&ptest, ds + DFUDGE);    /* So now ptest is at the edge of the wind as defined by the boundary
                                            From here on we should be in the grid  */
-		ds=ds+DFUDGE; //Fix for Bug #592 - we need to keep track of the little DFUDGE we moved the test photon
+    ds = ds + DFUDGE;           //Fix for Bug #592 - we need to keep track of the little DFUDGE we moved the test photon
     /* XXX this is a test.  We check at the start whether we are in the grid */
 
     if ((ifail = where_in_grid (ndom, ptest.x)) < 0)

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -837,7 +837,7 @@ calls to two_level atom
    * or equal to the minimum too.
    */
 
-  if ( (d1 < DENSITY_PHOT_MIN && d2 < DENSITY_PHOT_MIN) || (d2 / xplasma->density[nion]) <= DENSITY_MIN)
+  if ((d1 < DENSITY_PHOT_MIN && d2 < DENSITY_PHOT_MIN) || (d2 / xplasma->density[nion]) <= DENSITY_MIN)
   {
     return (0);
   }
@@ -850,11 +850,13 @@ calls to two_level atom
     sobolev_error_counter++;
     if (sobolev_error_counter < 100)
     {
-      Error ("sobolev: VERY BAD den_ion has population inversion %g %g %g %g %g %g\n", d1, d2, lptr->gl, lptr->gu, lptr->freq, lptr->f);
+      Error ("sobolev: VERY BAD population inversion in cell %d: d1 %g d2 %g g1 %g g2  %g freq %g f %g frac_upper %g %g\n",
+             xplasma->nplasma, d1, d2, lptr->gl, lptr->gu, lptr->freq, lptr->f, d2 / xplasma->density[nion],
+             xplasma->levden[config[lptr->nconfigu].nden]);
     }
     else if (sobolev_error_counter == 100)
     {
-      Error ("sobolev: suppressing negative density errors\n");
+      Error ("sobolev: suppressing population inversion errors\n");
     }
 
     /* With the changes above to limit the densities the above error should not be happening, and if this does occur then 
@@ -863,7 +865,7 @@ calls to two_level atom
      * ksl 181127
      */
 
-    /*SS July 08: With macro atoms, the population solver can default to d2 = gu/gl * d1 which should
+    /* SS July 08: With macro atoms, the population solver can default to d2 = gu/gl * d1 which should
        give exactly zero here but can be negative, numerically.
        So I'm modyfying this to set tau to zero in such cases, when the populations are vanishingly small anyway. */
     tau_x_dvds = PI_E2_OVER_M * d1 * lptr->f / (lptr->freq);

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -779,7 +779,7 @@ sobolev (one, x, den_ion, lptr, dvds)
      struct lines *lptr;
      double dvds;
 {
-  double tau, xden_ion, tau_x_dvds;
+  double tau, xden_ion, tau_x_dvds, levden_upper;
   double two_level_atom (), d1, d2;
   int nion;
   double d_hold;
@@ -837,7 +837,8 @@ calls to two_level atom
    * or equal to the minimum too.
    */
 
-  if ((d1 < DENSITY_PHOT_MIN && d2 < DENSITY_PHOT_MIN) || (d2 / xplasma->density[nion]) <= DENSITY_MIN)
+  levden_upper = xplasma->levden[config[lptr->nconfigu].nden];
+  if ((d1 < DENSITY_PHOT_MIN && d2 < DENSITY_PHOT_MIN) || (levden_upper <= DENSITY_MIN))
   {
     return (0);
   }
@@ -850,9 +851,8 @@ calls to two_level atom
     sobolev_error_counter++;
     if (sobolev_error_counter < 100)
     {
-      Error ("sobolev: VERY BAD population inversion in cell %d: d1 %g d2 %g g1 %g g2  %g freq %g f %g frac_upper %g %g\n",
-             xplasma->nplasma, d1, d2, lptr->gl, lptr->gu, lptr->freq, lptr->f, d2 / xplasma->density[nion],
-             xplasma->levden[config[lptr->nconfigu].nden]);
+      Error ("sobolev: VERY BAD population inversion in cell %d: d1 %g d2 %g g1 %g g2  %g freq %g f %g frac_upper %g\n",
+             xplasma->nplasma, d1, d2, lptr->gl, lptr->gu, lptr->freq, lptr->f, levden_upper);
     }
     else if (sobolev_error_counter == 100)
     {


### PR DESCRIPTION
This change should hopefully solve #583. A few main changes:
* Fix to a mistake in how the error check on the density floor for fractional matom populations was carried out in macro_gov.c
* only report population inversion if the upper level is above the density floor 
* same approach in sobolev() in resonate.c

without these mistakes, I don't get the errors in the parameter file Knox provided as part of #583. 

It's possible there's a slightly better way to do this, e.g. one could clean populations after one sets the floors, but this seems a reasonable enough approach to me for something that won't affect overall calculations at all.

@kslong @saultyevil you can either test before merge by checking out jhmatthews/estimator_fix, or can be checked after merging into dev. We probably want to test for same results, and for no more of the sobolev and estimators errors that were happening.