### PR TITLE
Bug792 clang

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -20,6 +20,21 @@ EXTRA_FLAGS =
 LDFLAGS =
 
 
+# COMPILER_VERSION := $(shell expr `gcc -dumpversion`)
+ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+	XVERSION := $(shell cc -v 2>&1 | head -1 )
+	COMPILER_VERSION := $(shell $(CC) -v 2>&1 | head -1 )
+else
+	COMPILER_VERSION := $(shell expr `gcc -dumpversion`)
+	XVERSION:= $(shell expr `gcc -dumpversion`)
+endif
+
+
+# @echo 'Gotcha=' $(XVERSION)
+
+# COMPILER_PRINT_STRING = Compiling with mpicc wrapper, for compiler $(COMPILER_VERSION)
+# @echo  $(COMPILER_PRINT_STRING)
+
 # Check a load of compiler options
 # This is mostly to address GitHub issues #100
 ifeq (mpicc, $(CC))
@@ -29,7 +44,7 @@ ifeq (mpicc, $(CC))
 	# check what underlying compiler mpi is using, and the version
 	# we'll use this to print to the user and also to do some checks
 	MPI_COMPILER := $(shell mpicc --showme:command)
-	COMPILER_VERSION := $(shell expr `'$(CC)' -dumpversion`)
+	# COMPILER_VERSION := $(shell expr `'$(CC)' -dumpversion`)
 	COMPILER_PRINT_STRING = Compiling with mpicc wrapper, for compiler $(MPI_COMPILER) $(COMPILER_VERSION)
 
 	# if it's gcc we want to check if the version is 4.8 or later
@@ -48,7 +63,7 @@ else ifeq (gcc, $(CC))
 
 	# check the version
 	# we'll use this to print to the user and also to do some checks
-	COMPILER_VERSION := $(shell expr `gcc -dumpversion`)
+	# COMPILER_VERSION := $(shell expr `gcc -dumpversion`)
 
 	# if it's gcc we want to check if the version is 4.8 or later
 	# if it is then we'll disable aggressive loop optimizations, see #100
@@ -62,7 +77,7 @@ else	# you must be using clang or icc
 	MPI_FLAG =
 
 	# check the version we'll use this to print to the user
-	COMPILER_VERSION = $(shell expr `$(CC) -dumpversion`)
+	# COMPILER_VERSION = $(shell expr `$(CC) -dumpversion`)
 	COMPILER_PRINT_STRING = Compiling with $(CC) $(COMPILER_VERSION)
 endif
 
@@ -84,6 +99,11 @@ ifeq (D,$(firstword $(MAKECMDGOALS)))
 	FFLAGS = -g -pg
 	PRINT_VAR = DEBUGGING, -g -pg -Wall flags
         XDEBUG = True
+	ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+		CFLAGS = -g -Wall $(EXTRA_FLAGS) -I$(INCLUDE)  $(MPI_FLAG)
+		FFLAGS = -g 
+		PRINT_VAR = DEBUGGING, -g -Wall flags
+	endif
 else
 # Use this for large runs
 	CFLAGS = -O3 -Wall $(EXTRA_FLAGS) -I$(INCLUDE)  $(MPI_FLAG)
@@ -112,6 +132,9 @@ startup:
 	echo "#define VERSION " \"$(VERSION)\" > version.h
 	echo "#define GIT_COMMIT_HASH" \"$(GIT_COMMIT_HASH)\" >> version.h
 	echo "#define GIT_DIFF_STATUS" $(GIT_DIFF_STATUS)\ >> version.h
+	@echo 'Gotcha Sports Fans'
+	echo 'Compiler  $(XVERSION)'
+
 
 # indent:
 # 	@echo $(INDENT_STRING)

--- a/source/Makefile
+++ b/source/Makefile
@@ -127,12 +127,12 @@ INDENT = yes
 
 startup:
 	@echo $(COMPILER_PRINT_STRING)			# prints out compiler information
+	@echo 'Compiler is really  $(XVERSION)'
 	@echo 'YOU ARE COMPILING FOR' $(PRINT_VAR)	# tells user if compiling for optimized or debug
 	@echo 'MPI_FLAG=' $(MPI_FLAG)
 	echo "#define VERSION " \"$(VERSION)\" > version.h
 	echo "#define GIT_COMMIT_HASH" \"$(GIT_COMMIT_HASH)\" >> version.h
 	echo "#define GIT_DIFF_STATUS" $(GIT_DIFF_STATUS)\ >> version.h
-	@echo 'Compiler is really  $(XVERSION)'
 
 
 # indent:

--- a/source/Makefile
+++ b/source/Makefile
@@ -26,7 +26,7 @@ ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
 	COMPILER_VERSION := $(shell $(CC) -v 2>&1 | head -1 )
 else
 	COMPILER_VERSION := $(shell expr `gcc -dumpversion`)
-	XVERSION:= $(shell expr `gcc -dumpversion`)
+	XVERSION:= gcc $(shell expr `gcc -dumpversion`)
 endif
 
 
@@ -132,8 +132,7 @@ startup:
 	echo "#define VERSION " \"$(VERSION)\" > version.h
 	echo "#define GIT_COMMIT_HASH" \"$(GIT_COMMIT_HASH)\" >> version.h
 	echo "#define GIT_DIFF_STATUS" $(GIT_DIFF_STATUS)\ >> version.h
-	@echo 'Gotcha Sports Fans'
-	echo 'Compiler  $(XVERSION)'
+	@echo 'Compiler is really  $(XVERSION)'
 
 
 # indent:


### PR DESCRIPTION
These are changes to the Makefile

* They remove the -gprof switch when compiling in debug mode on clang, which is not supported.

* They print out information when make is run to allow the user to see whether on a mac, one is actually compiling with clang and not gcc, even though the it may appear that it is using gcc.  (This happens because of the way aliases are typically set up on a (ksl's) mac