### PR TITLE
Modify wind

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -313,7 +313,7 @@ modify_wind:  $(modify_wind_objects)
 
 # The next line runs recompiles all of the routines after first cleaning the directory
 # all: clean run_indent python windsave2table py_wind
-all: clean python windsave2table py_wind indent rad_hydro_files
+all: clean python windsave2table py_wind indent rad_hydro_files modify_wind
 
 
 FILE = get_atomicdata.o atomic.o

--- a/source/Makefile
+++ b/source/Makefile
@@ -288,7 +288,7 @@ rad_hydro_files: $(rhf_objects)
 
 
 
-modify_wind_objects = modify_wind.o windsave.o \
+modify_wind_objects = modify_wind.o windsave.o  windsave2table_sub.o\
 		emission.o recomb.o wind_util.o  \
 		cdf.o random.o recipes.o saha.o \
 		stellar_wind.o homologous.o sv.o hydro_import.o corona.o knigge.o  disk.o\

--- a/source/Makefile
+++ b/source/Makefile
@@ -288,6 +288,29 @@ rad_hydro_files: $(rhf_objects)
 
 
 
+modify_wind_objects = modify_wind.o windsave.o \
+		emission.o recomb.o wind_util.o  \
+		cdf.o random.o recipes.o saha.o \
+		stellar_wind.o homologous.o sv.o hydro_import.o corona.o knigge.o  disk.o\
+		lines.o vvector.o wind2d.o wind.o  ionization.o  py_wind_write.o levels.o \
+		radiation.o gradv.o phot_util.o anisowind.o resonate.o density.o \
+		matom.o estimators.o photon2d.o cylindrical.o rtheta.o spherical.o \
+		import.o import_spherical.o import_cylindrical.o import_rtheta.o  \
+		cylind_var.o bilinear.o gridwind.o py_wind_macro.o partition.o \
+		spectral_estimators.o shell_wind.o compton.o zeta.o dielectronic.o \
+		bb.o rdpar.o rdpar_init.o xlog.o direct_ion.o diag.o matrix_ion.o \
+		pi_rates.o photo_gen_matom.o macro_gov.o reverb.o paths.o time.o synonyms.o \
+		cooling.o import_calloc.o walls.o charge_exchange.o frame.o \
+		get_atomicdata.o
+
+
+modify_wind:  $(modify_wind_objects)
+	$(CC) $(CFLAGS) $(modify_wind_objects) $(LDFLAGS)  -o modify_wind               
+	cp $@ $(BIN)                                                               
+	mv $@ $(BIN)/modify_wind$(VERSION)                                         
+	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi         
+
+
 # The next line runs recompiles all of the routines after first cleaning the directory
 # all: clean run_indent python windsave2table py_wind
 all: clean python windsave2table py_wind indent rad_hydro_files

--- a/source/import.c
+++ b/source/import.c
@@ -58,6 +58,17 @@ import_wind (ndom)
 
   rdstr ("Wind.model2import", filename);
 
+  import_wind2 (ndom, filename);
+
+  return (0);
+}
+
+int
+import_wind2 (ndom, filename)
+     int ndom;
+     char *filename;
+{
+
   calloc_import (zdom[ndom].coord_type, ndom);
 
   if (zdom[ndom].coord_type == SPHERICAL)
@@ -82,8 +93,6 @@ import_wind (ndom)
 
   return (0);
 }
-
-
 
 
 /**********************************************************/

