### PR TITLE
Photon banding documentation

### DIFF
--- a/docs/sphinx/source/banding.rst
+++ b/docs/sphinx/source/banding.rst
@@ -1,0 +1,31 @@
+Photon Banding
+##############
+
+Photon packets are emitted from a number of different radiation sources, such as
+the accretion disk or from the wind itself. When a photon is created, it
+is defined by its frequency :math:`\nu` and weight :math:`w`. Photons are 
+generated at the beginning of each cycle and can either be generated uniformly
+over the entire frequency range, or can be generated in pre-defined frequency
+bands, where certain frequency bands are biased to have more photons.
+
+Uniform Samlping
+================
+
+In the most simple case photon packets are generated uniformly over the entire
+frequency range, with equal photon having equal weight. In this uniform scheme, 
+the total weight of all photon packets is equal to the luminosity of the system,
+where each photon packet has weight,
+
+.. math ::
+    w = \frac{\sum_{\text{sources}} \int_{\nu_{\text{min}}}^{\nu_{\text{max}}} L_{\nu}}{N},
+
+where :math:`N` is the total number of photons, :math:`\nu_{\text{min}}` and 
+:math:`\nu_{\text{max}}` define the frequency range and :math:`L_{\nu}` is the
+luminosity for a radiation source. Note that a summation is used to find the
+total luminosity from all radiation sources and that :math:`w` has units
+:math:`\text{ergs s}^{-1}`.
+
+Banded Sampling
+===============
+
+In practise, uniform sampling has a few limiations.

--- a/docs/sphinx/source/banding.rst
+++ b/docs/sphinx/source/banding.rst
@@ -74,8 +74,6 @@ sampling scheme is,
     temperature of hottest radiation source, but is at least 115 Angstroms - 
     twice that of the Helium edge.
 
-.. todo :: more detailed description of the different bands
-
 T_star
 ------
 
@@ -104,8 +102,6 @@ Pre-defined which have been tuned for use with AGN system. In this scheme, there
 are ten bands, with a minimum frequency of :math:`1 \times 10^{14}` Hz and a 
 maximum frequency of :math:`1 \times 10^{20}` Hz.
 
-.. todo :: this band mode just look like uniform banding but with different f1, f2? am I confusing something here?
-
 min_max_freq
 ------------
 
@@ -121,31 +117,40 @@ and each subsequent band must have a larger energy than the previous band. Each
 band also requires a minimum fraction of photons to be sampled from this band,
 where the sum of the fractions for each band must be equal to or less than one.
 
-.. todo :: there are currently no checks to see if nbands > 20 or if the total fraction >= 1
-
 .. admonition :: Maximum Number of Bands
 
-    Currently, a maximum of 20 frequency bands can be defined.
+    Currently, a maximum of 20 frequency bands can be defined. If a user 
+    attemps to specify more than than 20 bands, Python will create an error
+    message and fallback to using 20 bands.
 
 cloudy_test
 -----------
 
-This set of bands were originally created for use in testing against the
-photoionisation and spectral synthesis code Cloudy_.
+This set of bands were created for use in testing against the photoionisation 
+and spectral synthesis code Cloudy_.
 
 .. _Cloudy: https://www.nublado.org
 
 wide
 ----
 
-Pre-defined bands which have very wide frequency ranges. The purpose of this
-band is for testing, hence is best avoided for a working model. 
-
-.. todo :: very similar to uniform banding? but slight bias for smaller frequencies
+Pre-defined bands which have very wide frequency range. The purpose of this
+band is for testing, hence is best to avoid using this band for a working model. 
 
 logarithmic
 -----------
 
 This is the same as ``user_bands``, however the frequency bands are now defined
-in log space. This allows one to better sample a frequency range which spans many
-orders of magnitude.
+in log space. This allows one to better sample a frequency range which spans
+many orders of magnitude. 
+
+.. admonition :: Maximum Number of Bands
+
+    Currently, a maximum of 20 frequency bands can be defined. If a user 
+    attemps to specify more than than 20 bands, Python will create an error
+    message and fallback to using 20 bands.
+
+.. admonition :: Minimum Fraction
+
+    For logarithmic user defined bands, the fraction of each band is set to
+    1 / nbands.

