### PR TITLE
Adding program to calculate optical depth spectrum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ cmake_minimum_required(VERSION 3.0)
 
 # Set the Python version
 
-set(PYTHON_VERSION 84g)
+set(PYTHON_VERSION 85c)
 message(STATUS "Python version : ${PYTHON_VERSION}")
 
 # The C standard is being set to 99, although if we follow this standard is
@@ -34,7 +34,7 @@ message(STATUS "Python version : ${PYTHON_VERSION}")
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_COMPILER mpicc)
-add_definitions(-Wall -Wextra -O3 -D MPI_ON)
+add_definitions(-Wall -Wextra -D MPI_ON)
 
 # Setup any include directories, as well as any library directories. This is
 # used to link the GSL directories
@@ -80,7 +80,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     file(WRITE ${VERSION_FILE} "#define VERSION \"${PYTHON_VERSION}\"\n\
 #define GIT_COMMIT_HASH \"${GIT_HASH}\"\n\
 #define GIT_DIFF_STATUS \"${GIT_NUM_CHANGES}\"\n"
-     )
+            )
 endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
 # Define the source for the various different programs contained with the
@@ -115,21 +115,25 @@ set(PYTHON_SOURCE
         source/trans_phot.c source/vvector.c source/walls.c source/wind.c
         source/wind2d.c source/wind_sum.c source/wind_updates2d.c
         source/wind_util.c source/windsave.c source/windsave2table_sub.c
-        source/xlog.c source/xtest.c source/zeta.c
-)
+        source/xlog.c source/xtest.c source/zeta.c source/macro_accelerate.c
+        )
 
 set(PY_WIND_SOURCE
         source/py_wind_ion.c source/py_wind_macro.c
         source/py_wind_sub.c source/py_wind_write.c
-)
+        )
 
 set(WINDSAVE2TABLE_SOURCE
         source/windsave2table_sub.c
-)
+        )
 
 set(RAD_HYDRO_SOURCE
         source/rad_hydro_files.c
-)
+        )
+
+set(OPTICAL_DEPTH_SOURCE
+        source/py_optical_depth.c source/py_optical_depth_sub.c
+        )
 
 # Create the executables for each program, and link the required libraries
 
@@ -144,6 +148,10 @@ target_link_libraries(windsave2table gsl gslcblas m)
 # Rad_hydro_files
 add_executable(rad_hydro_files ${PYTHON_SOURCE} ${RAD_HYDRO_SOURCE})
 target_link_libraries(rad_hydro_files gsl gslcblas m)
+
+# py_optical_depth
+add_executable(py_optical_depth ${PYTHON_SOURCE} ${OPTICAL_DEPTH_SOURCE})
+target_link_libraries(py_optical_depth gsl gslcblas m)
 
 # Python
 add_executable(python source/python.c ${PYTHON_SOURCE})

--- a/source/Makefile
+++ b/source/Makefile
@@ -336,10 +336,35 @@ modify_wind:  $(modify_wind_objects)
 	mv $@ $(BIN)/modify_wind$(VERSION)                                         
 	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi         
 
+py_optical_depth_objects = py_optical_depth.o py_optical_depth_sub.o \
+		bb.o atomicdata.o atomicdata_init.o atomicdata_sub.o photon2d.o photon_gen.o parse.o setup_files.o \
+		saha.o spectra.o wind2d.o wind.o  vvector.o recipes.o \
+		trans_phot.o phot_util.o resonate.o radiation.o estimators_simple.o\
+		wind_updates2d.o windsave.o extract.o cdf.o roche.o random.o \
+		stellar_wind.o homologous.o hydro_import.o corona.o knigge.o  disk.o\
+		lines.o  continuum.o get_models.o emission.o cooling.o recomb.o diag.o \
+		sv.o ionization.o  levels.o gradv.o reposition.o \
+		anisowind.o wind_util.o density.o  bands.o time.o \
+		matom.o estimators_macro.o wind_sum.o cylindrical.o rtheta.o spherical.o  \
+		cylind_var.o bilinear.o gridwind.o partition.o signal.o  \
+		agn.o shell_wind.o compton.o zeta.o dielectronic.o \
+		spectral_estimators.o matom_diag.o disk_init.o \
+		xlog.o rdpar.o direct_ion.o pi_rates.o matrix_ion.o para_update.o \
+		setup_star_bh.o setup_domains.o setup_disk.o photo_gen_matom.o macro_gov.o windsave2table_sub.o \
+		import.o import_spherical.o import_cylindrical.o import_rtheta.o  \
+		reverb.o paths.o setup.o run.o brem.o synonyms.o walls.o xtest.o \
+		setup_reverb.o setup_line_transfer.o rdpar_init.o cv.o import_calloc.o charge_exchange.o frame.o \
+		macro_accelerate.o
+
+py_optical_depth: startup $(py_optical_depth_objects)
+	$(CC) $(CFLAGS) $(py_optical_depth_objects) $(LDFLAGS)  -o py_optical_depth
+	cp $@ $(BIN)
+	mv $@ $(BIN)/py_optical_depth$(VERSION)
+	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi
 
 # The next line runs recompiles all of the routines after first cleaning the directory
 # all: clean run_indent python windsave2table py_wind
-all: clean python windsave2table py_wind indent rad_hydro_files modify_wind
+all: clean python windsave2table py_wind indent rad_hydro_files modify_wind py_optical_depth
 
 
 FILE = atomicdata.o atomicdata_init.o atomicdata_sub.o atomic.o

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -437,6 +437,7 @@ translate_in_wind (w, p, tau_scat, tau, nres)
   int ndom, ndom_current;
   int inwind;
   int hit_disk;
+  double kappa_tot;
 
   WindPtr one;
   PlasmaPtr xplasma;
@@ -469,6 +470,97 @@ return and record an error */
 
 /* Calculate the maximum distance the photon can travel in the cell */
 