--- a/source/import_spherical.c
+++ b/source/import_spherical.c
@@ -88,7 +88,6 @@ import_1d (ndom, filename)
   while (fgets (line, LINELENGTH, fptr) != NULL)
   {
     n = sscanf (line, " %d %le %le %le %le %le", &icell, &r, &v_r, &mass_rho, &t_e, &t_r);
-
     if (n < READ_NO_TEMP_1D)
     {
       continue;

--- a/source/modify_wind.c
+++ b/source/modify_wind.c
@@ -1,0 +1,146 @@
+
+/***********************************************************/
+/** @file  modify_wind.c
+ * @author ksl
+ * @date   June, 2020     
+ *
+ * @brief  Routines to modfify a wind structure to for example
+ * change densities of certain ions
+ *
+ ***********************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "atomic.h"
+#include "python.h"
+
+
+char outroot[LINELENGTH];
+
+
+/**********************************************************/
+/** 
+ * @brief      parses the command line options
+ *
+ * @param [in]  int  argc   the number of command line arguments
+ * @param [in]  char *  argv[]   The command line arguments
+ * @return      restart_stat   1 if restarting a previous model,
+ * 0 in all other cases.
+ *
+ * Python has a fairly rich set of command line options, which
+ * are parsed by this routine
+ *
+ * The routine also creates the diag folder, which is where most
+ * of the log files are written 
+ *
+ * ###Notes###
+ *
+ * The general purpose of each of the command line options
+ * should be fairly obvious from reading the code.
+ *
+ * If changes to the command line interface are made they should
+ * be described in the routine help 
+ *
+ * Although this routine uses the standard Log and Error commands
+ * the diag files have not been created yet and so this information
+ * is really simply written to the terminal.  
+ *
+ **********************************************************/
+
+int
+xparse_command_line (argc, argv)
+     int argc;
+     char *argv[];
+{
+  int restart_stat, verbosity, max_errors, i;
+  int j = 0;
+  char dummy[LINELENGTH];
+  int mkdir ();
+  double time_max;
+  char *fgets_rc;
+  double x;
+
+  restart_stat = 0;
+
+  if (argc == 1)
+  {
+    printf ("Parameter file name (e.g. my_model.pf, or just my_model):");
+    fgets_rc = fgets (dummy, LINELENGTH, stdin);
+    if (!fgets_rc)
+    {
+      printf ("Input rootname is NULL or invalid\n");
+      exit (1);
+    }
+    get_root (files.root, dummy);
+    strcpy (files.diag, files.root);
+    strcat (files.diag, ".diag");
+  }
+  else
+  {
+
+    for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "-out_root") == 0)
+      {
+        if (sscanf (argv[i + 1], "%s", outroot) != 1)
+        {
+          printf ("python: Expected out_root after -out_root switch\n");
+          exit (0);
+        }
+        i++;
+        j = i;
+
+      }
+      else if (strcmp (argv[i], "--dry-run") == 0)
+      {
+        modes.quit_after_inputs = 1;
+        j = i;
+      }
+
+      else if (strncmp (argv[i], "-", 1) == 0)
+      {
+        printf ("python: Unknown switch %s\n", argv[i]);
+        exit (0);
+      }
+    }
+
+    /* The last command line variable is always the windsave file */
+
+    if (j + 1 == argc)
+    {
+      printf ("All of the command line has been consumed without specifying a parameter file name, so exiting\n");
+      exit (1);
+    }
+
+
+    strcpy (dummy, argv[argc - 1]);
+    get_root (files.root, dummy);
+
+  }
+
+  return (0);
+}
+
+
+
+int
+main (argc, argv)
+     int argc;
+     char *argv[];
+{
+
+    xparse_command_line (argc, argv);
+
+    wind_read("star.wind_save");
+
+    wind_save("foo.wind_save");
+
+
+    printf("gotcha %s\n",files.root);
+
+
+
+}

--- a/source/modify_wind.c
+++ b/source/modify_wind.c
@@ -36,7 +36,7 @@
 
 
 char inroot[LINELENGTH], outroot[LINELENGTH], model_file[LINELENGTH];
-int model_flag;
+int model_flag, ksl_flag;
 
 /**********************************************************/
 /**
@@ -71,9 +71,8 @@ xparse_command_line (argc, argv)
 
 
   sprintf (outroot, "%s", "new");
-  printf ("BOOM argc=%i\n", argc);
 
-  model_flag = 0;
+  model_flag = ksl_flag = 0;
 
   if (argc == 1)
   {
@@ -116,6 +115,11 @@ xparse_command_line (argc, argv)
         j = i;
         printf ("got a model file %s\n", model_file);
         model_flag = 1;
+      }
+      else if (strcmp (argv[i], "-ksl") == 0)
+      {
+        printf ("Carrying out a simple hard wired ion modification\n");
+        ksl_flag = 1;
       }
       else if (strcmp (argv[i], "--dry-run") == 0)
       {
@@ -180,6 +184,7 @@ main (argc, argv)
   int put_ion ();
   int apply_model ();
   int ndom;
+  int i;
 
   ndom = 0;
 
@@ -198,27 +203,27 @@ main (argc, argv)
   {
     apply_model (ndom, model_file);
   }
+  if (ksl_flag)
+  {
+    den = get_ion (0, 1, 1, 1, name);
 
+    /* Having gotten the densities, modify them */
 
-//  den = get_ion (0, 1, 1, 1, name);
+    printf ("%d\n", zdom[0].ndim2);
 
-  /* Having gotten the densities, modify them */
+    for (i = 0; i < zdom[0].ndim2; i++)
+    {
+      printf ("%e\n", den[i]);
+      den[i] *= 1e-6;
+    }
 
-//  printf ("%d\n", zdom[0].ndim2);
-
-
-//  for (i = 0; i < zdom[0].ndim2; i++)
-//  {
-//    printf ("%e\n", den[i]);
-//    den[i] *= 1e-6;
-//  }
-
-  /* Now paint the densities into the appropriatle
-     places in the plasma structure
-   */
-
-
-//  put_ion (0, 1, 1, den);
+    /* Now paint the densities into the appropriatle
+       places in the plasma structure
+     */
+    put_ion (0, 1, 1, den);
+  }
+  
+  
   printf ("outputting to %s\n", outfile);
 
 

