### PR TITLE
Normalize all spectra with number of MPI processes

### DIFF
--- a/source/para_update.c
+++ b/source/para_update.c
@@ -434,7 +434,7 @@ gather_spectra_para ()
     nspec = MSPEC;
   }
 
-  size_of_commbuffer = 2 * nspec * NWAVE;       //we need space for log and lin spectra for MSPEC XNWAVE
+  size_of_commbuffer = 4 * nspec * NWAVE;       //we need space for log and lin spectra for MSPEC XNWAVE
 
 
 
@@ -446,9 +446,9 @@ gather_spectra_para ()
     for (mpi_j = 0; mpi_j < nspec; mpi_j++)
     {
       redhelper[mpi_i * nspec + mpi_j] = xxspec[mpi_j].f[mpi_i] / np_mpi_global;
-
-      if (geo.ioniz_or_extract == CYCLE_IONIZ)
-        redhelper[mpi_i * nspec + mpi_j + (NWAVE * nspec)] = xxspec[mpi_j].lf[mpi_i] / np_mpi_global;
+      redhelper[mpi_i * nspec + mpi_j + (NWAVE * nspec)] = xxspec[mpi_j].lf[mpi_i] / np_mpi_global;
+      redhelper[mpi_i * nspec + mpi_j + (2 * NWAVE * nspec)] = xxspec[mpi_j].f_wind[mpi_i] / np_mpi_global;
+      redhelper[mpi_i * nspec + mpi_j + (3 * NWAVE * nspec)] = xxspec[mpi_j].lf_wind[mpi_i] / np_mpi_global;
     }
   }
 
@@ -461,9 +461,9 @@ gather_spectra_para ()
     for (mpi_j = 0; mpi_j < nspec; mpi_j++)
     {
       xxspec[mpi_j].f[mpi_i] = redhelper2[mpi_i * nspec + mpi_j];
-
-      if (geo.ioniz_or_extract == CYCLE_IONIZ)
-        xxspec[mpi_j].lf[mpi_i] = redhelper2[mpi_i * nspec + mpi_j + (NWAVE * nspec)];
+      xxspec[mpi_j].lf[mpi_i] = redhelper2[mpi_i * nspec + mpi_j + (NWAVE * nspec)];
+      xxspec[mpi_j].f_wind[mpi_i] = redhelper2[mpi_i * nspec + mpi_j + (2 * NWAVE * nspec)];
+      xxspec[mpi_j].lf_wind[mpi_i] = redhelper2[mpi_i * nspec + mpi_j + (3 * NWAVE * nspec)];
     }
   }
   MPI_Barrier (MPI_COMM_WORLD);

--- a/source/para_update.c
+++ b/source/para_update.c
@@ -418,12 +418,9 @@ int
 gather_spectra_para ()
 {
 #ifdef MPI_ON
-
   double *redhelper, *redhelper2;
   int mpi_i, mpi_j;
-
   int size_of_commbuffer, nspec;
-
 
   if (geo.ioniz_or_extract == CYCLE_EXTRACT)
   {
@@ -434,9 +431,7 @@ gather_spectra_para ()
     nspec = MSPEC;
   }
 
-  size_of_commbuffer = 4 * nspec * NWAVE;       //we need space for log and lin spectra for MSPEC XNWAVE
-
-
+  size_of_commbuffer = 4 * nspec * NWAVE;       //we need space for all 4 separate spectra we are normalizing
 
   redhelper = calloc (sizeof (double), size_of_commbuffer);
   redhelper2 = calloc (sizeof (double), size_of_commbuffer);
@@ -470,8 +465,6 @@ gather_spectra_para ()
 
   free (redhelper);
   free (redhelper2);
-
-
 #endif
 
   return (0);


### PR DESCRIPTION
For example, the log_spec file was only normalized over all MPI processes during the ionization cycles. Now it is normalized during ionization and spectral cycles.