--- a/docs/sphinx/source/banding.rst
+++ b/docs/sphinx/source/banding.rst
@@ -1,5 +1,5 @@
-Photon Banding
-##############
+Photon Banding Strategies
+#########################
 
 Photon packets are emitted from a number of different radiation sources, such as
 the accretion disk or from the wind itself. When a photon is created, it
@@ -8,24 +8,54 @@ generated at the beginning of each cycle and can either be generated uniformly
 over the entire frequency range, or can be generated in pre-defined frequency
 bands, where certain frequency bands are biased to have more photons.
 
-Uniform Samlping
+Uniform Sampling
 ================
 
-In the most simple case photon packets are generated uniformly over the entire
-frequency range, with equal photon having equal weight. In this uniform scheme, 
-the total weight of all photon packets is equal to the luminosity of the system,
-where each photon packet has weight,
+In the most simple case, the frequency of a photon is sampled uniformly over the
+entire frequency range. The total weight of all photons is equal to the 
+luminosity of the system and each photon has weight has equal weight given by,
 
 .. math ::
-    w = \frac{\sum_{\text{sources}} \int_{\nu_{\text{min}}}^{\nu_{\text{max}}} L_{\nu}}{N},
+    w_{i} = \frac{\sum_{i = \text{sources}} ~ \int_{\nu_{\text{min}}}^{\nu_{\text{max}}} L_{\nu, i} d\nu}{N},
 
 where :math:`N` is the total number of photons, :math:`\nu_{\text{min}}` and 
-:math:`\nu_{\text{max}}` define the frequency range and :math:`L_{\nu}` is the
+:math:`\nu_{\text{max}}` define the frequency range and :math:`L_{\nu, i}` is the
 luminosity for a radiation source. Note that a summation is used to find the
-total luminosity from all radiation sources and that :math:`w` has units
+luminosity for each radiation source and that :math:`w` has units of 
 :math:`\text{ergs s}^{-1}`.
 
 Banded Sampling
 ===============
 
-In practise, uniform sampling has a few limiations.
+In practice, uniform sampling is generally an inefficient approach to generating
+photon packets. For example, it is often desirable to produce a sufficient 
+number of photons within a specific frequency range, i.e. around a 
+photoionisation edge. However, if these frequencies lie on the Wien tail of a
+blackbody distribution, it is unlikely that a sufficient number of photons will
+be generated as most of the luminosity is generated at lower frequencies.
+It is possible to get around this problem by generating an increasingly large
+number of photons. But, this is computationally expensive and inefficient.
+
+In order to cope with cases this, Python implements *importance sampling* which
+effectively increases the number of photons which are sampled from specific 
+frequency bands considered important. Photons are now generated with the weight,
+
+.. math ::
+    w_{j} = \frac{\sum_{j = \text{sources}} ~ \int_{\nu_{i}}^{\nu_{i + 1}} L_{\nu, j} ~ d\nu}{f_{i} N},
+
+where, again, this is a summation over all radiation sources. :math:`N` is the
+total number of photons, :math:`f_{i}` is the fraction of photons emerging from
+frequency band :math:`i`, :math:`\nu_{i}` and :math:`nu_{i+1}` are the lower
+and upper frequency boundaries for each frequency band and :math:`L_{\nu, j}` is
+the luminosity of the radiation source. Hence, more photons from frequency bands
+with a larger fraction :math:`f_{i}` will be generated. However, photons from
+*important* bands (where more photons are sampled from) will have reduced 
+weight, whilst photons from the *less important* frequency bands will have
+increased weight. 
+
+This scheme has the benefit of allowing the generation of a lower number of
+photons whilst still sufficiently sampling important frequency ranges, 
+decreasing the computational expense of a simulation.
+
+Implemented Banding Schemes
+===========================

