### PR TITLE
Change rmax setting to 1st guard cell rather than 2nd

### DIFF
--- a/source/import_spherical.c
+++ b/source/import_spherical.c
@@ -178,7 +178,7 @@ spherical_make_grid_import (w, ndom)
 
   zdom[ndom].wind_rho_min = zdom[ndom].rho_min = 0;
   zdom[ndom].rmin = imported_model[ndom].r[0];
-  zdom[ndom].wind_rho_max = zdom[ndom].zmax = zdom[ndom].rho_max = zdom[ndom].rmax = imported_model[ndom].r[imported_model[ndom].ncell - 1];
+  zdom[ndom].wind_rho_max = zdom[ndom].zmax = zdom[ndom].rho_max = zdom[ndom].rmax = imported_model[ndom].r[imported_model[ndom].ncell - 2];
   zdom[ndom].wind_thetamin = zdom[ndom].wind_thetamax = 0.;
 
   for (j = 0; j < imported_model[ndom].ncell; j++)


### PR DESCRIPTION
This should be the change to stop 1D models from crashing. The problem was that zdom[ndom].rmax was being set incorrectly, so photons were able to go into the final cell which had inwind < 0, but radmax had a value larger than the radial coordinate of this cell. This created a bit of confusion and a lot of errors being thrown.

I haven't changed the behavior of Python reading in Wind.radmax as mentioned in Issue #686 , as it turned out to be more complex than a quick fix. It looks like some internal checks require the maximum wind radius to be set to something, but for imported models we do not set the maximum wind radius before these internal checks.

Edit
The regression checks seemed to be fine...