### PR TITLE
proposed change to distinguish between energies and luminosities for wind photon generation

### DIFF
--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -110,7 +110,7 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     {                           // The reinitialization is required
       xdefine_phot (f1, f2, ioniz_or_final, iwind, PRINT_ON);
     }
-    /* The weight of each photon is designed so that all of the photons add up to the
+    /* The weight of each photon is designed §so that all of the photons add up to the
        luminosity of the photosphere.  This implies that photons must be generated in such
        a way that it mimics the energy distribution of the star. */
 
@@ -388,10 +388,13 @@ iwind = -1 	Don't generate any wind photons at all
     geo.f_wind = geo.lum_wind = 0.0;
 
   if (iwind == 1 || (iwind == 0))
-  {                             /* Then find the luminosity and flux of the wind */
-    geo.lum_wind = wind_luminosity (0.0, VERY_BIG);
+  {
+    /* Then find the luminosity of the wind, and the energy emerging in the simulation time step */
+    /* XFRAME -- the latter includes a factor of dt_cmf = 1.0 / gamma in each wind cell so is 
+       called with a different mode */
+    geo.lum_wind = wind_luminosity (0.0, VERY_BIG, MODE_LUMINOSITY);
     xxxpdfwind = 1;             // Turn on the portion of the line luminosity routine which creates pdfs
-    geo.f_wind = wind_luminosity (f1, f2);
+    geo.f_wind = wind_luminosity (f1, f2, MODE_ENERGY);
     xxxpdfwind = 0;             // Turn off the portion of the line luminosity routine which creates pdfs
   }
 

--- a/source/py_wind_sub.c
+++ b/source/py_wind_sub.c
@@ -2988,7 +2988,7 @@ heatcool_summary (w, rootname, ochoice)
   char filename[LINELENGTH];
   float x;
 
-  x = wind_luminosity (0.0, VERY_BIG);
+  x = wind_luminosity (0.0, VERY_BIG, MODE_LUMINOSITY);
 
   for (n = 0; n < NDIM2; n++)
   {

--- a/source/python.h
+++ b/source/python.h
@@ -1135,7 +1135,9 @@ int size_Jbar_est, size_gamma_est, size_alpha_est;
 #define NEBULARMODE_MATRIX_SPECTRALMODEL 9      // matrix solver spectral model
 #define NEBULARMODE_MATRIX_ESTIMATORS 10        // matrix solver spectral model
 
-
+// modes for the wind_luminosity routine 
+#define MODE_ENERGY 0
+#define MODE_LUMINOSITY 1
 
 typedef struct photon
 {

--- a/source/rad_hydro_files.c
+++ b/source/rad_hydro_files.c
@@ -199,8 +199,8 @@ main (argc, argv)
 
 
   cool_sum = wind_cooling ();   /*We call wind_cooling here to obtain an up to date set of cooling rates */
-  lum_sum = wind_luminosity (0.0, VERY_BIG);    /*and we also call wind_luminosity to get the luminosities */
-
+  lum_sum = wind_luminosity (0.0, VERY_BIG, MODE_LUMINOSITY);   /*and we also call wind_luminosity to get the luminosities */
+  /* XFRAME -- need to check this is what is required here (luminosity rather than energy) */
 
   fptr = fopen ("py_heatcool.dat", "w");
   fptr2 = fopen ("py_driving.dat", "w");

--- a/source/templates.h
+++ b/source/templates.h
@@ -230,7 +230,7 @@ double one_continuum(int spectype, double t, double g, double freqmin, double fr
 double emittance_continuum(int spectype, double freqmin, double freqmax, double t, double g);
 double model_int(double lambda, void *params);
 /* emission.c */
-double wind_luminosity(double f1, double f2);
+double wind_luminosity(double f1, double f2, int mode);
 double total_emission(WindPtr one, double f1, double f2);
 int photo_gen_wind(PhotPtr p, double weight, double freqmin, double freqmax, int photstart, int nphot);
 double one_line(WindPtr one, int *nres);

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -620,10 +620,10 @@ WindPtr (w);
 
   /* Check the balance between the absorbed and the emitted flux */
 
-  //NSH 0717 - first we need to ensure the cooling and luminosities reflect the current temperature
+  /* NSH 0717 - ensure the cooling and luminosities reflect the current temperature */
 
-  cool_sum = wind_cooling ();   /*We call wind_cooling here to obtain an up to date set of cooling rates */
-  lum_sum = wind_luminosity (0.0, VERY_BIG);    /*and we also call wind_luminosity to get the luminosities */
+  cool_sum = wind_cooling ();   /* We call wind_cooling here to obtain an up to date set of cooling rates */
+  lum_sum = wind_luminosity (0.0, VERY_BIG, MODE_LUMINOSITY);   /* and we also call wind_luminosity to get the luminosities */
 
 
 
@@ -838,10 +838,10 @@ WindPtr (w);
      lum_sum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
 
 
-  rad_sum = wind_luminosity (xband.f1[0], xband.f2[xband.nbands - 1]);  /*and we also call wind_luminosity to get the luminosities */
+  rad_sum = wind_luminosity (xband.f1[0], xband.f2[xband.nbands - 1], MODE_LUMINOSITY); /*and we also call wind_luminosity to get the luminosities */
 
   Log
-    ("!!wind_update: Rad  luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
+    ("!!wind_update: Rad luminosity  %8.2e (recomb %8.2e ff %8.2e lines %8.2e) after update\n",
      rad_sum, geo.lum_rr, geo.lum_ff, geo.lum_lines);
 
   Log


### PR DESCRIPTION
This is a proposed change regarding emissivities. Specifically:
* make things like geo.f_tot to be CMF energy = CMF luminosity * delta_t_cmf
* keep the lum_ fields as co-moving luminosity

Otherwise I think we end up overwriting lum_ fields with different quantities in the luminosity and cooling routines, and also we are a bit inconsistent with our approach to other rates. 

actual changes:
* revert to old behaviour in the wind_luminosity routine (i.e. remove the Gammas so the lums are emissivity * CMF volume with no time correction)
* ensure that all fields like geo.f_wind have a gamma converting them to using Delta_t_obs (i.e., they are an energy used to generate photons)
* add a gamma in the wind photon generation routine where we use a lum_ field to work out which cell the photon comes from
* this requires one to be able to call wind_luminosity with two modes, some where the luminosities calculated as energies (luminosity * dt_cmf) for photon generation and others where luminosities are really CMF luminosities. 
* In **all** cases, the quantities in geo and xplasma always refer to CMF luminosities, sometimes summed over cells (and so not in one specific frame). 

I believe this approach will mean minimum confusion in terms of what the fields containing without needing a ton of gamma factors all over the place. It will also mean that fields containing luminosities really are CMF luminosities, although the summed quantities will be a little odd - but they would also be a little odd if they were CMF energy/observer time.