### PR TITLE
Fix for reposition bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,12 @@ set(CMAKE_C_COMPILER mpicc)
 add_definitions(-D MPI_ON)
 
 # Include the source
-include_directories(source)
+include_directories(inc)
+link_directories(lib)
 
 # Define the executables
 add_executable(python
+        source/rdpar_init.c
         source/bb.c
         source/get_atomicdata.c
         source/python.c
@@ -70,7 +72,6 @@ add_executable(python
         source/matom.c
         source/estimators.c
         source/wind_sum.c
-        source/yso.c
         source/cylindrical.c
         source/rtheta.c
         source/spherical.c
@@ -163,7 +164,6 @@ add_executable(py_wind
         source/matom.c
         source/estimators.c
         source/wind_sum.c
-        source/yso.c
         source/cylindrical.c
         source/rtheta.c
         source/spherical.c
@@ -261,7 +261,6 @@ add_executable(windsave2table
         source/matom.c
         source/estimators.c
         source/wind_sum.c
-        source/yso.c
         source/cylindrical.c
         source/rtheta.c
         source/spherical.c
@@ -310,7 +309,6 @@ add_executable(windsave2table
         )
 
 # Include external libs
-find_package(GSL REQUIRED)
-target_link_libraries(python GSL::gsl GSL::gslcblas m)
-target_link_libraries(py_wind GSL::gsl GSL::gslcblas m)
-target_link_libraries(windsave2table GSL::gsl GSL::gslcblas m)
+target_link_libraries(python gsl gslcblas m)
+target_link_libraries(py_wind gsl gslcblas m)
+target_link_libraries(windsave2table gsl gslcblas m)

--- a/source/phot_util.c
+++ b/source/phot_util.c
@@ -72,7 +72,6 @@ stuff_phot (pin, pout)
   pout->np = pin->np;
 
   pout->path = pin->path;
-  pout->repos = pin->repos;
 
   return (0);
 }

--- a/source/phot_util.c
+++ b/source/phot_util.c
@@ -72,6 +72,7 @@ stuff_phot (pin, pout)
   pout->np = pin->np;
 
   pout->path = pin->path;
+  pout->repos = pin->repos;
 
   return (0);
 }

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -807,11 +807,18 @@ walls (p, pold, normal)
   else if (geo.disk_type == DISK_FLAT && p->x[2] * pold->x[2] < 0.0)
   {                             /* Then the photon crossed the xy plane and probably hit the disk */
     s = (-(pold->x[2])) / (pold->lmn[2]);
+
+    if (s < 0 && fabs (pold->x[2]) < wmain[pold->grid].dfudge)
+    {
+      return (p->repos = TRUE);
+    }
+
     if (s < 0)
     {
       Error ("walls: distance %g<0. Position %g %g %g \n", s, p->x[0], p->x[1], p->x[2]);
       return (-1);
     }
+
     /* Check whether it hit the disk plane beyond the geo.diskrad**2 */
     vmove (pold->x, pold->lmn, s, xxx);
 

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -808,10 +808,8 @@ walls (p, pold, normal)
   {                             /* Then the photon crossed the xy plane and probably hit the disk */
     s = (-(pold->x[2])) / (pold->lmn[2]);
 
-    if (s < 0 && fabs (pold->x[2]) < wmain[pold->grid].dfudge)
-    {
-      return (p->repos = TRUE);
-    }
+    if (s < 0 && fabs (pold->x[2]) < wmain[pold->grid].dfudge && pold->lmn[2] * p->lmn[2] < 0.0)
+      return (p->istat = P_REPOSITION_ERROR);
 
     if (s < 0)
     {

--- a/source/python.c
+++ b/source/python.c
@@ -327,8 +327,6 @@ main (argc, argv)
   }
 
 
-
-
 /* Get the remainder of the input data.  Note that the next few lines are read from the input file whether or not the windsave file was read in,
    because these are things one would like to be able to change even if we have read in an old windsave file.  init_photons reads in
    the numbers of ionization and spectral cycles and then instatiates PhotPtr.  It is possilbe that this should be moved to else where in

--- a/source/python.h
+++ b/source/python.h
@@ -1080,7 +1080,8 @@ typedef struct photon
     P_SEC = 8,                  //Photon hit secondary
     P_ADIABATIC = 9,            //records that a photon created a kpkt which was destroyed by adiabatic cooling
     P_ERROR_MATOM = 10,         //Some kind of error in processing of a photon which excited a macroattom
-    P_LOFREQ_FF = 11            //records a photon that had too low a frequency  
+    P_LOFREQ_FF = 11,           //records a photon that had too low a frequency
+    P_REPOSITION_ERROR = 12     //A photon passed through the disk due to dfudge pushing it through incorrectly
   } istat;                      /*status of photon. */
 
   int nscat;                    /*number of scatterings */
@@ -1122,7 +1123,6 @@ typedef struct photon
   int np;                       /*NSH 13/4/11 - an internal pointer to the photon number so 
                                    so we can write out details of where the photon goes */
   double path;                  /* SWM - Photon path length */
-  int repos;
 }
 p_dummy, *PhotPtr;
 

--- a/source/python.h
+++ b/source/python.h
@@ -1122,6 +1122,7 @@ typedef struct photon
   int np;                       /*NSH 13/4/11 - an internal pointer to the photon number so 
                                    so we can write out details of where the photon goes */
   double path;                  /* SWM - Photon path length */
+  int repos;
 }
 p_dummy, *PhotPtr;
 

--- a/source/reposition.c
+++ b/source/reposition.c
@@ -70,6 +70,14 @@ reposition (PhotPtr p)
  *
  * @details
  *
+ * For resonant scatters, this function will push the photon a distance away
+ * from the location where it previously interacted to assure that the photon
+ * does not interact with the same resonance twice.
+ *
+ * Created in response to issue #584 on the GitHub repository. The purpose of
+ * this function is to calculate the distance to the surface of the accretion
+ * disc and to make it some distance towards the disc instead of dfudge, which
+ * previously pushed the photon through the disc plane accidentally.
  *
  * ************************************************************************** */
 
@@ -79,8 +87,14 @@ reposition_lost_disk_photon (PhotPtr p)
   double smax;
 
   if (p->nres < 0)
-    return;  /* Do nothing for non-resonant scatters */
+    return;                     /* Do nothing for non-resonant scatters */
 
-  smax = -p->x[2] / p->lmn[2] * 0.999;
+  if ((p->grid = where_in_grid (wmain[p->grid].ndom, p->x)) < 0)
+  {
+    Error ("%s:%s(%i): Photon not in grid\n", __FILE__, __func__, __LINE__);
+    return;                     /* Photon was not in wind */
+  }
+
+  smax = -p->x[2] / p->lmn[2] * 0.999;  // Move some distance toward the disc
   move_phot (p, smax);
 }

--- a/source/reposition.c
+++ b/source/reposition.c
@@ -62,7 +62,7 @@ reposition (PhotPtr p)
 /* ************************************************************************* */
 /**
  * @brief           Reposition a photon which was lost due to dfudge pushing
- *                  the photon into the disk or central object
+ *                  the photon into the disk
  *
  * @param[in,out]   PhotPtr   p     The photon to be repositioned
  *

--- a/source/reposition.c
+++ b/source/reposition.c
@@ -78,8 +78,9 @@ reposition_lost_disk_photon (PhotPtr p)
 {
   double smax;
 
-  p->repos = FALSE;
+  if (p->nres < 0)
+    return;  /* Do nothing for non-resonant scatters */
+
   smax = -p->x[2] / p->lmn[2] * 0.999;
-  Log ("%s: smax %e\n", __func__, smax);
   move_phot (p, smax);
 }

