### PR TITLE
Clean up of ion_abundances() and saha()

### DIFF
--- a/source/ionization.c
+++ b/source/ionization.c
@@ -31,6 +31,9 @@
  *
  * ### Notes ###
  *
+ * EP 15 Jun 2020: It appears to me that this function can only ever return 0
+ * as the functions called in here only return 0.
+ *
  **********************************************************/
 
 int
@@ -41,9 +44,8 @@ ion_abundances (PlasmaPtr xplasma, int mode)
 
   if (mode == IONMODE_ML93_FIXTE)
   {
-/* on-the-spot approximation using existing t_e.   This routine does not attempt
-to match heating and cooling in the wind element! */
-
+    /* on-the-spot approximation using existing t_e.   This routine does not attempt
+    to match heating and cooling in the wind element! */
     if ((ireturn = nebular_concentrations (xplasma, NEBULARMODE_ML93)))
     {
       Error ("ionization_abundances: nebular_concentrations failed to converge\n");
@@ -52,12 +54,12 @@ to match heating and cooling in the wind element! */
   }
   else if (mode == IONMODE_LTE_TR)
   {
-/* LTE using t_r */
+    /* LTE using t_r */
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TR);
   }
   else if (mode == IONMODE_LTE_TE)
   {
-/* LTE using t_e */
+    /* LTE using t_e */
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TE);
   }
   else if (mode == IONMODE_FIXED)
@@ -65,82 +67,32 @@ to match heating and cooling in the wind element! */
 
     ireturn = fix_concentrations (xplasma, 0);
   }
-  else if (mode == IONMODE_ML93)
+  else if (mode == IONMODE_ML93 || mode == IONMODE_MATRIX_BB)
   {
-/* On the spot, with one_shot at updating t_e before calculating densities */
+    /* On the spot, with one_shot at updating t_e before calculating densities */
 
-/* Shift values to old */
     xplasma->dt_e_old = xplasma->dt_e;
     xplasma->dt_e = xplasma->t_e - xplasma->t_e_old;
     xplasma->t_e_old = xplasma->t_e;
-    //OLD xplasma->t_r_old = xplasma->t_r;
     xplasma->lum_tot_old = xplasma->lum_tot;
     xplasma->heat_tot_old = xplasma->heat_tot;
-
     ireturn = one_shot (xplasma, mode);
 
-/* Convergence check */
     convergence (xplasma);
   }
-  else if (mode == IONMODE_MATRIX_BB)
+  else if (mode == IONMODE_MATRIX_SPECTRALMODEL || mode == IONMODE_MATRIX_ESTIMATORS)
   {
-    /* New abundances have been computed using matrix scheme with dilute blackbody model for J_nu
-       We can now attempt to balance heating and cooling with the new abundance in the
-       same way as mode 3. */
-
-/* Shift values to old */
-    xplasma->dt_e_old = xplasma->dt_e;
-    xplasma->dt_e = xplasma->t_e - xplasma->t_e_old;
-    xplasma->t_e_old = xplasma->t_e;
-    //OLD xplasma->t_r_old = xplasma->t_r;
-    xplasma->lum_tot_old = xplasma->lum_tot;
-    xplasma->heat_tot_old = xplasma->heat_tot;
-
-    ireturn = one_shot (xplasma, mode);
-
-/* Convergence check */
-    convergence (xplasma);
-  }
-  else if (IONMODE_MATRIX_SPECTRALMODEL)
-  {
-
 /*  spectral_estimators does the work of getting banded W and alpha. Then oneshot gets called. */
 
-    ireturn = spectral_estimators (xplasma);
+    spectral_estimators (xplasma);
 
     xplasma->dt_e_old = xplasma->dt_e;
     xplasma->dt_e = xplasma->t_e - xplasma->t_e_old;
     xplasma->t_e_old = xplasma->t_e;
-    //OLD xplasma->t_r_old = xplasma->t_r;
     xplasma->lum_tot_old = xplasma->lum_tot;
     xplasma->heat_tot_old = xplasma->heat_tot;
-
-
     ireturn = one_shot (xplasma, mode);
 
-
-/* Convergence check */
-    convergence (xplasma);
-  }
-  else if (IONMODE_MATRIX_ESTIMATORS)
-  {
-
-/*  spectral_estimators does the work of getting banded W and alpha. Then oneshot gets called. */
-
-    ireturn = spectral_estimators (xplasma);
-
-    xplasma->dt_e_old = xplasma->dt_e;
-    xplasma->dt_e = xplasma->t_e - xplasma->t_e_old;
-    xplasma->t_e_old = xplasma->t_e;
-    //OLD xplasma->t_r_old = xplasma->t_r;
-    xplasma->lum_tot_old = xplasma->lum_tot;
-    xplasma->heat_tot_old = xplasma->heat_tot;
-
-
-    ireturn = one_shot (xplasma, mode);
-
-
-/* Convergence check */
     convergence (xplasma);
   }
   else
