### PR TITLE
Modified examples files for new data files

### DIFF
--- a/examples/basic/1d_sn.pf
+++ b/examples/basic/1d_sn.pf
@@ -26,7 +26,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard_sn_kurucz
+Atomic_data                                data/standard80_sn_kurucz
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)                 none
 

--- a/examples/basic/cv_standard.pf
+++ b/examples/basic/cv_standard.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/basic/fiducial_agn.pf
+++ b/examples/basic/fiducial_agn.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/basic/star.pf
+++ b/examples/basic/star.pf
@@ -26,7 +26,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/beta/agn_ss_2010_modela.pf
+++ b/examples/beta/agn_ss_2010_modela.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/beta/cv_import.pf
+++ b/examples/beta/cv_import.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          15
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/beta/lamp_post.pf
+++ b/examples/beta/lamp_post.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/beta/ngc5548.pf
+++ b/examples/beta/ngc5548.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/beta/ulx1.pf
+++ b/examples/beta/ulx1.pf
@@ -32,7 +32,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard79
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/extended/cv_macro_benchmark.pf
+++ b/examples/extended/cv_macro_benchmark.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping) macro_atoms_thermal_trapping
-Atomic_data                                data/h20_hetop_standard78
+Atomic_data                                data/h20_hetop_standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/extended/m16_agn.pf
+++ b/examples/extended/m16_agn.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          20.0
 Spectrum_cycles                            5.0
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping) macro_atoms_thermal_trapping
-Atomic_data                                data/h10_hetop_lohe1_standard78
+Atomic_data                                data/h10_hetop_lohe1_standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/extended/sv_detailedmode.pf
+++ b/examples/extended/sv_detailedmode.pf
@@ -36,7 +36,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 @Diag.write_atomicdata(yes,no)                   no
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic

--- a/examples/regress/1d_sn.pf
+++ b/examples/regress/1d_sn.pf
@@ -26,7 +26,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard_sn_kurucz
+Atomic_data                                data/standard80_sn_kurucz
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)                 none
 

--- a/examples/regress/agn_short.pf
+++ b/examples/regress/agn_short.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          3
 Spectrum_cycles                            2
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/cv.pf
+++ b/examples/regress/cv.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/cv_boundary_layer.pf
+++ b/examples/regress/cv_boundary_layer.pf
@@ -37,7 +37,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/cv_kur.pf
+++ b/examples/regress/cv_kur.pf
@@ -36,7 +36,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/cv_reflect.pf
+++ b/examples/regress/cv_reflect.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)              reflect
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/cv_reflect2.pf
+++ b/examples/regress/cv_reflect2.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)    thermalized.rerad
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/rtheta.pf
+++ b/examples/regress/rtheta.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/star.pf
+++ b/examples/regress/star.pf
@@ -26,7 +26,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/regress/two.pf
+++ b/examples/regress/two.pf
@@ -36,7 +36,7 @@ Ionization_cycles                          2
 Spectrum_cycles                            2
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/1d_sn.pf
+++ b/examples/travis/1d_sn.pf
@@ -26,7 +26,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard_sn_kurucz
+Atomic_data                                data/standard80_sn_kurucz
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)                 none
 

--- a/examples/travis/agn_ss_2010_modela.pf
+++ b/examples/travis/agn_ss_2010_modela.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          20
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/cv_macro_benchmark.pf
+++ b/examples/travis/cv_macro_benchmark.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping) macro_atoms_thermal_trapping
-Atomic_data                                data/h20_hetop_standard78
+Atomic_data                                data/h10_hetop_standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/cv_standard.pf
+++ b/examples/travis/cv_standard.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/cv_standard_import.pf
+++ b/examples/travis/cv_standard_import.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          15
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)            matrix_bb
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/fiducial_agn.pf
+++ b/examples/travis/fiducial_agn.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/lamp_post.pf
+++ b/examples/travis/lamp_post.pf
@@ -34,7 +34,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/ngc5548.pf
+++ b/examples/travis/ngc5548.pf
@@ -33,7 +33,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 

--- a/examples/travis/sv_detailedmode.pf
+++ b/examples/travis/sv_detailedmode.pf
@@ -36,7 +36,7 @@ Ionization_cycles                          10
 Spectrum_cycles                            10
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)                 ml93
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)          escape_prob
-Atomic_data                                data/standard78
+Atomic_data                                data/standard80
 @Diag.write_atomicdata(yes,no)                   no
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic

--- a/examples/travis/ulx1.pf
+++ b/examples/travis/ulx1.pf
@@ -32,7 +32,7 @@ Ionization_cycles                          30
 Spectrum_cycles                            20
 Wind.ionization(on.the.spot,ML93,LTE_tr,LTE_te,fixed,matrix_bb,matrix_pow)           matrix_pow
 Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)     thermal_trapping
-Atomic_data                                data/standard79
+Atomic_data                                data/standard80
 Surface.reflection.or.absorption(reflect,absorb,thermalized.rerad)               absorb
 Wind_heating.extra_processes(none,adiabatic,nonthermal,both)            adiabatic
 


### PR DESCRIPTION
Atomic data has been modified to remove old data files and consolidate. This has meant that all the examples files had to change