--- a/docs/sphinx/source/banding.rst
+++ b/docs/sphinx/source/banding.rst
@@ -45,7 +45,7 @@ frequency bands considered important. Photons are now generated with the weight,
 
 where, again, this is a summation over all radiation sources. :math:`N` is the
 total number of photons, :math:`f_{i}` is the fraction of photons emerging from
-frequency band :math:`i`, :math:`\nu_{i}` and :math:`nu_{i+1}` are the lower
+frequency band :math:`i`, :math:`\nu_{i}` and :math:`\nu_{i+1}` are the lower
 and upper frequency boundaries for each frequency band and :math:`L_{\nu, j}` is
 the luminosity of the radiation source. Hence, more photons from frequency bands
 with a larger fraction :math:`f_{i}` will be generated. However, photons from
@@ -55,7 +55,97 @@ increased weight.
 
 This scheme has the benefit of allowing the generation of a lower number of
 photons whilst still sufficiently sampling important frequency ranges, 
-decreasing the computational expense of a simulation.
+decreasing the computational expense of a simulation. As such, this is the
+preferred sampling method.
 
-Implemented Banding Schemes
-===========================
+Available Sampling Schemes
+==========================
+
+Python currently implements seven pre-defined frequency bands and and two
+flexible *run time* banding schemes. The parameter used to define the photon
+sampling scheme is,
+
+``Photon_sampling.approach(T_star,cv,yso,AGN,min_max_freq,user_bands,cloudy_test,wide,logarithmic)``
+
+.. admonition :: Minimum and Maximum Wavelengths
+
+    At present, the largest wavelength a photon can be is hardwired to 20,000
+    Angstroms. The smallest wavelength a photon can take is defined by the 
+    temperature of hottest radiation source, but is at least 115 Angstroms - 
+    twice that of the Helium edge.
+
+.. todo :: more detailed description of the different bands
+
+T_star
+------
+
+Create a single frequency band given a temperature T, which is the temperature
+of the hottest radiation source in the model. All photons will then be 
+generated from this single frequency band.
+
+CV
+--
+
+Pre-defined bands which have been tuned for use with CV systems, where a hot
+accretion disk (~100,000 K) is assumed to exist. In this scheme, there are four
+bands where the majority of photons are generated with a wavelength of 912
+Angstroms or less.
+
+YSO
+---
+
+Pre-defined bands which have been tuned for use with YSO systems. In this 
+scheme, there are four bands.
+
+AGN
+---
+
+Pre-defined which have been tuned for use with AGN system. In this scheme, there
+are ten bands, with a minimum frequency of :math:`1 \times 10^{14}` Hz and a 
+maximum frequency of :math:`1 \times 10^{20}` Hz.
+
+.. todo :: this band mode just look like uniform banding but with different f1, f2? am I confusing something here?
+
+min_max_freq
+------------
+
+Create a single band using the minimum and maximum wavelength as described by
+the minimum and maximum wavelengths calculated for the current model.
+
+user_bands
+----------
+
+This allows a user to create their own frequency bands, defined by photon
+energies measured in electron volts. The first band has the lowest photon energy
+and each subsequent band must have a larger energy than the previous band. Each
+band also requires a minimum fraction of photons to be sampled from this band,
+where the sum of the fractions for each band must be equal to or less than one.
+
+.. todo :: there are currently no checks to see if nbands > 20 or if the total fraction >= 1
+
+.. admonition :: Maximum Number of Bands
+
+    Currently, a maximum of 20 frequency bands can be defined.
+
+cloudy_test
+-----------
+
+This set of bands were originally created for use in testing against the
+photoionisation and spectral synthesis code Cloudy_.
+
+.. _Cloudy: https://www.nublado.org
+
+wide
+----
+
+Pre-defined bands which have very wide frequency ranges. The purpose of this
+band is for testing, hence is best avoided for a working model. 
+
+.. todo :: very similar to uniform banding? but slight bias for smaller frequencies
+
+logarithmic
+-----------
+
+This is the same as ``user_bands``, however the frequency bands are now defined
+in log space. This allows one to better sample a frequency range which spans many
+orders of magnitude.