--- a/source/modify_wind.c
+++ b/source/modify_wind.c
@@ -7,6 +7,20 @@
  * @brief  Routines to modfify a wind structure to for example
  * change densities of certain ions
  *
+ *###Notes###
+ * At present this is just a prototype of a more general 
+ * purpose routine to paint sections of a windsavefile
+ * with new values.  At present the code just supports
+ * changing densities, although it would be fairly 
+ * straighfoward to extend to propeties like T_e
+ *
+ * At present the changes have to be hardcoded into 
+ * main, and the program lacks an interface to for
+ * example files of the tupe produced by windsave2table
+ * 
+ * The intent is to make the structure of this program
+ * like the inverse of windsave2table.
+ *
  ***********************************************************/
 
 #include <stdio.h>
@@ -27,22 +41,13 @@ char inroot[LINELENGTH], outroot[LINELENGTH];
  *
  * @param [in]  int  argc   the number of command line arguments
  * @param [in]  char *  argv[]   The command line arguments
- * @return      restart_stat   1 if restarting a previous model,
- * 0 in all other cases.
  *
- * Python has a fairly rich set of command line options, which
- * are parsed by this routine
- *
- * The routine also creates the diag folder, which is where most
- * of the log files are written
  *
  * ###Notes###
  *
  * The general purpose of each of the command line options
  * should be fairly obvious from reading the code.
  *
- * If changes to the command line interface are made they should
- * be described in the routine help
  *
  * Although this routine uses the standard Log and Error commands
  * the diag files have not been created yet and so this information
@@ -123,6 +128,28 @@ xparse_command_line (argc, argv)
 
 
 
+/**********************************************************/
+/**
+ * @brief      the main routine which carries out the effort
+ *
+ * @param [in]  int  argc   the number of command line arguments
+ * @param [in]  char *  argv[]   The command line arguments
+ *
+ *
+ * ###Notes###
+ *
+ * This routine oversees the effort.  The basic steps are
+ *
+ * - parse the command line to get the names of files
+ * - read the old windsave file
+ * - read the densities from in this case H
+ * - modify the densities
+ * - write out the new windsave file
+ *
+ *
+ **********************************************************/
+
+
 int
 main (argc, argv)
      int argc;
@@ -148,6 +175,8 @@ main (argc, argv)
 
   den = get_ion (0, 1, 1, 1, name);
 
+  /* Having gotten the densities, modify them */
+
   printf ("%d\n", zdom[0].ndim2);
 
 
@@ -156,6 +185,10 @@ main (argc, argv)
     printf ("%e\n", den[i]);
     den[i] *= 1e-6;
   }
+
+  /* Now paint the densities into the appropriatle
+     places in the plasma structure
+   */
 
 
   put_ion (0, 1, 1, den);
@@ -170,6 +203,22 @@ main (argc, argv)
   exit (0);
 
 }
+
+
+/**********************************************************/
+/**
+ * @brief      update a specific ion with new densities
+ *
+ * @param [in]  int ndom   the domain number
+ * @param [in]  int element the element(z) for which 
+ * @param [in]  int istate  the ion number
+ * @param [in]  double den  an array with the new densities
+ *
+ *
+ * ###Notes###
+ *
+ *
+ **********************************************************/
 
 int
 put_ion (ndom, element, istate, den)

--- a/source/modify_wind.c
+++ b/source/modify_wind.c
@@ -175,9 +175,8 @@ main (argc, argv)
   double *den;
   char name[LINELENGTH];        /* file name extension */
   char infile[LINELENGTH], outfile[LINELENGTH];
-  int i;
   int put_ion ();
-  int ndim, mdim;
+  int apply_model ();
   int ndom;
 
   ndom = 0;
@@ -195,44 +194,30 @@ main (argc, argv)
 
   if (model_flag)
   {
-    printf ("We have been given a model file - we will be using this for new densities in domain 0\n");
-    ndim = zdom[ndom].ndim;
-    mdim = zdom[ndom].mdim;
-    printf ("Current dimensions are %i %i\n", ndim, mdim);
-    import_wind2 (ndom, model_file);
-    printf ("Model dimensions are %i %i\n", imported_model[ndom].ndim, imported_model[ndom].mdim);
-    if (ndim == imported_model[ndom].ndim && mdim == imported_model[ndom].mdim)
-    {
-      printf ("THe model dimensions match the current file - proceeding\n");
-    }
-    else
-    {
-      printf ("The model doesnt match the current windsave aborting\n");
-      exit (0);
-    }
+    apply_model (ndom, model_file);
   }
 
 
