### PR TITLE
Fix incorrect index for wmain array in xtemp_rad

### DIFF
--- a/source/wind_sum.c
+++ b/source/wind_sum.c
@@ -223,7 +223,7 @@ xtemp_rad (w)
       {
         n = nstart + i * mdim + j;
         nplasma = w[n].nplasma;
-        if (wmain[nplasma].inwind >= 0)
+        if (wmain[n].inwind >= 0)
         {
           ntot = plasmamain[nplasma].ntot;
         }


### PR DESCRIPTION
I found a small error in the ntot map diagnostics thing. Basically almost all of the cells had -99 photon passages, meaning those cells weren't classified as wind cells. Thankfully not a bug with CMF, but just seemed to be a small mistake using the wrong index to index into wmain - as nplasma was being used. This should fix it and I do not believe there are any underlying bugs elsewhere which caused this. I'm creating a temporary branch to merge this into dev to let travis check before I make any changes.