### PR TITLE
Modifications for issue #644

### DIFF
--- a/source/diag.c
+++ b/source/diag.c
@@ -186,7 +186,7 @@ get_extra_diagnostics ()
   strcpy (answer, "no");
   modes.track_resonant_scatters = rdchoice ("@Diag.track_resonant_scatters(yes,no)", "1,0", answer);
 
-  if (modes.save_cell_stats || modes.save_photons || modes.save_extract_photons | modes.track_resonant_scatters)
+  if (modes.save_cell_stats || modes.save_photons || modes.save_extract_photons || modes.track_resonant_scatters)
   {
     modes.extra_diagnostics = 1;
   }

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -549,15 +549,14 @@ The choice of SMAX_FRAC can affect execution time.*/
        subroutine radiation can be avoided.
      */
 
-
     one = &w[p->grid];
     nplasma = one->nplasma;
     xplasma = &plasmamain[nplasma];
-    xplasma->ntot++;
-
 
     if (geo.ioniz_or_extract == 1)
     {
+      xplasma->ntot++;  // EP 11-19: Moved so only increments during ionisation cycles
+
       /* For an ionization cycle */
       bf_estimators_increment (one, p, ds_current);
 
@@ -568,7 +567,6 @@ The choice of SMAX_FRAC can affect execution time.*/
       xplasma->ave_freq += p->freq * p->w * ds_current;
 
     }
-
   }
   else
   {

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -553,7 +553,6 @@ The choice of SMAX_FRAC can affect execution time.*/
     one = &w[p->grid];
     nplasma = one->nplasma;
     xplasma = &plasmamain[nplasma];
-    xplasma->ntot++;
 
 
     if (geo.ioniz_or_extract == 1)
@@ -567,6 +566,7 @@ The choice of SMAX_FRAC can affect execution time.*/
       /* frequency weighted by the weights and distance in the shell.  See eqn 2 ML93 */
       xplasma->ave_freq += p->freq * p->w * ds_current;
 
+      xplasma->ntot++;
     }
 
   }

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -456,10 +456,6 @@ radiation (p, ds)
       xplasma->heat_auger += z * frac_auger;
       xplasma->heat_tot += z * frac_auger;      //All the inner shell opacities
 
-      /* Calculate the number of H ionizing photons, see #255 */
-      if (freq > (RYD2ERGS / PLANCK))
-        xplasma->nioniz++;
-
       q = (z) / (PLANCK * freq * xplasma->vol);
       /* So xplasma->ioniz for each species is just 
          (energy_abs)*kappa_h/kappa_tot / PLANCK*freq / volume
@@ -948,6 +944,14 @@ update_banded_estimators (xplasma, p, ds, w_ave)
 
   if (HEV * p->freq > 13.6)     // only record if above H ionization edge
   {
+
+    /*
+     * Calculate the number of H ionizing photons, see #255
+     * EP 11-19: moving the number of ionizing photons counter into this
+     * function so it will be incremented for both macro and non-macro modes
+     */
+
+    xplasma->nioniz++;
 
     /* IP needs to be radiation density in the cell. We sum contributions from
        each photon, then it is normalised in wind_update. */

--- a/source/recomb.c
+++ b/source/recomb.c
@@ -1577,13 +1577,10 @@ gs_rrate (nion, T)
  **********************************************************/
 
 int
-sort_and_compress (array_in, array_out, npts)
-     double *array_in, *array_out;
-     int npts;
+sort_and_compress (double *array_in, double *array_out, int npts)
 {
   double *values;
   int n, nfinal;
-  int compare_doubles ();
 
   values = calloc (sizeof (double), npts);
   for (n = 0; n < npts; n++)
@@ -1607,7 +1604,7 @@ sort_and_compress (array_in, array_out, npts)
     }
   }
 
-
+  free (values);
 
   return (nfinal);
 }


### PR DESCRIPTION
This changes where nioniz is incremented so it now works in macro and non-macro modes.

I've also included a few small fixes for other issues I encountered,
- ntot was being incremented incorrectly during spectral cycles in macro atom mode creating streaks when ntot was plotted
- there was (I assume) a typo in the diag files where | was being used instead of ||
- fixed a small memory leak