+  smax = smax_in_cell (p);
+
+  /* We now determine whether scattering prevents the photon from reaching the far edge of
+     the cell.  calculate_ds calculates whether there are scatterings and makes use of the
+     current position of the photon and the position of the photon at the far edge of the
+     shell.  It needs a "trial photon at the maximum distance however...
+     Note that ds_current does not alter p in any way */
+
+  ds_current = calculate_ds (w, p, tau_scat, tau, nres, smax, &istat);
+
+  if (p->nres < 0)
+    xplasma->nscat_es++;
+  if (p->nres > 0)
+    xplasma->nscat_res++;
+
+
+
+/* We now increment the radiation field in the cell, translate the photon and wrap
+   things up.  For simple atoms, the routine radiation also reduces
+   the weight of the photon due to continuum absorption, e.g. free free.
+   */
+
+
+  if (geo.rt_mode == RT_MODE_MACRO)
+  {
+    /* In the macro-method, b-f and other continuum processes do not reduce the photon
+       weight, but are treated as as scattering processes.  Therefore most of what was in
+       subroutine radiation for the simple atom case can be avoided.  
+     */
+    if (geo.ioniz_or_extract == CYCLE_IONIZ)
+    {
+      /* Provide inputs to bf_estimators in the local frame  */
+      stuff_phot (p, &phot_mid);
+      move_phot (&phot_mid, 0.5 * ds_current);
+      observer_to_local_frame (&phot_mid, &phot_mid_cmf);
+      ds_cmf = observer_to_local_frame_ds (&phot_mid, ds_current);
+      bf_estimators_increment (&w[p->grid], &phot_mid_cmf, ds_cmf);
+    }
+  }
+  else
+  {
+    radiation (p, ds_current, &kappa_tot);
+  }
+
+  move_phot (p, ds_current);
+
+  p->nres = (*nres);
+
+  return (p->istat = istat);
+
+
+}
+
+
+
+
+/* ************************************************************************* */
+/**
+ * @brief           Calculate the maximum distance a photon can travel in its
+ *                  current cell.
+ *
+ * @param[in]       PhotPtr   p       The currently transported photon packet
+ *
+ * @return          double    smax    The maximum distance the photon packet
+ *                                    can move
+ *
+ * @details
+ *
+ * smax can be found in various ways depending on if the photon is in the wind
+ * or not.
+ *
+ * This section of code was put into its own function in an attempt to avoid
+ * code duplication for the optical depth diagnostic ray tracing thing.
+ *
+ * ************************************************************************** */
+
+double
+smax_in_cell (PhotPtr p)
+{
+  int n, ndom, ndom_current;
+  double s, smax;
+  int hit_disk;
+
+  WindPtr one;
+
+  n = p->grid;
+  one = &wmain[n];              /* one is the grid cell where the photon is */
+  ndom = one->ndom;
+
+  /* Calculate the maximum distance the photon can travel in the cell */
+
   if ((smax = ds_in_cell (ndom, p)) < 0)
   {
     return ((int) smax);
@@ -499,84 +591,22 @@ return and record an error */
 
   }
 
-//OLD  if (modes.save_photons)
-//OLD  {
-//OLD    Diag ("smax  %10.3e tau_scat %10.3e tau %10.3e\n", smax, tau_scat, *tau);
-//OLD  }
-
-
-/* At this point we now know how far the photon can travel in it's current grid cell */
+  /* At this point we now know how far the photon can travel in it's current grid cell */
 
   smax += one->dfudge;          /* dfudge is to force the photon through the cell boundaries. */
 
-/* Set limits the distance a photon can travel.  There are
-a good many photons which travel more than this distance without this
-limitation, at least in the standard 30 x 30 instantiation.  It does
-make small differences in the structure of lines in some cases.
-The choice of SMAX_FRAC can affect execution time.*/
+  /* Set limits the distance a photon can travel.  There are
+     a good many photons which travel more than this distance without this
+     limitation, at least in the standard 30 x 30 instantiation.  It does
+     make small differences in the structure of lines in some cases.
+     The choice of SMAX_FRAC can affect execution time. */
 
   if (smax > SMAX_FRAC * length (p->x))
   {
     smax = SMAX_FRAC * length (p->x);
   }
 
-  /* We now determine whether scattering prevents the photon from reaching the far edge of
-     the cell.  calculate_ds calculates whether there are scatterings and makes use of the
-     current position of the photon and the position of the photon at the far edge of the
-     shell.  It needs a "trial photon at the maximum distance however */
-
-
-/* Note that ds_current does not alter p in any way */
-
-  ds_current = calculate_ds (w, p, tau_scat, tau, nres, smax, &istat);
-
-  if (p->nres < 0)
-    xplasma->nscat_es++;
-  if (p->nres > 0)
-    xplasma->nscat_res++;
-
-
-
-/* We now increment the radiation field in the cell, translate the photon and wrap
-   things up.  For simple atoms, the routine radiation also reduces
-   the weight of the photon due to continuum absorption, e.g. free free.
-   */
-
-
-  if (geo.rt_mode == RT_MODE_MACRO)
-  {
-    /* In the macro-method, b-f and other continuum processes do not reduce the photon
-       weight, but are treated as as scattering processes.  Therefore most of what was in
-       subroutine radiation for the simple atom case can be avoided.  
-     */
-
-    one = &w[p->grid];
-    nplasma = one->nplasma;
-    xplasma = &plasmamain[nplasma];
-
-    /* Provide inputs to bf_estimators in the local frame  */
-    stuff_phot (p, &phot_mid);
-    move_phot (&phot_mid, 0.5 * ds_current);
-    observer_to_local_frame (&phot_mid, &phot_mid_cmf);
-    ds_cmf = observer_to_local_frame_ds (&phot_mid, ds_current);
-
-    if (geo.ioniz_or_extract == CYCLE_IONIZ)
-    {
-      bf_estimators_increment (one, &phot_mid_cmf, ds_cmf);
-    }
-  }
-  else
-  {
-    radiation (p, ds_current);
-  }
-
-  move_phot (p, ds_current);
-
-  p->nres = (*nres);
-
-  return (p->istat = istat);
-
-
+  return smax;
 }
 
 

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -511,7 +511,7 @@ return and record an error */
   }
   else
   {
-    radiation (p, ds_current, &kappa_tot);
+    radiation (p, ds_current);
   }
 
   move_phot (p, ds_current);