--- a/source/reposition.c
+++ b/source/reposition.c
@@ -41,8 +41,7 @@
  **********************************************************/
 
 int
-reposition (p)
-     PhotPtr p;
+reposition (PhotPtr p)
 {
   int n;
 
@@ -55,11 +54,32 @@ reposition (p)
     return (n);                 /* Photon was not in wind */
   }
 
-  /*
-   * EP 0818: the cell specific dfudge is now used as previously the global
-   * value of DFUDGE was being used
-   */
   move_phot (p, wmain[p->grid].dfudge);
 
   return (0);
+}
+
+/* ************************************************************************* */
+/**
+ * @brief           Reposition a photon which was lost due to dfudge pushing
+ *                  the photon into the disk or central object
+ *
+ * @param[in,out]   PhotPtr   p     The photon to be repositioned
+ *
+ * @return          void
+ *
+ * @details
+ *
+ *
+ * ************************************************************************** */
+
+void
+reposition_lost_disk_photon (PhotPtr p)
+{
+  double smax;
+
+  p->repos = FALSE;
+  smax = -p->x[2] / p->lmn[2] * 0.999;
+  Log ("%s: smax %e\n", __func__, smax);
+  move_phot (p, smax);
 }

--- a/source/templates.h
+++ b/source/templates.h
@@ -293,6 +293,7 @@ double dvwind_ds (PhotPtr p);
 int dvds_ave (void);
 /* reposition.c */
 int reposition (PhotPtr p);