@@ -155,10 +107,10 @@ to match heating and cooling in the wind element! */
      ions so that the ionization balance of the other ions is not
      affected in an important way. */
 
-//  if (geo.auger_ionization == 1)
-//    {
-//      auger_ionization (xplasma);
-//    }
+//OLD    if (geo.auger_ionization == 1)
+//OLD    {
+//OLD      auger_ionization (xplasma);
+//OLD    }
 
 
   return (ireturn);

--- a/source/saha.c
+++ b/source/saha.c
@@ -50,22 +50,22 @@ nebular_concentrations (xplasma, mode)
 {
   int m;
 
+  // LTE all the way -- uses tr or te for partition functions depending on nebular mode
   if (mode == NEBULARMODE_TR || mode == NEBULARMODE_TE)
-  {                             // LTE all the way -- uses tr
-                                //LTE but uses temperature te
+  {
     partition_functions (xplasma, mode);
     m = concentrations (xplasma, mode);
   }
   else if (mode == NEBULARMODE_ML93)    // This is the standard LM method
   {
-    partition_functions (xplasma, mode);        // calculate partition functions, using t_r with weights
+    partition_functions (xplasma, mode);        // calculate partition functions, using t_r with weights (dilute blackbody W)
 
     /* JM 1308 -- concentrations then populates xplasma with saha abundances. 
        in macro atom mode it also call macro_pops, which is done incorrectly, 
        the escape probabilities are calculated with saha ion densities each time,
        because saha() repopulates xplasma in each cycle. */
 
-    concentrations (xplasma, NEBULARMODE_TR);       // Saha equation using t_r
+    concentrations (xplasma, NEBULARMODE_TR);   // Saha equation using t_r
 
     /* JM 1308 -- lucy then applies the lucy mazzali correction factors to the saha abundances. 
        in macro atom mode it also call macro_pops which is done correctly in this case, as lucy_mazzali, 
@@ -73,12 +73,13 @@ nebular_concentrations (xplasma, mode)
        it doesn't actually matter that concentrations does macro level populations wrong, as that is 
        corrected here. It should be sorted very soon, however. */
 
-    m = lucy (xplasma);         // Main routine for running LucyMazzali
+    m = lucy (xplasma);         // Main routine for running Lucy Mazzali
   }
   else if (mode == NEBULARMODE_MATRIX_BB || mode == NEBULARMODE_MATRIX_SPECTRALMODEL || mode == NEBULARMODE_MATRIX_ESTIMATORS)
   {
-    /* Use rate matrices based on pairwise bb approxmaitions
-     * to the spectra
+    /*
+     * Use rate matrices based on pairwise bb approximations (matrix_bb) or
+     * power law approximations for the SED in a cell (matrix_est, matrix_pow)
      */
 
     m = matrix_ion_populations (xplasma, mode);
@@ -87,7 +88,7 @@ nebular_concentrations (xplasma, mode)
   {
     Error ("nebular_concentrations: Unknown mode %d\n", mode);
     Exit (EXIT_FAILURE);
-    return (EXIT_FAILURE);
+    return (EXIT_FAILURE);      // avoids compiler warnings about return being uninitialized
   }
 
 

--- a/source/saha.c
+++ b/source/saha.c
@@ -48,30 +48,16 @@ nebular_concentrations (xplasma, mode)
      PlasmaPtr xplasma;
      int mode;
 {
-  double get_ne ();
-  int lucy_mazzali1 ();
   int m;
 
-  if (mode == NEBULARMODE_TR)
+  if (mode == NEBULARMODE_TR || mode == NEBULARMODE_TE)
   {                             // LTE all the way -- uses tr
-
+                                //LTE but uses temperature te
     partition_functions (xplasma, mode);
-
     m = concentrations (xplasma, mode);
-
-  }
-  else if (mode == NEBULARMODE_TE)
-  {                             //LTE but uses temperature te
-
-    partition_functions (xplasma, mode);
-
-    m = concentrations (xplasma, mode);
-
   }
   else if (mode == NEBULARMODE_ML93)    // This is the standard LM method
   {
-
-
     partition_functions (xplasma, mode);        // calculate partition functions, using t_r with weights
 
     /* JM 1308 -- concentrations then populates xplasma with saha abundances. 
@@ -79,7 +65,7 @@ nebular_concentrations (xplasma, mode)
        the escape probabilities are calculated with saha ion densities each time,
        because saha() repopulates xplasma in each cycle. */
 
-    m = concentrations (xplasma, NEBULARMODE_TR);       // Saha equation using t_r
+    concentrations (xplasma, NEBULARMODE_TR);       // Saha equation using t_r
 
     /* JM 1308 -- lucy then applies the lucy mazzali correction factors to the saha abundances. 
        in macro atom mode it also call macro_pops which is done correctly in this case, as lucy_mazzali, 
@@ -88,9 +74,8 @@ nebular_concentrations (xplasma, mode)
        corrected here. It should be sorted very soon, however. */
 
     m = lucy (xplasma);         // Main routine for running LucyMazzali
-
   }
-  else if (mode == NEBULARMODE_MATRIX_BB)
+  else if (mode == NEBULARMODE_MATRIX_BB || mode == NEBULARMODE_MATRIX_SPECTRALMODEL || mode == NEBULARMODE_MATRIX_ESTIMATORS)
   {
     /* Use rate matrices based on pairwise bb approxmaitions
      * to the spectra
@@ -98,31 +83,11 @@ nebular_concentrations (xplasma, mode)
 
     m = matrix_ion_populations (xplasma, mode);
   }
-
-  else if (mode == NEBULARMODE_MATRIX_SPECTRALMODEL)
-  {
-
-    /* Use rate natrices based on powr law approximations to
-     * the spectra
-     */
-
-    m = matrix_ion_populations (xplasma, mode);
-  }
-
-  else if (mode == NEBULARMODE_MATRIX_ESTIMATORS)
-  {
-
-    /* Use rate natrices based on powr law approximations to
-     * the spectra
-     */
-
-    m = matrix_ion_populations (xplasma, mode);
-  }
   else
   {
     Error ("nebular_concentrations: Unknown mode %d\n", mode);
-    Exit (0);
-    return (0);
+    Exit (EXIT_FAILURE);
+    return (EXIT_FAILURE);
   }
 
 

--- a/source/spectral_estimators.c
+++ b/source/spectral_estimators.c
@@ -40,7 +40,7 @@ double lspec_numin, lspec_numax;
  * in variables, such as spec_mod_type, pl_alpah, pl_log,exp_temp, etc.
  *
  * ### Notes ###
- * ??? NOTES ???
+ * TODO this function only returns 0, the documentation claims otherwise however
  *
  **********************************************************/
 


### PR DESCRIPTION
Whilst figuring out the difference between matrix_est and matrix_pow, I ended up in ion_abundances(). The function was one big if statement, and because of a couple of typos, the matrix_est branch of the if statement was unreachable. Fortunately, the matrix_est and matrix_pow branches were identical in the if statement, so nothing bad happened from that mistake.

I've fixed up the if statement to remove duplicate code, which, I think so at least, makes the function easier to read and understand -- as well as all branches are reachable now. I've also done the same for saha(), which had duplicate branches.

Comparing regression tests from this PR and the last dev commit showed no changes.