--- a/source/py_optical_depth.c
+++ b/source/py_optical_depth.c
@@ -1,0 +1,241 @@
+/** ************************************************************************* */
+/**
+ * @file  py_optical_depth.c
+ * @author  Edward Parkinson
+ * @date  February 2021
+ *
+ * @brief  File containing the main functions defining the program.
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "atomic.h"
+#include "python.h"
+#include "py_optical_depth.h"
+
+/* ************************************************************************* */
+/**
+ * @brief  Help text for the program.
+ *
+ * ************************************************************************** */
+
+void
+print_help (void)
+{
+  char *help = "Create optical depth diagnostics for a Python simulation.\n\n"
+    "usage: py_optical_depth [-h] [-cion nion] [-classic] [--version] root\n"
+    "\n"
+    "-h           Print this help message and exit\n"
+    "-cion nion   Extract the column density for an ion of number nion\n"
+    "-classic     Use linear frequency transforms. Use when Python run in classic mode.\n"
+    "--version    Print the version information and exit.\n";
+  printf ("%s", help);
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Parse run time arguments provided at the command line.
+ *
+ * @param[in]  argc  The number of arguments provided
+ * @param[in]  argv  The command line arguments
+ *
+ * @details
+ *
+ * Reads the command line arguments. Assumes the final argument is the root name
+ * of the model. If no arguments are provided, then the program will run in a
+ * default mode and query the user for the root name of the simulation.
+ *
+ * ************************************************************************** */
+
+void
+get_arguments (int argc, char *argv[])
+{
+  int n_read;
+  char input[LINELENGTH];
+
+  /*
+   * If no command line arguments are provided, then use fgets to query the
+   * root name from the user and return
+   */
+
+  if (argc == 1)
+  {
+    printf ("Please input the model root name: ");
+    if (fgets (input, LINELENGTH, stdin) == NULL)
+    {
+      printf ("Unable to parse root name\n");
+      exit (EXIT_FAILURE);
+    }
+    get_root (files.root, input);
+    return;
+  }
+
+  /*
+   * Otherwise, iterate over the command line arguments and initialize various
+   * variables
+   */
+
+  n_read = 0;
+  for (int i = 1; i < argc; ++i)
+  {
+    if (!strcmp (argv[i], "-h"))
+    {
+      print_help ();
+      exit (EXIT_SUCCESS);
+    }
+    else if (!strcmp (argv[i], "-classic"))
+    {
+      rel_mode = REL_MODE_LINEAR;
+      n_read = i;
+    }
+    else if (!strcmp (argv[i], "--version"))
+    {
+      printf ("Python version %s\n", VERSION);
+      printf ("Built from git commit %s\n", GIT_COMMIT_HASH);
+      if (GIT_DIFF_STATUS)
+        printf ("This version was compiled with %d files with uncommited changes\n", GIT_DIFF_STATUS);
+      exit (EXIT_SUCCESS);
+    }
+    else if (!strcmp (argv[i], "-cion"))
+    {
+      char *check;
+      COLUMN_MODE = COLUMN_MODE_ION;
+      COLUMN_MODE_ION_NUMBER = (int) strtol (argv[i + 1], &check, 10);
+      if (*check != '\0')
+      {
+        printf ("Unable to convert argument provided for -cion into an integer\n");
+        exit (EXIT_FAILURE);
+      }
+      if (COLUMN_MODE_ION_NUMBER < 0)
+      {
+        printf ("Argument for -cion cannot be negative\n");
+        exit (EXIT_FAILURE);
+      }
+      i++;
+      n_read = i;
+    }
+    else if (!strncmp (argv[i], "-", 1))
+    {
+      printf ("Unknown argument %s\n", argv[i]);
+      print_help ();
+      exit (EXIT_FAILURE);
+    }
+  }
+
+  if (n_read + 1 == argc)
+  {
+    printf ("All command line arguments have been consumed without specifying a root name\n");
+    exit (EXIT_FAILURE);
+  }
+
+  get_root (files.root, argv[argc - 1]);
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  The main function of the program.
+ *
+ * @param  argc  The number of command line arguments
+ * @param  argv  The command line arguments
+ *
+ * @return  EXIT_SUCCESS
+ *
+ * @details
+ *
+ * ************************************************************************** */
+
+int
+main (int argc, char *argv[])
+{
+  char windsave_filename[LINELENGTH + 24];
+  char specsave_filename[LINELENGTH + 24];
+  void do_optical_depth_diagnostics (void);
+
+  timer ();
+
+  /*
+   * Initialize global variables which are required for photon
+   * transport and general program operation
+   */
+
+  Log_set_verbosity (0);
+  init_rand (time (NULL));
+  rel_mode = REL_MODE_FULL;     // this is updated in get_arguments if required
+  SMAX_FRAC = 0.5;
+  DENSITY_PHOT_MIN = 1.e-10;
+  COLUMN_MODE = COLUMN_MODE_RHO;
+  N_INCLINATION_ANGLES = 0;
+
+  get_arguments (argc, argv);
+  printf ("%-20s Optical depth diagnostics beginning\n", "TAU");
+  strcpy (windsave_filename, files.root);
+  strcat (windsave_filename, ".wind_save");
+  strcpy (specsave_filename, files.root);
+  strcat (specsave_filename, ".spec_save");
+
+  /*
+   * Read in the wind_save file and initialize the wind cones and DFUDGE which
+   * are important for photon transport. The atomic data is also read in at
+   * this point (which is also very important)
+   */
+
+  if (wind_read (windsave_filename) < 0)
+  {
+    printf ("Unable to open %s\n", windsave_filename);
+    exit (EXIT_FAILURE);
+  }
+
+  DFUDGE = setup_dfudge ();
+  setup_windcone ();
+
+  /*
+   * Do some further error checking on the COLUMN_MODE_ION to ensure that
+   * it is a sensible number and print the ion to be extracted
+   */
+
+  if (COLUMN_MODE == COLUMN_MODE_ION)
+  {
+    if (COLUMN_MODE_ION_NUMBER > nions - 1)
+    {
+      printf ("Argument for -cion > nions\n");
+      exit (1);
+    }
+    printf ("Extracting column density for %s %i\n", ele[ion[COLUMN_MODE_ION_NUMBER].nelem].name, ion[COLUMN_MODE_ION_NUMBER].istate);
+  }
+  else
+  {
+    printf ("Extracting mass and Hydrogen column density\n");
+  }
+
+  /*
+   * If a spec_save exists, and there are spectral cycles (possibly a redundant
+   * check), then read in the spec_save file.
+   */
+
+  if (access (specsave_filename, F_OK) == 0)
+  {
+    if (geo.pcycle > 0)
+    {
+      if (spec_read (specsave_filename) < 0)
+      {
+        printf ("Unable to open %s when spectrum cycles have been run\n", specsave_filename);
+        exit (EXIT_FAILURE);
+      }
+    }
+  }
+
+  /*
+   * Now we can finally being the optical depth diagnostics...
+   */
+
+  do_optical_depth_diagnostics ();
+  printf ("\n%-20s Optical depth diagnostics completed\n", "TAU");
+  printf ("Completed optical depth diagnostics. The elapsed TIME was %f\n", timer ());
+
+  return EXIT_SUCCESS;
+}

--- a/source/py_optical_depth.h
+++ b/source/py_optical_depth.h
@@ -1,0 +1,52 @@
+/** ************************************************************************* */
+/**
+ * @file     py_optical_depth.h
+ * @author   Edward Parkinson
+ * @date     February 2021
+ *
+ * @brief    Globals used during optical depth diagnostics.
+ *
+ * @details
+ *
+ * Do not include this in any file other than py_optical_depth_sub.c, otherwise
+ * there will be double definition errors. If you want to include it in
+ * multiple, place MAXDIFF and N_PI_EDGES into py_optical_depth_sub.c to avoid
+ * the errors. The reason they are in this header file, and why it exists, is
+ * to keep things a bit cleaner in py_optical_depth_sub.c
+ *
+ * ************************************************************************** */
+
+#define DOMAIN_TO_CONSIDER 0  // For now, we only care about photons starting in domain 0
+#define N_FREQ_BINS 25000
+
+// Inclination angles structure
+
+typedef struct SightLines_s
+{
+  char name[50];
+  double lmn[3];
+} SightLines_t;
+
+SightLines_t *INCLINATION_ANGLES;
+int N_INCLINATION_ANGLES;         // The number of inclination angles
+
+// PI edges structure
+
+typedef struct PIEdges_s
+{
+  char name[50];
+  double freq;
+} PIEdges_t;
+
+#define N_PI_EDGES (int) (sizeof PI_EDGES_TO_MEASURE / sizeof *PI_EDGES_TO_MEASURE)  // The number of optical depths for the simple calculation
+
+// Control the column density extracted
+
+enum COLUMN_DENSITY
+{
+  COLUMN_MODE_RHO,
+  COLUMN_MODE_ION,
+};
+
+int COLUMN_MODE;
+int COLUMN_MODE_ION_NUMBER;

--- a/source/py_optical_depth_sub.c
+++ b/source/py_optical_depth_sub.c
@@ -21,7 +21,7 @@
 const PIEdges_t PI_EDGES_TO_MEASURE[] = {
   {"HLymanEdge", 3.387485e+15},
   {"HBalmerEdge", 8.293014e+14},
-  {"HeI24eVEdge", 4.9483e+15},
+  {"HeI24eVEdge", 5.9483e+15},
   {"HeII54eVEdge", 1.394384e+16}
 };
 

--- a/source/py_optical_depth_sub.c
+++ b/source/py_optical_depth_sub.c
@@ -21,6 +21,7 @@
 const PIEdges_t PI_EDGES_TO_MEASURE[] = {
   {"HLymanEdge", 3.387485e+15},
   {"HBalmerEdge", 8.293014e+14},
+  {"HeI24eVEdge", 4.9483e+15},
   {"HeII54eVEdge", 1.394384e+16}
 };
 

--- a/source/py_optical_depth_sub.c
+++ b/source/py_optical_depth_sub.c
@@ -1,0 +1,684 @@
+/** ************************************************************************* */
+/**
+ * @file     py_optical_depth_sub.c
+ * @author   Edward Parkinson
+ * @date     April 2019
+ *
+ * @brief    The main resting place for most functions related to providing
+ *           optical depth diagnostics.
+ *
+ * ************************************************************************** */
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "atomic.h"
+#include "python.h"
+#include "py_optical_depth.h"
+
+const PIEdges_t PI_EDGES_TO_MEASURE[] = {
+  {"HLymanEdge", 3.387485e+15},
+  {"HBalmerEdge", 8.293014e+14},
+  {"HeII54eVEdge", 1.394384e+16}
+};
+
+/* ************************************************************************** */
+/**
+ * @brief  Print the various optical depths calculated using this routine
+ *
+ * @param[in]  optical_depths  The 2d array containing the optical depth for
+ *                             each observer and tau
+ * @param[in]  column_densities  The 2d array containing the column densities
+ *                               for each observer
+ *
+ * @details
+ *
+ * Prints the different optical depths for each angle and optical depth.
+ * Historically, this used to also print to file. But I found that it was mostly
+ * useless to do this.
+ *
+ * ************************************************************************** */
+
+void
+print_optical_depths (const double *optical_depth_values, const double *column_density_values)
+{
+  int i, j;
+  int c_linelen;
+  char str[LINELENGTH];
+  const int MAX_COL = 120;
+
+  printf ("\nOptical depths along the defined line of sights for domain %i:\n\n", DOMAIN_TO_CONSIDER);
+
+  for (i = 0; i < N_INCLINATION_ANGLES; i++)
+  {
+    if (COLUMN_MODE == COLUMN_MODE_RHO)
+    {
+      printf ("%-8s: Mass column density     : %3.2e cm^-2\n", INCLINATION_ANGLES[i].name, column_density_values[i]);
+      printf ("%-8s: Hydrogen column density : %3.2e cm^-2\n", "", column_density_values[i] * rho2nh);
+    }
+    else
+    {
+      printf ("%-8s: %s %i column density    : %3.2e cm^-2\n", INCLINATION_ANGLES[i].name, ele[ion[COLUMN_MODE_ION_NUMBER].nelem].name,
+              ion[COLUMN_MODE_ION_NUMBER].istate, column_density_values[i]);
+    }
+
+    c_linelen = 0;
+    for (j = 0; j < N_PI_EDGES; j++)
+    {
+      c_linelen += sprintf (str, "tau_%-9s: %3.2e  ", PI_EDGES_TO_MEASURE[j].name, optical_depth_values[i * N_PI_EDGES + j]);
+      if (c_linelen > MAX_COL)
+      {
+        c_linelen = 0;
+        printf ("\n");
+      }
+      printf ("%s", str);
+    }
+    printf ("\n\n");
+  }
+}
+
+/* ************************************************************************* */
+/**
+ * @brief           Write the various optical depth spectra to file
+ *
+ * @param[in]  tau_spectrum  The various optical depth spectra
+ * @param[in]  freq_min  The smallest frequency in the spectra
+ * @param[in]  d_freq  The size of the frequncy bins
+
+ *
+ * @details
+ *
+ * Simply write the optical depth spectra to the file named root.tau_spec.diag.
+ * This file will be located in the diag folder.
+ *
+ * ************************************************************************** */
+
+void
+write_optical_depth_spectrum (const double *tau_spectrum, const double freq_min, const double d_freq)
+{
+  int i, j;
+  double c_wavelength, c_frequency;
+  char filename[LINELENGTH + 12];
+  FILE *fp;
+
+  sprintf (filename, "%s.spec_tau", files.root);
+
+  if ((fp = fopen (filename, "w")) == NULL)
+  {
+    printf ("write_optical_depth_spectrum: uh oh, could not open optical depth spectrum output file\n");
+    exit (EXIT_FAILURE);
+  }
+
+  /*
+   * Write out the tau spectrum header
+   */
+
+  fprintf (fp, "%-12s %-12s ", "Freq.", "Lambda");
+  for (j = 0; j < N_INCLINATION_ANGLES; j++)
+    fprintf (fp, "%-12s ", INCLINATION_ANGLES[j].name);
+  fprintf (fp, "\n");
+
+  /*
+   * Write out the tau spectrum for each inclination angle
+   */
+
+  c_frequency = freq_min;
+  for (i = 0; i < N_FREQ_BINS; i++)
+  {
+    c_wavelength = VLIGHT / c_frequency / ANGSTROM;
+    fprintf (fp, "%-12e %-12e ", c_frequency, c_wavelength);
+    for (j = 0; j < N_INCLINATION_ANGLES; j++)
+      fprintf (fp, "%-12e ", tau_spectrum[j * N_FREQ_BINS + i]);
+    fprintf (fp, "\n");
+    c_frequency += d_freq;
+  }
+
+  fflush (fp);                  // probably not required, but was needed when this was part of Python rather than standalone
+
+  if (fclose (fp))
+    printf ("write_optical_depth_spectrum: uh oh, could not close optical depth spectrum output file\n");
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Calculate the total optical depth a photon experiences across the
+ *         cell of distance SMAX_FRAC * smax.
+
+ * @param[in]  photon  The photon packet
+ * @param[in,out]  *c_column_density  The column density the photon has moved
+ *                                    through
+ * @param[in,out]  *c_optical_depth  The optical depth experienced by the photon
+ *
+ * @return p_istat  The current photon status or EXIT_FAILURE on failure.
+ *
+ * @details
+ *
+ * This function is concerned with finding the opacity of the photon's current
+ * cell, the distance the photon can move in the cell and hence it increments
+ * the optical depth tau a photon has experienced as it moves through the wind.
+ *
+ * ************************************************************************** */
+
+const double MAXDIFF = VCHECK / VLIGHT; // For linear velocity requirement for photon transport
+
+int
+calculate_tau_across_cell (PhotPtr photon, double *c_column_density, double *c_optical_depth)
+{
+  int p_istat;
+  int n_dom, n_plasma;
+  double kappa_total, density;
+  double smax;
+  double diff;
+  double freq_inner, freq_outer, mean_freq;
+  WindPtr c_wind_cell;
+  PlasmaPtr c_plasma_cell;
+  struct photon p_start, p_stop, p_now;
+
+  if ((photon->grid = where_in_grid (wmain[photon->grid].ndom, photon->x)) < 0)
+  {
+    printf ("calculate_tau_across_cell: photon is not in grid in cell %i\n", photon->grid);
+    return EXIT_FAILURE;
+  }
+
+  /*
+   * Determine where in the plasma grid the cell is. This is required so a
+   * column density can be calculated. Also calculate the maximum distance the
+   * photon can traverse across the cell
+   */
+
+  c_wind_cell = &wmain[photon->grid];
+  n_dom = c_wind_cell->ndom;
+  n_plasma = wmain[photon->grid].nplasma;
+  c_plasma_cell = &plasmamain[n_plasma];
+
+  if (COLUMN_MODE == COLUMN_MODE_RHO)
+  {
+    density = c_plasma_cell->rho;
+  }
+  else
+  {
+    density = c_plasma_cell->density[COLUMN_MODE_ION_NUMBER];
+  }
+
+  smax = smax_in_cell (photon);
+  if (smax < 0)
+  {
+    printf ("calculate_tau_across_cell: abnormal value of smax for photon\n");
+    return EXIT_FAILURE;
+  }
+
+  /*
+   * Transform the photon into the CMF and create a photon in the CMF at the
+   * end of the path of length smax
+   */
+
+  observer_to_local_frame (photon, &p_start);
+  stuff_phot (photon, &p_stop);
+  move_phot (&p_stop, smax);
+  observer_to_local_frame (&p_stop, &p_stop);
+
+  /* At this point p_start and p_stop are in the local frame
+   * at the and p_stop is at the maximum distance it can
+   * travel. We want to check that the frequency shift is
+   * not too great along the path that a linear approximation
+   * to the change in frequency is not reasonable
+   */
+
+  while (smax > DFUDGE)
+  {
+    stuff_phot (photon, &p_now);
+    move_phot (&p_now, smax * 0.5);
+    observer_to_local_frame (&p_now, &p_now);
+    diff = fabs (p_now.freq - 0.5 * (p_start.freq + p_stop.freq)) / p_start.freq;
+    if (diff < MAXDIFF)
+      break;
+    stuff_phot (&p_now, &p_stop);
+    smax *= 0.5;
+  }
+
+  freq_inner = p_start.freq;
+  freq_outer = p_stop.freq;
+  mean_freq = 0.5 * (freq_inner + freq_outer);
+
+  /*
+   * Now we can finally calculate the opacity due to all the continuum
+   * processes. In macro-atom mode, we need to calculate the continuum opacity
+   * using kappa_bf and kappa_ff using the macro treatment. For simple mode, we
+   * can simply use radiation which **SHOULD** return the continuum opacity
+   * as well, plus something from induced Compton heating. In either cases,
+   * we still then need to add the optical depth from electron scattering at
+   * the end.
+   */
+
+  kappa_total = 0;
+
+  if (geo.rt_mode == RT_MODE_2LEVEL)
+  {
+    radiation (photon, smax, &kappa_total);
+  }
+  else                          // macro atom case
+  {
+    if (c_wind_cell->vol > 0)
+    {
+      kappa_total += kappa_bf (c_plasma_cell, freq_inner, 0);
+      kappa_total += kappa_ff (c_plasma_cell, freq_inner);
+    }
+  }
+
+  kappa_total += klein_nishina (mean_freq) * c_plasma_cell->ne * zdom[n_dom].fill;
+
+  /*
+   * Increment the optical depth and column density variables and move the
+   * photon to the edge of the cell
+   */
+
+  *c_column_density += smax * density;
+  *c_optical_depth += smax * kappa_total;
+  move_phot (photon, smax);
+  p_istat = photon->istat;
+
+  return p_istat;
+}
+
+/* ************************************************************************* */
+/**
+ * @brief           Extract the optical depth the photon packet porig must
+ *                  travel through to reach the observer.
+ *
+ * @param[in]  photon  The photon packet to extract
+ * @param[out]  *c_column_density  The column depth of the extracted photon angle
+ * @param[out]  *c_optical_depth  The optical depth from photon origin to
+ *                                the observer
+ *
+ * @return  EXIT_SUCCESS or EXIT_FAILURE
+ *
+ * @details
+ *
+ * The direction of the observer is set in porig.lmn and should be set prior
+ * to passing a photon to this function. If any values of lmn are negative, the
+ * photon will translate in the negative direction. However, have no fear as this
+ * is normal and is fine due to the assumed symmetry of models in Python.
+ *
+ * ************************************************************************** */
+
+int
+extract_tau (PhotPtr photon, double *c_column_density, double *c_optical_depth)
+{
+  int n_dom;
+  enum istat_enum p_istat;
+  const int max_translate_in_space = 10;
+  int n_in_space;
+  double norm[3];
+  struct photon p_extract;
+
+  p_istat = P_INWIND;           // assume photon is in wind for initialisation reasons
+  stuff_phot (photon, &p_extract);
+
+  n_in_space = 0;
+  while (p_istat == P_INWIND)
+  {
+    if (where_in_wind (p_extract.x, &n_dom) < 0)
+    {
+      translate_in_space (&p_extract);
+      if (++n_in_space > max_translate_in_space)
+      {
+        printf ("extract_tau: tau_extract photon transport ended due to too many translate_in_space\n");
+        return EXIT_FAILURE;
+      }
+    }
+    else if ((p_extract.grid = where_in_grid (n_dom, p_extract.x)) >= 0)
+    {
+      if (calculate_tau_across_cell (&p_extract, c_column_density, c_optical_depth))
+        return EXIT_FAILURE;
+    }
+    else
+    {
+      printf ("extract_tau: photon in unknown location grid stat %i\n", p_extract.grid);
+      return EXIT_FAILURE;
+    }
+
+    p_istat = walls (&p_extract, photon, norm);
+  }
+
+  if (p_istat == P_HIT_STAR || p_istat == P_HIT_DISK)
+  {
+    printf ("extract_tau: photon hit central source or disk incorrectly istat = %i\n", p_istat);
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Generate a photon packet with a given frequency nu for use with the
+ *         optical depth diagnostic routines.
+ *
+ * @param[in,out]  p_out  The photon packet to initialise
+ * @param[in]  freq  The frequency of the photon packet
+ *
+ * @return  EXIT_SUCCESS or EXIT_FAILURE
+ *
+ * @details
+ *
+ * This routine assumes that the user wishes for the photon to be generated from
+ * the surface of the central source, taking into account the current direction
+ * of the sight-line being extracted. It's currently not possible, without a
+ * tedious re-write, to place the photon at the very origin of the grid when
+ * there is a central source because of how we check boundaries.
+ *
+ * Note that photons are initialised with a weight of f_tot as photons are
+ * required to have weight, but since functions do not care about the weight of
+ * the photon, it is set to something large to make sure it does not get
+ * destroyed by accident somehow.
+ *
+ * ************************************************************************** */
+
+int
+create_photon (PhotPtr p_out, double freq, double *lmn)
+{
+  if (freq < 0)
+  {
+    printf ("create_photon: photon can't be created with negative frequency\n");
+    return EXIT_FAILURE;
+  }
+
+  stuff_v (lmn, p_out->lmn);
+  p_out->freq = p_out->freq_orig = freq;
+  p_out->origin = p_out->origin_orig = PTYPE_DISK;
+  p_out->istat = P_INWIND;
+  p_out->w = p_out->w_orig = geo.f_tot;
+  p_out->tau = 0.0;
+  p_out->x[0] = p_out->x[1] = p_out->x[2] = 0;
+  p_out->frame = F_OBSERVER;
+  move_phot (p_out, geo.rstar + DFUDGE);
+
+  return EXIT_SUCCESS;
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Initialise the viewing angles for the optical depth diagnostic
+ *         routines.
+ *
+ * @details
+ *
+ * This purpose of this function is to initialise the angles of which to extract
+ * optical depth information from. If xxspec is initialised, then the optical
+ * depth information will be extracted from the observer angles provided in the
+ * parameter file for spectrum generation. Otherwise, the routines will instead
+ * use a set of pre-defined angles.
+ *
+ * ************************************************************************** */
+
+void
+initialize_inclination_angles (void)
+{
+  int i;
+  long mem_req;
+  const double default_phase = 0.5;
+  const double default_angles[] = { 0.0, 10.0, 30.0, 45.0, 60.0, 75.0, 85.0, 90.0 };
+  const int n_default_angles = sizeof default_angles / sizeof default_angles[0];
+
+  /*
+   * Use the angles specified for by the user for spectrum generation, this
+   * requires for xxspec to be initialised.
+   */
+
+  if (geo.nangles > 0 && xxspec != NULL)
+  {
+    N_INCLINATION_ANGLES = geo.nangles;
+    INCLINATION_ANGLES = calloc (geo.nangles, sizeof *INCLINATION_ANGLES);
+    if (INCLINATION_ANGLES == NULL)
+    {
+      mem_req = geo.nangles * (int) sizeof *INCLINATION_ANGLES;
+      printf ("initialize_inclination_angles: cannot allocate %ld bytes for observers array\n", mem_req);
+      exit (EXIT_FAILURE);
+    }
+    else                        // Use else to avoid compiler warning
+    {
+      for (i = MSPEC; i < MSPEC + geo.nangles; i++)
+      {
+        strcpy (INCLINATION_ANGLES[i - MSPEC].name, xxspec[i].name);
+        stuff_v (xxspec[i].lmn, INCLINATION_ANGLES[i - MSPEC].lmn);
+      }
+    }
+  }
+
+  /*
+   * If no spectrum cycles are being run, or if the model is being restarted
+   * without initialising xxspec, then a default set of angles is used instead.
+   */
+
+  else
+  {
+    printf ("tau_spectrum: as there are no spectrum cycles or observers defined, a set of default angles will be used instead\n");
+    N_INCLINATION_ANGLES = n_default_angles;
+    INCLINATION_ANGLES = calloc (n_default_angles, sizeof *INCLINATION_ANGLES);
+    if (INCLINATION_ANGLES == NULL)
+    {
+      mem_req = n_default_angles * (int) sizeof *INCLINATION_ANGLES;
+      printf ("initialize_inclination_angles: cannot allocate %ld bytes for observers array\n", mem_req);
+      exit (EXIT_FAILURE);
+    }
+    else
+    {
+      for (i = 0; i < n_default_angles; i++)
+      {
+        sprintf (INCLINATION_ANGLES[i].name, "A%02.0fP%04.2f", default_angles[i], default_phase);
+        INCLINATION_ANGLES[i].lmn[0] = sin (default_angles[i] / RADIAN) * cos (-default_phase * 360.0 / RADIAN);
+        INCLINATION_ANGLES[i].lmn[1] = sin (default_angles[i] / RADIAN) * sin (-default_phase * 360.0 / RADIAN);
+        INCLINATION_ANGLES[i].lmn[2] = cos (default_angles[i] / RADIAN);
+      }
+    }
+  }
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Create spectra of tau vs lambda for each observer angle
+ *
+ * @details
+ *
+ * This is the main function which will generate the optical depth spectra for
+ * each observer angle in xxspec. The algorithm is similar to extract and the
+ * tau_diag algorithm which this function is called in.
+ *
+ * A photon is generated at the central source of the model and is extracted
+ * from this location towards the observer where it escapes, where extract_tau
+ * returns the integrated optical depth along its path to escape. This is done
+ * for a range of photon frequencies to find how optical depth changes with
+ * frequency.
+ *
+ * This processes can take some time compared to tau_evalulate_photo_edges. But,
+ * since N_FREQ_BINS photons are being generated for each spectrum and the fact
+ * that these photons do not interact, the spectra does not actually take that
+ * long to complete.
+ *
+ * ************************************************************************** */
+
+void
+create_optical_depth_spectrum (void)
+{
+  int i, j;
+  double *tau_spectrum;
+  double c_optical_depth, c_column_density;
+  double c_frequency, freq_min, freq_max, d_freq;
+  struct photon photon;
+
+  printf ("Creating optical depth spectra:\n");
+
+  if ((tau_spectrum = calloc (N_INCLINATION_ANGLES * N_FREQ_BINS, sizeof *tau_spectrum)) == NULL)
+  {
+    printf ("create_optical_depth_spectrum: cannot allocate %lu bytes for tau_spectrum\n",
+            N_INCLINATION_ANGLES * N_FREQ_BINS * sizeof *tau_spectrum);
+    return;
+  }
+
+  /*
+   * Define the limits of the spectra in frequency space. If xxpsec is NULL,
+   * then the frequency range will be over a default 100 - 10,000 Angstrom
+   * band.
+   */
+
+  if ((geo.nangles == 0 && xxspec == NULL) || (geo.swavemax == 0 && geo.swavemin == 0))
+  {
+    printf ("create_optical_depth_spectrum: xxspec is uninitialized, defaulting spectral wavelength range to 100 - 10,000 Angstrom\n");
+    freq_min = VLIGHT / (10000 * ANGSTROM);
+    freq_max = VLIGHT / (100 * ANGSTROM);
+  }
+  else
+  {
+    freq_min = VLIGHT / (geo.swavemax * ANGSTROM);
+    freq_max = VLIGHT / (geo.swavemin * ANGSTROM);
+    if (sane_check (freq_min))
+    {
+      freq_min = VLIGHT / (10000 * ANGSTROM);
+      printf ("create_optical_depth_spectrum: freq_min has an invalid value setting to %e\n", freq_min);
+    }
+    if (sane_check (freq_max))
+    {
+      freq_max = VLIGHT / (100 * ANGSTROM);
+      printf ("create_optical_depth_spectrum: freq_min has an invalid value setting to %e\n", freq_max);
+    }
+  }
+
+  d_freq = (freq_max - freq_min) / N_FREQ_BINS;
+  kbf_need (freq_min, freq_max);
+
+  /*
+   * Now create the optical depth spectra for each inclination
+   */
+
+  for (i = 0; i < N_INCLINATION_ANGLES; i++)
+  {
+    printf ("  - Creating spectrum: %s\n", INCLINATION_ANGLES[i].name);
+    c_frequency = freq_min;
+    for (j = 0; j < N_FREQ_BINS; j++)
+    {
+      c_optical_depth = 0.0;
+      c_column_density = 0.0;
+      if ((create_photon (&photon, c_frequency, INCLINATION_ANGLES[i].lmn)) == EXIT_FAILURE)
+      {
+        printf ("create_optical_depth_spectrum: skipping photon of frequency %e when creating spectrum\n", c_frequency);
+        continue;
+      }
+      if ((extract_tau (&photon, &c_column_density, &c_optical_depth)) == EXIT_FAILURE)
+        continue;
+      tau_spectrum[i * N_FREQ_BINS + j] = c_optical_depth;
+      c_frequency += d_freq;
+    }
+  }
+
+  write_optical_depth_spectrum (tau_spectrum, freq_min, d_freq);
+  if (tau_spectrum)             // I didn't think I needed to do this, but if I don't, there are runtime errors
+    free (tau_spectrum);
+}
+
+/* ************************************************************************* */
+/**
+ * @brief Calculate the optical depth for various optical depth edges and
+ *        extract the column density.
+ *
+ * @details
+ *
+ * This is the main function which will control the procedure for calculating
+ * various diagnostic numbers for the optical depth's experienced in the current
+ * model. Namely, this function aims to show the total integrated optical depth
+ * to each observer angle using (originally) the following optical depths:
+ *
+ *  - Lymann edge
+ *  - Balmer edge
+ *  - Helium II edge
+ *
+ * Once these integrated optical depths have been calculated for each angle, a
+ * spectrum of optical depth vs wavelength is created for each angle.
+ *
+ * The aim of these diagnostic numbers it to provide some sort of quick metric
+ * on the optical thickness of the current model.
+ *
+ * ************************************************************************** */
+
+void
+calculate_PI_edge_optical_depth (void)
+{
+  int i, j;
+  double c_frequency, c_optical_depth, c_column_density;
+  double *optical_depth_values, *column_density_values;
+  struct photon photon;
+
+  if ((optical_depth_values = calloc (N_INCLINATION_ANGLES * N_PI_EDGES, sizeof *optical_depth_values)) == NULL)
+  {
+    printf ("calculate_PI_edge_optical_depth: cannot allocate %lu bytes for optical_depths\n",
+            N_INCLINATION_ANGLES * N_PI_EDGES * sizeof *optical_depth_values);
+    return;
+  }
+  if ((column_density_values = calloc (N_INCLINATION_ANGLES, sizeof *optical_depth_values)) == NULL)
+  {
+    printf ("calculate_PI_edge_optical_depth: cannot allocate %lu bytes for column_densities\n",
+            N_INCLINATION_ANGLES * sizeof *optical_depth_values);
+    free (optical_depth_values);
+    return;
+  }
+
+  /*
+   * Now extract the optical depths and mass column densities. We loop over
+   * each PI edge for each inclination angle.
+   */
+
+  for (i = 0; i < N_INCLINATION_ANGLES; i++)
+  {
+    for (j = 0; j < N_PI_EDGES; j++)
+    {
+      c_optical_depth = 0.0;
+      c_column_density = 0.0;
+      c_frequency = PI_EDGES_TO_MEASURE[j].freq;
+
+      if (create_photon (&photon, c_frequency, INCLINATION_ANGLES[i].lmn) == EXIT_FAILURE)
+      {
+        printf ("calculate_PI_edge_optical_depth: skipping photon of frequency %e\n", c_frequency);
+        continue;
+      }
+
+      if (extract_tau (&photon, &c_column_density, &c_optical_depth) == EXIT_FAILURE)
+        continue;               // do not throw extra warning when one is already thrown in extract_tau
+
+      optical_depth_values[i * N_PI_EDGES + j] = c_optical_depth;
+      column_density_values[i] = c_column_density;
+    }
+  }
+
+  print_optical_depths (optical_depth_values, column_density_values);
+
+  /*
+   * The if's here are to avoid warnings with potentially freeing already
+   * deallocated memory
+   */
+
+  if (optical_depth_values)
+    free (optical_depth_values);
+  if (column_density_values)
+    free (column_density_values);
+}
+
+/* ************************************************************************* */
+/**
+ * @brief  Main control function for create optical depth diagnostics.
+ *
+ * @details
+ *
+ * This function is the main steering function for generating the optical depth
+ * diagnostics.
+ *
+ * ************************************************************************** */
+
+void
+do_optical_depth_diagnostics (void)
+{
+  initialize_inclination_angles ();
+  calculate_PI_edge_optical_depth ();
+  create_optical_depth_spectrum ();
+  free (INCLINATION_ANGLES);
+}

--- a/source/py_optical_depth_sub.c
+++ b/source/py_optical_depth_sub.c
@@ -257,7 +257,7 @@ calculate_tau_across_cell (PhotPtr photon, double *c_column_density, double *c_o
 
   if (geo.rt_mode == RT_MODE_2LEVEL)
   {
-    radiation (photon, smax, &kappa_total);
+    kappa_total += radiation (photon, smax);
   }
   else                          // macro atom case
   {

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -1,4 +1,3 @@
-
 /***********************************************************/
 /** @file  radiation.c
  * @author ksl
@@ -16,24 +15,30 @@
 #include "atomic.h"
 #include "python.h"
 
-#define COLMIN	0.01
+#define COLMIN  0.01
 
 int iicount = 0;
 
 
 /**********************************************************/
-/** 
- * @brief      updates the  field parameters in the wind and reduces 
- * the weight of the photon as a result of the effects of  free free, bound-free and 
- * Compton scattering. The routine  
+/**
+ * @brief      updates the  field parameters in the wind and reduces
+ * the weight of the photon as a result of the effects of  free free, bound-free and
+ * Compton scattering. The routine
  * also keeps track of the number of photoionizations for H and He in the
  * cell.
  *
  * @param [in,out] PhotPtr  p   the photon
  * @param [in] double  ds   the distance the photon has travelled in the cell
- * @return     Always returns 0.  The pieces of the wind structure which are updated are
- * 	j,ave_freq,ntot, heat_photo, heat_ff, heat_h, heat_he1, heat_he2, heat_z,
- * 	nioniz, and ioniz[].
+ * @param [out] double *kappa_tot_return  The total opacity in the CMF(?) frame
+ * @return     Always returns 0
+ *
+ * @details
+ *
+ * The pieces of the wind structure which are updated in each call to radiation
+ * are:
+ *   j,ave_freq,ntot, heat_photo, heat_ff, heat_h, heat_he1, heat_he2, heat_z,
+ *   nioniz, and ioniz[].
  *
  * @details
  *
@@ -44,7 +49,7 @@ int iicount = 0;
  * n_i sigma and h nu can be brought outside the integral.  Hence the integral is just over w(s),
  * but that is just given by (w(0)-w(smax))/kappa_tot.)  The routine calculates the number of ionizations per
  * unit volume.
- * 	
+ *
  * Inputs to radiation are assumed to be in the observer frame.  kappas are calculated
  * in the CMF frame, as elsewhere.  Where tau is calculted from kappa ds, one needs to
  * account for the difference in length in the two frames
@@ -52,9 +57,7 @@ int iicount = 0;
  **********************************************************/
 
 int
-radiation (p, ds)
-     PhotPtr p;
-     double ds;
+radiation (PhotPtr p, double ds, double *kappa_tot_return)
 {
   TopPhotPtr x_top_ptr;
 
@@ -108,9 +111,9 @@ radiation (p, ds)
   stuff_v (p->lmn, p_in);       //Get the direction
   renorm (p_in, p->w / VLIGHT); //Renormalise to momentum
 
-  /* Create phot, a photon at the position we are moving to 
-   *  note that the actual movement of the photon gets done after 
-   *  the call to radiation 
+  /* Create phot, a photon at the position we are moving to
+   *  note that the actual movement of the photon gets done after
+   *  the call to radiation
    */
 
   stuff_phot (p, &phot);        // copy photon ptr
@@ -148,17 +151,17 @@ radiation (p, ds)
   phot_mid_cmf.freq = freq = 0.5 * (freq_inner + freq_outer);
   phot_mid.freq = 0.5 * (p->freq + phot.freq);
 
-  /* calculate free-free, Compton and induced-Compton opacities 
+  /* calculate free-free, Compton and induced-Compton opacities
      note that we also call these with the average frequency along ds */
 
   kappa_tot = frac_ff = kappa_ff (xplasma, freq);       /* Add ff opacity */
-  kappa_tot += frac_comp = kappa_comp (xplasma, freq);  /* Calculate Compton opacity, 
-                                                           store it in kappa_comp and also add it to kappa_tot, 
+  kappa_tot += frac_comp = kappa_comp (xplasma, freq);  /* Calculate Compton opacity,
+                                                           store it in kappa_comp and also add it to kappa_tot,
                                                            the total opacity for the photon path */
 
   kappa_tot += frac_ind_comp = kappa_ind_comp (xplasma, freq);
 
-  frac_tot = frac_z = 0;        /* 59a - ksl - Moved this line out of loop to avoid warning, but notes 
+  frac_tot = frac_z = 0;        /* 59a - ksl - Moved this line out of loop to avoid warning, but notes
                                    indicate this is all diagnostic and might be removed */
   frac_auger = 0;
   frac_tot_abs = frac_auger_abs = 0.0;
@@ -198,7 +201,7 @@ radiation (p, ds)
        of the energy that goes into heating electrons carefully.  */
 
     /* JM 1405 -- I've added a check here that checks if a photoionization edge has been crossed.
-       If it has, then we multiply sigma*density by a factor frac_path, which is equal to the how far along 
+       If it has, then we multiply sigma*density by a factor frac_path, which is equal to the how far along
        ds the edge occurs in frequency space  [(ft - freq_min) / (freq_max - freq_min)] */
 
 
@@ -213,7 +216,7 @@ radiation (p, ds)
         ft = x_top_ptr->freq[0];
         if (ft > freq_min && ft < freq_max)
         {
-          /* then the shifting of the photon causes it to cross an edge. 
+          /* then the shifting of the photon causes it to cross an edge.
              Find out where between fmin and fmax the edge would be in freq space.
              frac_path is the fraction of the total path length above the absorption edge
              freq_xs is freq halfway between the edge and the max freq if an edge gets crossed */
@@ -232,8 +235,8 @@ radiation (p, ds)
 
         if (freq_xs < x_top_ptr->freq[x_top_ptr->np - 1])
         {
-          /* Need the appropriate density at this point. 
-             how we get this depends if we have a topbase (level by level) 
+          /* Need the appropriate density at this point.
+             how we get this depends if we have a topbase (level by level)
              or vfky cross-section (ion by ion) */
 
           nion = x_top_ptr->nion;
@@ -345,11 +348,11 @@ radiation (p, ds)
 
 
 
-  /* finished looping over cross-sections to calculate bf opacity 
+  /* finished looping over cross-sections to calculate bf opacity
      we can now reduce weights and record certain estimators */
 
 
-
+  *kappa_tot_return = kappa_tot;
   kappa_tot_obs = kappa_tot / observer_to_local_frame_ds (p, 1);
   tau = kappa_tot_obs * ds;
 
@@ -414,7 +417,7 @@ radiation (p, ds)
   }
 
   if (geo.ioniz_or_extract == CYCLE_EXTRACT)
-    return (0);
+    return 0;                   // 57h -- ksl -- 060715
 
 /* Everything after this point is only needed for ionization calculations */
 /* Update the radiation parameters used ultimately in calculating t_r */
@@ -477,7 +480,7 @@ radiation (p, ds)
       xplasma->heat_tot += z * frac_auger;      //All the inner shell opacities
 
       q = (z) / (PLANCK * freq * xplasma->vol);
-      /* So xplasma->ioniz for each species is just 
+      /* So xplasma->ioniz for each species is just
          (energy_abs)*kappa_h/kappa_tot / PLANCK*freq / volume
          or the number of photons absorbed in this bundle per unit volume by this ion
        */
@@ -490,7 +493,7 @@ radiation (p, ds)
       for (n = 0; n < n_inner_tot; n++)
       {
         xplasma->heat_inner_ion[inner_cross_ptr[n]->nion] += frac_inner_ion[n] * z;     //This quantity is per ion - the ion number comes from the freq ordered cross section
-        xplasma->inner_ioniz[n] += kappa_inner_ion[n] * q;      //This is the number of ionizations from this innershell cross section - at this point, inner_ioniz is ordered by frequency                
+        xplasma->inner_ioniz[n] += kappa_inner_ion[n] * q;      //This is the number of ionizations from this innershell cross section - at this point, inner_ioniz is ordered by frequency
       }
     }
   }
@@ -505,12 +508,12 @@ radiation (p, ds)
 
 
 /**********************************************************/
-/** 
+/**
  * @brief      calculates the free-free opacity allowing for stimulated emission
  *
  * @param [in] PlasmaPtr  xplasma   The plasma cell where the free-free optacity is to be calculated
  * @param [in] double  freq   The frequency at which kappa_ff is to be calculated
- * @return     kappa           
+ * @return     kappa
  *
  * @details
  * Uses the formula from Allen
@@ -520,10 +523,10 @@ radiation (p, ds)
  * The routine originally only includes the effect of singly ionized H and doubly ionized He
  * and did not include a gaunt factor
  *
- * More recent versions include all ions and a gaunt factor, as calculated in 
+ * More recent versions include all ions and a gaunt factor, as calculated in
  * pop_kappa_ff_array and stored in kappa_ff_factor. The gaunt factor as currewntly
- * implemented is a frequency averaged one, and so is approximate (but better than 
- * just using 1). A future upgrade would use a more complex implementation where we 
+ * implemented is a frequency averaged one, and so is approximate (but better than
+ * just using 1). A future upgrade would use a more complex implementation where we
  * use the frequency dependant gaunt factor.
  *
  **********************************************************/
@@ -567,20 +570,20 @@ kappa_ff (xplasma, freq)
 
 
 /**********************************************************/
-/** 
+/**
  * @brief      calculates the
- * 	photionization crossection due to a Topbase level associated with
- * 	x_ptr at frequency freq
+ *  photionization crossection due to a Topbase level associated with
+ *  x_ptr at frequency freq
  *
  * @param [in,out] struct topbase_phot *  x_ptr   The structure that contains
  * TopBase information about the photoionization x-section
  * @param [in] double  freq   The frequency where the x-section is to be calculated
  *
- * @return     The x-section   
+ * @return     The x-section
  *
  * @details
  * sigma_phot uses the Topbase x-sections to calculate the bound free
- * (or photoionization) xsection.	The data must have been into the
+ * (or photoionization) xsection.   The data must have been into the
  * photoionization structures xphot with get_atomic_data and the
  * densities of individual ions must have been calculated previously.
  *
@@ -638,12 +641,12 @@ sigma_phot (x_ptr, freq)
 
 
 /**********************************************************/
-/** 
+/**
  * @brief      returns the precalculated density
- * 	of a particular "nlte" level.	
+ *  of a particular "nlte" level.
  *
  * @param [in] PlasmaPtr  xplasma   The Plasma structure containing information about
- * the cell of interest. 
+ * the cell of interest.
  * @param [in] int  nconf   The running index that describes which level we are interested in
  * @return     The density for a particular level of an ion in the cell
  *
@@ -677,7 +680,7 @@ den_config (xplasma, nconf)
   }
   else if (nconf == ion[nion].firstlevel)
   {
-/* Then we are using a Topbase photoionization x-section for this ion, 
+/* Then we are using a Topbase photoionization x-section for this ion,
 but we are not storing any densities, and so we assume it is completely in the
 in the ground state */
     density = xplasma->density[nion];
@@ -695,8 +698,8 @@ in the ground state */
 
 
 /**********************************************************/
-/** 
- * @brief      populates the multiplicative 	
+/**
+ * @brief      populates the multiplicative
  * constant, including a gaunt factor, to be  used in the 
  * calculating free free  emission (and absorption). 
  *

--- a/source/radiation.c
+++ b/source/radiation.c
@@ -56,8 +56,8 @@ int iicount = 0;
  *
  **********************************************************/
 
-int
-radiation (PhotPtr p, double ds, double *kappa_tot_return)
+double
+radiation (PhotPtr p, double ds)
 {
   TopPhotPtr x_top_ptr;
 
@@ -352,7 +352,6 @@ radiation (PhotPtr p, double ds, double *kappa_tot_return)
      we can now reduce weights and record certain estimators */
 
 
-  *kappa_tot_return = kappa_tot;
   kappa_tot_obs = kappa_tot / observer_to_local_frame_ds (p, 1);
   tau = kappa_tot_obs * ds;
 
@@ -417,7 +416,7 @@ radiation (PhotPtr p, double ds, double *kappa_tot_return)
   }
 
   if (geo.ioniz_or_extract == CYCLE_EXTRACT)
-    return 0;                   // 57h -- ksl -- 060715
+    return kappa_tot;           // 57h -- ksl -- 060715
 
 /* Everything after this point is only needed for ionization calculations */
 /* Update the radiation parameters used ultimately in calculating t_r */
@@ -501,7 +500,7 @@ radiation (PhotPtr p, double ds, double *kappa_tot_return)
   z_obs = z * p_cmf.freq / p->freq;
   update_force_estimators (xplasma, p, &phot_mid, ds, w_ave_obs, ndom, z_obs, frac_ff, frac_auger, frac_tot);
 
-  return (0);
+  return kappa_tot;
 }
 
 

--- a/source/templates.h
+++ b/source/templates.h
@@ -33,6 +33,7 @@ int translate(WindPtr w, PhotPtr pp, double tau_scat, double *tau, int *nres);
 int translate_in_space(PhotPtr pp);
 double ds_to_wind(PhotPtr pp, int *ndom_current);
 int translate_in_wind(WindPtr w, PhotPtr p, double tau_scat, double *tau, int *nres);
+double smax_in_cell(PhotPtr p);
 double ds_in_cell(int ndom, PhotPtr p);
 /* photon_gen.c */
 int define_phot(PhotPtr p, double f1, double f2, long nphot_tot, int ioniz_or_final, int iwind, int freq_sampling);
@@ -127,7 +128,7 @@ int kbf_need(double fmin, double fmax);
 double sobolev(WindPtr one, double x[], double den_ion, struct lines *lptr, double dvds);
 int scatter(PhotPtr p, int *nres, int *nnscat);
 /* radiation.c */
-int radiation(PhotPtr p, double ds);
+int radiation(PhotPtr p, double ds, double *kappa_tot_return);
 double kappa_ff(PlasmaPtr xplasma, double freq);
 double sigma_phot(struct topbase_phot *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);

--- a/source/templates.h
+++ b/source/templates.h
@@ -128,7 +128,7 @@ int kbf_need(double fmin, double fmax);
 double sobolev(WindPtr one, double x[], double den_ion, struct lines *lptr, double dvds);
 int scatter(PhotPtr p, int *nres, int *nnscat);
 /* radiation.c */
-int radiation(PhotPtr p, double ds, double *kappa_tot_return);
+double radiation(PhotPtr p, double ds);
 double kappa_ff(PlasmaPtr xplasma, double freq);
 double sigma_phot(struct topbase_phot *x_ptr, double freq);
 double den_config(PlasmaPtr xplasma, int nconf);

--- a/source/windsave.c
+++ b/source/windsave.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <sys/stat.h>
 
 #include "atomic.h"
 #include "python.h"
@@ -182,6 +183,7 @@ wind_read (filename)
   int n, m;
   char line[LINELENGTH];
   char version[LINELENGTH];
+  struct stat file_stat;        // Used to check the atomic data exists
 
   if ((fptr = fopen (filename, "r")) == NULL)
   {
@@ -202,8 +204,16 @@ wind_read (filename)
    * with macro atoms, especially but likely to be a good idea ovrall
    */
 
-  get_atomic_data (geo.atomic_filename);
+  if (stat (geo.atomic_filename, &file_stat))
+  {
+    if (system ("Setup_Py_Dir"))
+    {
+      Error ("Unable to open %s or create link for atomic data\n", geo.atomic_filename);
+      Exit (1);
+    }
+  }
 
+  get_atomic_data (geo.atomic_filename);
 
 /* Now allocate space for the wind array */
 


### PR DESCRIPTION
This is the code which I have been using to generate my optical depth spectra, and in some cases, extract the column density along certain inclination angles. I'm aware there are some things we probably want to sort out before this gets merged in, but here is a description of it anyway.

It's contained within a separate program, `py_optical_depth`, which you can run after a model has finished and has the following usage:

```
py_optical_depth [-h] [-cion nion] [-classic] [--version] root

-h           Print this help message and exit
-cion nion   Extract the column density for an ion of number nion
-classic     Use linear frequency transforms. Use when Python run in classic mode.
--version    Print the version information and exit.
```

The program calculates the optical depth as a function of frequency along the inclination angles and spectral wavelength range of the model. If no spectral cycles have been run, then the program adopts a set of default inclination angles and a default wavelength range. Along these same inclination angles, the optical depth for a few PI edges are evaluated and so are the column densities. By default the mass and Hydrogen column densities are extracted, but using the -cion command means you can extract a certain ion's column density instead. All densities and optical depth are extracted from the central source, so should be the same as how we define the inclination angles for extracted spectra.

I made a couple of alterations to Python when writing this. Namely, I've added a new function `smax_in_cell (PhotPtr p)` which calculates the maximum distance a photon can move in a cell. This function implements the code which was already in Python, but now is in a function since I use the same code elsewhere in my program. I have also added an extra return, by pointer, for the total opacity calculated in `radiation()`. None of the functionality otherwise has been modified. It looks like my text editor/GNU indent also touched a couple of lines removing/adding whitespace.

Are there any features missing which people would like? The Plank and Rosseland mean frequencies were originally gonna be added, but we decided to drop this. I've also been thinking about adding an option to launch photons from an arbitrary point in the wind, but unsure if it would be actually useful compared to being able to evaluate single cells in the wind would be nice too. But both might require a bit of UI work to make it easy/obvious to use. Oh and I guess a RtD page about this program (and our other auxiliary programs) would be helpful too.