-  den = get_ion (0, 1, 1, 1, name);
+//  den = get_ion (0, 1, 1, 1, name);
 
   /* Having gotten the densities, modify them */
 
-  printf ("%d\n", zdom[0].ndim2);
+//  printf ("%d\n", zdom[0].ndim2);
 
 
-  for (i = 0; i < zdom[0].ndim2; i++)
-  {
-    printf ("%e\n", den[i]);
-    den[i] *= 1e-6;
-  }
+//  for (i = 0; i < zdom[0].ndim2; i++)
+//  {
+//    printf ("%e\n", den[i]);
+//    den[i] *= 1e-6;
+//  }
 
   /* Now paint the densities into the appropriatle
      places in the plasma structure
    */
 
 
-  put_ion (0, 1, 1, den);
-
+//  put_ion (0, 1, 1, den);
+  printf ("outputting to %s\n", outfile);
 
 
   wind_save (outfile);
@@ -274,7 +259,7 @@ put_ion (ndom, element, istate, den)
 
   for (i = 0; i < zdom[0].ndim2; i++)
   {
-    printf ("%e\n", den[i]);
+//    printf ("%e\n", den[i]);
   }
   nstart = zdom[ndom].nstart;
   ndim2 = zdom[ndom].ndim2;
@@ -297,4 +282,55 @@ put_ion (ndom, element, istate, den)
 
   return (0);
 
+}
+
+
+int
+apply_model (ndom, filename)
+     int ndom;
+     char *filename;
+{
+  int ndim, mdim;
+  int nstart, n, nion, nplasma;
+
+  printf ("We have been given a model file - we will be using this for new densities in domain 0\n");
+  ndim = zdom[ndom].ndim;
+  mdim = zdom[ndom].mdim;
+  printf ("Current dimensions are %i %i\n", ndim, mdim);
+  import_wind2 (ndom, model_file);
+  printf ("Model dimensions are %i %i\n", imported_model[ndom].ndim, imported_model[ndom].mdim);
+  if (ndim == imported_model[ndom].ndim && mdim == imported_model[ndom].mdim)
+  {
+    printf ("The model dimensions match the current file - proceeding\n");
+    if (zdom[ndom].coord_type == SPHERICAL)
+    {
+      printf ("We have a spherical model\n");
+      nstart = zdom[ndom].nstart;
+      for (n = 0; n < ndim; n++)
+      {
+        wmain[n].v[0] = imported_model[ndom].v_r[n];    //we need a value for v_r for all cells including ghosts
+        if (wmain[n].inwind > -1)
+        {
+          for (nion = 0; nion < nions; nion++)  //Change the absolute number densities, fractions remain the same
+          {
+            nplasma = wmain[n].nplasma;
+            plasmamain[nplasma].density[nion] =
+              plasmamain[nplasma].density[nion] * (imported_model[ndom].mass_rho[n] / plasmamain[nplasma].rho);
+          }
+          plasmamain[nplasma].rho = imported_model[ndom].mass_rho[n];
+          if (imported_model[ndom].init_temperature == FALSE)
+          {
+            plasmamain[nplasma].t_e = imported_model[ndom].t_e[n];
+            plasmamain[nplasma].t_r = imported_model[ndom].t_r[n];
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    printf ("The model doesnt match the current windsave aborting\n");
+    exit (0);
+  }
+  return (0);
 }

--- a/source/modify_wind.c
+++ b/source/modify_wind.c
@@ -21,6 +21,8 @@
  * The intent is to make the structure of this program
  * like the inverse of windsave2table.
  *
+ * The initial commit that KSL write is 1485d5f6669704dde55e437f5c0cb061ec202653
+ *
  ***********************************************************/
 
 #include <stdio.h>

--- a/source/templates.h
+++ b/source/templates.h
@@ -482,6 +482,7 @@ double *get_ion(int ndom, int element, int istate, int iswitch, char *name);
 double *get_one(int ndom, char variable_name[]);
 /* import.c */
 int import_wind(int ndom);
+int import_wind2(int ndom, char *filename);
 int import_set_wind_boundaries(int ndom);
 int import_make_grid(WindPtr w, int ndom);
 double import_velocity(int ndom, double *x, double *v);


### PR DESCRIPTION
Add in the new modify_wind code. This is in early stages of development - intended to allow users to modify a wind_save file to modify ion densities, or densities etc in a wind save mid-run. 

Current has a -model mode where a model file is used to overwrite the densities, velocities and temperatures in a 1D model keeping the ionization state intact, and also a -ksl mode which out of the box reduces the H1 density by a factor of 1e6. 