+void reposition_lost_disk_photon (PhotPtr p);
 /* anisowind.c */
 int randwind_thermal_trapping (PhotPtr p, int *nnscat);
 /* wind_util.c */
@@ -476,13 +477,13 @@ int photo_gen_matom (PhotPtr p, double weight, int photstart, int nphot);
 int macro_gov (PhotPtr p, int *nres, int matom_or_kpkt, int *which_out);
 int macro_pops (PlasmaPtr xplasma, double xne);
 /* windsave2table_sub.c */
-int do_windsave2table(char *root, int ion_switch);
-int create_master_table(int ndom, char rootname[]);
-int create_heat_table(int ndom, char rootname[]);
-int create_convergence_table(int ndom, char rootname[]);
-int create_ion_table(int ndom, char rootname[], int iz, int ion_switch);
-double *get_ion(int ndom, int element, int istate, int iswitch);
-double *get_one(int ndom, char variable_name[]);
+int do_windsave2table (char *root, int ion_switch);
+int create_master_table (int ndom, char rootname[]);
+int create_heat_table (int ndom, char rootname[]);
+int create_convergence_table (int ndom, char rootname[]);
+int create_ion_table (int ndom, char rootname[], int iz, int ion_switch);
+double *get_ion (int ndom, int element, int istate, int iswitch);
+double *get_one (int ndom, char variable_name[]);
 /* import.c */
 int import_wind (int ndom);
 int import_make_grid (WindPtr w, int ndom);
@@ -634,10 +635,10 @@ void py_wind_help (void);
 void parse_arguments (int argc, char *argv[], char root[], int *ion_switch);
 int main (int argc, char *argv[]);
 /* windsave2table_sub.c */
-int do_windsave2table(char *root, int ion_switch);
-int create_master_table(int ndom, char rootname[]);
-int create_heat_table(int ndom, char rootname[]);
-int create_convergence_table(int ndom, char rootname[]);
-int create_ion_table(int ndom, char rootname[], int iz, int ion_switch);
-double *get_ion(int ndom, int element, int istate, int iswitch);
-double *get_one(int ndom, char variable_name[]);
+int do_windsave2table (char *root, int ion_switch);
+int create_master_table (int ndom, char rootname[]);
+int create_heat_table (int ndom, char rootname[]);
+int create_convergence_table (int ndom, char rootname[]);
+int create_ion_table (int ndom, char rootname[], int iz, int ion_switch);
+double *get_ion (int ndom, int element, int istate, int iswitch);
+double *get_one (int ndom, char variable_name[]);

--- a/source/trans_phot.c
+++ b/source/trans_phot.c
@@ -273,6 +273,7 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
   int kkk, n;
   double weight_min;
   struct photon pp, pextract;
+  struct photon pp_reposition_test;
   int nnscat;
   int nerr;
   double p_norm, tau_norm;
@@ -578,9 +579,7 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
       istat = pp.istat = P_INWIND;
       tau = 0;
 
-      struct photon pp_reposition;
-      stuff_phot (&pp, &pp_reposition);
-
+      stuff_phot (&pp, &pp_reposition_test);
       stuff_v (pp.x, x_dfudge_check);   // this is a vector we use to see if dfudge moved the photon outside the wind cone
       reposition (&pp);
 
@@ -606,8 +605,8 @@ trans_phot_single (WindPtr w, PhotPtr p, int iextract)
 
       if (istat == P_REPOSITION_ERROR)
       {
-        reposition_lost_disk_photon (&pp_reposition);
-        stuff_phot (&pp_reposition, &pp);
+        reposition_lost_disk_photon (&pp_reposition_test);
+        stuff_phot (&pp_reposition_test, &pp);
         istat = walls (&pp, p, normal);
       }
 

--- a/source/xlog.c
+++ b/source/xlog.c
@@ -859,6 +859,8 @@ Exit (int error_code)
     error_code = EXIT_FAILURE;
   }
 
+  Log_flush ();
+
 #ifdef MPI_ON
   Log_parallel ("--------------------------------------------------------------------------\n"
                 "Aborting rank %04i: exiting all processes with error %i\n", my_rank, error_code);


### PR DESCRIPTION
This is the proposed fix for issue #584. Essentially, it treats the photons which are pushed into the disk by dfudge as a special case and deals with them by moving them a more _appropriate_ distance from the last resonance interaction. In principle, it could potentially be extended to help treat photons lost to dfudge as well. Results from the regression test suite look positive as do tests with my TDE models.

I also made a slight change to Exit to flush the logfile as sometimes it was not fully up to date on exiting.