--- a/docs/sphinx/source/output/spectrum_generation_large_optical_depth.rst
+++ b/docs/sphinx/source/output/spectrum_generation_large_optical_depth.rst
@@ -1,8 +1,8 @@
-Spectrum Generation
-###################
+Issues with Generating Spectra
+##############################
 
 With the current machinery to create spectra, it is possible to come across the
-situation where models with large optical depths or wind velocities generate
+situation where models with large optical depth or wind velocities will generate
 spectra with different flux normalisation depending on the wavelength range.
 
 This problem was originally encountered whilst modelling Tidal Disruption Events.
@@ -94,12 +94,7 @@ number of photons were terminated due to too many scatters.
    number of photons in the simulation, but only the number of photons in the current
    process.
 
-
-.. todo::
-
-   Link to wiki entry on information about the spectral files when created
-
-Issue
-=====
+GitHub Issue
+============
 
 The original **GitHub** issue discussing this problem can be found here; :issue:`471`.

--- a/docs/sphinx/source/sv.rst
+++ b/docs/sphinx/source/sv.rst
@@ -1,9 +1,9 @@
 The Shlosman & Vitello prescription of a bi-conical wind
 ########################################################
 
-In the SV93 
-prescription, the wind emerges betwwen :math:`r_{min}` and :math:`r_{rmax}`
-along streamlines whose orientation with respect to the system are descbied an angle
+In the SV93 prescription, the wind emerges between :math:`r_{min}` and 
+:math:`r_{rmax}` along streamlines whose orientation with respect to the system 
+are described an angle
 
 .. math::
     \theta = \theta_{min} + (\theta_{max} - \theta_{min}) x^{\gamma}
@@ -22,26 +22,24 @@ and :math:`r_o` refers to the footpoint of a streamline.
     The geometry of a Shlosman & Vitello wind
     
 
-The poloidal velocity along the streamlies is defined to be
+The poloidal velocity along the streamlines is defined to be
 
 .. math::
-    v_l - v_o + (v_{\ifty}(r_o)-v_o) \frac {(l/R_v)^{\alpha}}{(l/R_v)^{\alpha}+1}
+    v_l - v_o + (v_{\infty}(r_o)-v_o) \frac {(l/R_v)^{\alpha}}{(l/R_v)^{\alpha}+1}
 
 The scale length :math:`R_v` and the exponent :math:`\alpha` control the
 acceleration of the wind between a velocity :math:`v_o`, at the base of the wind 
 and the terminal velocity :math:`v_{\infty}(r_o)`. The initial velocity :math:`v_o`
-can be set to either a constant, normally 6 km/s, or a multiple of the sound-speed at the 
-streamline base. The terminal velocity of each streamline varies
-depending on the location of the streamline in the inner and outer
-disk, being characterized as a fixed multiple of the escape
-velocity at the footpoint of the streamline. Thus the poloidal
-velocity is greatest for stream lines that originate from the
-inner regions of the disk, since the gravitational potential that
+can be set to either a constant, normally 6 km/s, or a multiple of the sound-speed 
+at the streamline base. The terminal velocity of each streamline varies
+depending on the location of the streamline in the inner and outer disk, being
+characterized as a fixed multiple of the escape velocity at the footpoint of the
+streamline. Thus the poloidal velocity is greatest for stream lines that originate 
+from the inner regions of the disk, since the gravitational potential that
 must be overcome is greatest there.
 
-
 The mass loss per unit surface area :math:`\delta \dot{m}/\delta A` of the disk is
-controlled by a parameter $\lambda$ such that
+controlled by a parameter :math:`\lambda` such that
 
 .. math::        
     \frac{\delta\dot{m}}{\delta A} \propto \dot{m}_{wind} r_o^{\lambda} cos(\theta(r_o))
