### PR TITLE
Address issue #663 and #662

### DIFF
--- a/source/parse.c
+++ b/source/parse.c
@@ -57,6 +57,7 @@ parse_command_line (argc, argv)
   int mkdir ();
   double time_max;
   char *fgets_rc;
+  double x;
 
   restart_stat = 0;
 
@@ -116,11 +117,12 @@ parse_command_line (argc, argv)
       }
       else if (strcmp (argv[i], "-e") == 0)
       {
-        if (sscanf (argv[i + 1], "%d", &max_errors) != 1)
+        if (sscanf (argv[i + 1], "%lf", &x) != 1)
         {
           Error ("python: Expected max errors after -e switch\n");
           exit (1);
         }
+        max_errors = x;
         Log_quit_after_n_errors (max_errors);
         i++;
         j = i;
@@ -129,11 +131,12 @@ parse_command_line (argc, argv)
       }
       else if (strcmp (argv[i], "-e_write") == 0)
       {
-        if (sscanf (argv[i + 1], "%d", &max_errors) != 1)
+        if (sscanf (argv[i + 1], "%lf", &x) != 1)
         {
           Error ("python: Expected max errors after -e switch\n");
           exit (1);
         }
+        max_errors = x;
         Log_print_max (max_errors);
         i++;
         j = i;
@@ -143,7 +146,7 @@ parse_command_line (argc, argv)
       else if (strcmp (argv[i], "-d") == 0)
       {
         modes.iadvanced = 1;
-        Log ("Enabling advanced/diagnositic inputs (@ commands)\n");
+        Log ("Enabling advanced/diagnostic inputs (@ commands)\n");
         j = i;
       }
       else if (strcmp (argv[i], "-f") == 0)

--- a/source/python.h
+++ b/source/python.h
@@ -459,7 +459,6 @@ struct geometry
 
   int scatter_mode;             /*The way in which scattering for resonance lines is treated 
                                    0  isotropic
-                                   1  anisotropic
                                    2  thermally broadened anisotropic
                                  */
 

--- a/source/setup_line_transfer.c
+++ b/source/setup_line_transfer.c
@@ -19,7 +19,8 @@
 
 /**********************************************************/
 /** 
- * @brief       Get the line transfer mode for the wind
+ * @brief       Get the line transfer mode for the wind and 
+ * several other variables related to line transfer
  *
  * @param [in] None
  * @return  0 
@@ -27,15 +28,16 @@
  * This rontinues simply gets the line tranfer mode for
  * all componensts of the wind.  After logging this
  * information, the routine also reads in the atomic 
- * data.
+ * data, and the variable that establishes in the 
+ * non-macro mode whether the wind is allowed to radiate
  *
  *
  * ###Notes###
- * 1801 -   Refactored into this file in 1801.  It is
- *          not obvioous this is the best place for this
- *          routine since it refers to all components
- *          of the wind.
-
+ * 
+ * Rather than having inputs for several aspects of line transfer
+ * the choices with regard to line_transfer_mode are used to
+ * define several variables, geo.rt_mode, geo.line_mode, and geo.scatter_mode.
+ * within the routine.  
 ***********************************************************/
 
 
@@ -55,8 +57,9 @@ get_line_transfer_mode ()
 
   strcpy (answer, "thermal_trapping");
   user_line_mode =
-    rdchoice ("Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms,macro_atoms_thermal_trapping)",
-              "0,1,2,3,5,6,7", answer);
+    rdchoice
+    ("Line_transfer(pure_abs,pure_scat,sing_scat,escape_prob,thermal_trapping,macro_atoms_escape_prob,macro_atoms_thermal_trapping)",
+     "0,1,2,3,5,6,7", answer);
 
   /* JM 1406 -- geo.rt_mode and geo.macro_simple control different things. geo.rt_mode controls the radiative
      transfer and whether or not you are going to use the indivisible packet constraint, so you can have all simple 


### PR DESCRIPTION
Modified parse.c so that it could accept a floating point number for the number of errors before quitting,
and changed the name of the line transfer mode macro_atoms to macro_atoms_escape so that it is distinct
from macro_atoms_thermal_trapping (on minimum match)