### PR TITLE
GSL memory leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_C_COMPILER mpicc)
 add_definitions(-D MPI_ON)
 
 # Include the source
-include_directories(inc)
+include_directories(include)
 link_directories(lib)
 
 # Define the executables

--- a/source/recipes.c
+++ b/source/recipes.c
@@ -14,7 +14,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <math.h>
 #include <time.h>
 #include <gsl/gsl_integration.h>
@@ -22,7 +21,6 @@
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_roots.h>
 #include <gsl/gsl_min.h>
-#include <gsl/gsl_errno.h>
 
 #include "atomic.h"
 #include "python.h"
@@ -33,6 +31,7 @@
 /******************************
  * The next two routines were written by ksl.  They were not part of
    the recipes programs which I had but I think they are what was intended
+   TODO EP: I think these to functions are redundant now - we don't seem to use them
 ********************************/
 
 double *
@@ -205,6 +204,8 @@ zero_find (func, x_lo, x_hi, tol)
 
   result = (x_lo + x_hi) / 2.0;
 
+  gsl_root_fsolver_free (s);
+
   return (result);
 }
 
@@ -279,6 +280,8 @@ func_minimiser (a, m, b, func, tol, xmin)
   }
   while (status == GSL_CONTINUE && iter < max_iter);
   *xmin = m;
+
+  gsl_min_fminimizer_free (s);
 
   return func (m, test);
 }


### PR DESCRIPTION
Free'ing GSL alloc'd memory which was not previously free'd - in response to issue #675, though I'm not 100% sure yet if this resolves the problem.

Regression tests are reasonable looking and no crashes.