@@ -53,7 +51,7 @@ To use the SV93 prescription, therefore, one must provide the
 basic parameters of the system, the mass of the WD, the accretion
 rate, the inner and outer radius of the disk, and in addition, for
 the wind :math:`\dot{m}_{wind}`, :math:`r_{min}`, :math:`r_{max}`, :math:`\theta_{min}`,
-:math:`\theta_{max}`, :math:`gamma` ,:math:`R_{\nu}`, :math:`\alpha`, :math:`\lambda`, and the
+:math:`\theta_{max}`, :math:`\gamma`, :math:`R_{\nu}`, :math:`\alpha`, :math:`\lambda`, and the
 multiple of the escape velocity to be used for :math:`v_{\infty}`.
 
 

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -1348,11 +1348,11 @@ bl_init (lum_bl, t_bl, freqmin, freqmax, ioniz_or_final, f)
   alphamin = H * freqmin / (BOLTZMANN * t_bl);
   alphamax = H * freqmax / (BOLTZMANN * t_bl);
 //  *f = q1 * integ_planck_d (alphamin, alphamax) * lum_bl / STEFAN_BOLTZMANN;
-  
-  *f =  emittance_bb (freqmin, freqmax, t_bl)*lum_bl/(t_bl*t_bl*t_bl*t_bl*STEFAN_BOLTZMANN);
-  
-  
-  
+
+  *f = emittance_bb (freqmin, freqmax, t_bl) * lum_bl / (t_bl * t_bl * t_bl * t_bl * STEFAN_BOLTZMANN);
+
+
+
   return (lum_bl);
 }
 

--- a/source/python.h
+++ b/source/python.h
@@ -618,6 +618,24 @@ struct geometry
 }
 geo;
 
+/*
+ * EP: 27/09/19
+ * Added enumerator to define different banding modes to make the banding
+ * code more self-documenting
+ */
+
+enum band_definition_enum
+{
+  T_STAR_BAND = 0,
+  MIN_MAX_FREQ_BAND = 1,
+  CV_BAND = 2,
+  YSO_BAND = 3,
+  USER_DEF_BAND = 4,
+  CLOUDY_TEST_BAND = 5,
+  WIDE_BAND = 6,
+  AGN_BAND = 7,
+  LOG_USER_DEF_BAND = 8
+};
 
 /* xdisk is a structure that is used to store information about the disk in a system */
 #define NRINGS	3001            /* The actual number of rings completely defined

--- a/source/spherical.c
+++ b/source/spherical.c
@@ -78,14 +78,14 @@ spherical_ds_in_cell (ndom, p)
 
   smax = ds_to_sphere (zdom[ndom].wind_x[ix], p);
   s = ds_to_sphere (zdom[ndom].wind_x[ix + 1], p);
-  
-  if (smax==VERY_BIG && s==VERY_BIG) 
-	{
-		Error ("spherical: ds_in_cell s and smax returning VERY_BIG in cell %i nudging photon by DFUDGE\n");
-		return(DFUDGE); //Set an error condtion and leave
-	}
-  
-  
+
+  if (smax == VERY_BIG && s == VERY_BIG)
+  {
+    Error ("spherical: ds_in_cell s and smax returning VERY_BIG in cell %i nudging photon by DFUDGE\n");
+    return (DFUDGE);            //Set an error condtion and leave
+  }
+
+
   if (s < smax)
     smax = s;
 


### PR DESCRIPTION
Here is the 1st draft of the photon banding documentation, as well as some math typos to the sv and high optical depth spectrum generation pages. 

I have also touched the banding code a little bit as I found there were some safety checks missing for user defined bands. These were that a user could input more bands than NXBANDS and that they could also specify band min_frac to be > 1 when summed over all bands. I also switched from having `mode == 7` to something like `mode == AGN_BANDS` to help the code be self-documenting. There we no changes between this PR and the current version of dev on the regression tests. 