### PR TITLE
Fix possibility of negative ds and frame errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(PYTHON_SOURCE
         source/wind2d.c source/wind_sum.c source/wind_updates2d.c
         source/wind_util.c source/windsave.c source/windsave2table_sub.c
         source/xlog.c source/xtest.c source/zeta.c source/macro_accelerate.c
+        source/macro_gen_f.c
         )
 
 set(PY_WIND_SOURCE

--- a/source/extract.c
+++ b/source/extract.c
@@ -148,8 +148,7 @@ extract (w, p, itype)
 
     mscat = xxspec[n].nscat;
 
-    // I think this should be mscat == MAXSCAT, can someone check? This part of the code confuses me
-    if (mscat == MAXSCAT || p_in.nscat == mscat || (mscat < 0 && p_in.nscat >= (-mscat)))
+    if (mscat > 999 || p_in.nscat == mscat || (mscat < 0 && p_in.nscat >= (-mscat)))
       extract_photon = TRUE;
     else
       extract_photon = FALSE;

--- a/source/extract.c
+++ b/source/extract.c
@@ -146,9 +146,10 @@ extract (w, p, itype)
        of times or in specific regions of the wind. A region is specified by a position
        and a radius. */
 
-    extract_photon = TRUE;
+    mscat = xxspec[n].nscat;
 
-    if ((mscat = xxspec[n].nscat) > MAXSCAT || p_in.nscat == mscat || (mscat < 0 && p_in.nscat >= (-mscat)))
+    // I think this should be mscat == MAXSCAT, can someone check? This part of the code confuses me
+    if (mscat == MAXSCAT || p_in.nscat == mscat || (mscat < 0 && p_in.nscat >= (-mscat)))
       extract_photon = TRUE;
     else
       extract_photon = FALSE;

--- a/source/import_rtheta.c
+++ b/source/import_rtheta.c
@@ -13,13 +13,11 @@
  * which is the way the zeus_python models work
  * is for the velocity to be given in spherical
  * polar coordinates.
-
  * However, internally, python uses xyz coordinates
  * for velocities (as measured in the xz plane),
  * and that is the model followed, here.  This also
  * makes these routines similar to those used
  * in imported cylindrical models.
-
  * This means that if the user provides a model
  * where velocities are in spherical polar coordinates
  * then one must translate them to the convention
@@ -62,7 +60,7 @@
  * * inwind defines whether or not a particular cell is actually
  * in the wind
  *
- * Guard cells are required at the outer boundaries. 
+ * Guard cells are required at the outer boundaries.
  *
  * This routine assumes the same conventions as used elsewhere
  * in Python, that is that the positions and velocities are given
@@ -81,6 +79,7 @@ import_rtheta (ndom, filename)
   int jz, jx;
   double delta;
   double r, theta, v_x, v_y, v_z, rho, t_r, t_e;
+  double mid_z;
 
 
   Log ("Reading a model %s in polar (r,theta) coordinates \n", filename);
@@ -144,7 +143,7 @@ import_rtheta (ndom, filename)
   }
 
   /* Set and check the dimensions of the grids to be set up.
-   * 
+   *
    * Note that some assumptions are built into the way the grid
    * is read in, most notably that the last cell to be read in
    * defines the dimensions of the entire grid.
@@ -182,9 +181,11 @@ import_rtheta (ndom, filename)
 
   for (n = 0; n < jz - 1; n++)
   {
-    imported_model[ndom].wind_midz[n] = 0.5 * (imported_model[ndom].wind_z[n] + imported_model[ndom].wind_z[n + 1]);
+    mid_z = 0.5 * (imported_model[ndom].wind_z[n] + imported_model[ndom].wind_z[n + 1]);
+    if (mid_z > 90)
+      mid_z = 90;
+    imported_model[ndom].wind_midz[n] = mid_z;
   }
-
 
   delta = (imported_model[ndom].wind_z[n - 1] - imported_model[ndom].wind_z[n - 2]);
   imported_model[ndom].wind_midz[n] = imported_model[ndom].wind_z[n - 1] + 0.5 * delta;
@@ -384,10 +385,9 @@ rtheta_make_grid_import (w, ndom)
     w[nn].v[2] = imported_model[ndom].v_z[n];
     w[nn].inwind = imported_model[ndom].inwind[n];
 
-    if (w[nn].inwind == W_NOT_INWIND || w[nn].inwind == W_PART_INWIND)
-      w[nn].inwind = W_IGNORE;
-
     w[nn].thetacen = imported_model[ndom].wind_midz[imported_model[ndom].j[n]];
+    if (w[nn].thetacen > 90)
+      w[nn].thetacen = 90;
     theta = w[nn].thetacen / RADIAN;
 
     w[nn].rcen = imported_model[ndom].wind_midx[imported_model[ndom].i[n]];
@@ -454,9 +454,9 @@ rtheta_make_grid_import (w, ndom)
  *
  * ### Notes ###
  *  In practice this routine is only used to initialize v in
- *  wind structure, and interpolation is only a convenient 
- *  way to do this.  
- *  
+ *  wind structure, and interpolation is only a convenient
+ *  way to do this.
+ *
  *  This is consistent with the way velocities
  *  are treated throughout Python.
  *
@@ -513,7 +513,7 @@ velocity_rtheta (ndom, x, v)
  * initialized, we always interpolate within the plasma structure
  * and do not access the original data
  *
- * This routine is dependent on the assumption that x is in 
+ * This routine is dependent on the assumption that x is in
  * the center of a cell.
  *
  **********************************************************/

--- a/source/import_spherical.c
+++ b/source/import_spherical.c
@@ -1,4 +1,3 @@
-
 /***********************************************************/
 /** @file  import_spherical.c
  * @author ksl
@@ -190,10 +189,8 @@ import_spherical_setup_boundaries (int ndom)
 
 
 /* The next section contains routines to make the grids for imported models.
-
    We make some assumptions here.  We assume that every cell is in the wind.
    and we assume that r refers to the inside edge of the cell.
-
  * */
 
 
@@ -245,10 +242,18 @@ spherical_make_grid_import (w, ndom)
     {
       w[n].rcen = w[n].r * 1.005;
     }
+    w[n].inwind = W_ALL_INWIND;
     w[n].x[1] = w[n].xcen[1] = 0.0;
     w[n].x[0] = w[n].x[2] = w[n].r * sin (PI / 4.);
     w[n].xcen[0] = w[n].xcen[2] = w[n].rcen * sin (PI / 4.);
   }
+
+  /*
+   * The first and last two cells are "guard" cells, as such they are not
+   * considered to be in the wind.
+   */
+
+  w[0].inwind = w[imported_model[ndom].ncell - 1].inwind = w[imported_model[ndom].ncell - 2].inwind = W_NOT_INWIND;
 
   /* Since we assume all of the cells are in the wind in a spherical wind
    * we can use the standard routine to finish everything off

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -1,4 +1,3 @@
-
 /***********************************************************/
 /** @file  photon2d.c
  * @author ksl
@@ -430,37 +429,30 @@ translate_in_wind (w, p, tau_scat, tau, nres)
 
 
 {
-
   int n;
   double smax, ds_current, ds_cmf;
   int istat;
   int nplasma;
-  int ndom;
-  int inwind;
 
   WindPtr one;
   PlasmaPtr xplasma;
   struct photon phot_mid, phot_mid_cmf; // Photon at the midpt of its path in the cell
 
-
-/* First verify that the photon is in the grid, and if not
-return and record an error */
+  /* First verify that the photon is in the grid, and if not
+     return and record an error */
 
   if ((p->grid = n = where_in_grid (wmain[p->grid].ndom, p->x)) < 0)
   {
     return (n);                 /* Photon was not in grid */
   }
-/* Assign the pointers for the cell containing the photon */
+
+  /* Assign the pointers for the cell containing the photon */
 
   one = &wmain[n];              /* one is the grid cell where the photon is */
   nplasma = one->nplasma;
   xplasma = &plasmamain[nplasma];
-  ndom = one->ndom;
-  inwind = one->inwind;
 
-
-
-/* Calculate the maximum distance the photon can travel in the cell */
+  /* Calculate the maximum distance the photon can travel in the cell */
 
   smax = smax_in_cell (p);
 
@@ -477,11 +469,9 @@ return and record an error */
   if (p->nres > 0)
     xplasma->nscat_res++;
 
-
-
-/* We now increment the radiation field in the cell, translate the photon and wrap
-   things up.  For simple atoms, the routine radiation also reduces
-   the weight of the photon due to continuum absorption, e.g. free free.
+  /* We now increment the radiation field in the cell, translate the photon and wrap
+     things up.  For simple atoms, the routine radiation also reduces
+     the weight of the photon due to continuum absorption, e.g. free free.
    */
 
 
@@ -511,11 +501,12 @@ return and record an error */
 
   if (*nres > -1 && *nres <= NLINES && *nres == p->nres && istat == P_SCAT && translate_in_wind_res_count < 5000)
   {
-    if (ds_current < 1e5)
+    if (ds_current < w[p->grid].dfudge)
     {
       Error ("translate_in_wind: nres %5d repeat after motion of %10.3e of phot %6d in ion cycle %2d spec cycle %2d stat(%d -> %d)\n",
              *nres, ds_current, p->np, geo.wcycle, geo.pcycle, p->istat, istat);
       istat = P_INWIND;
+      *tau = 0;
     }
   }
 


### PR DESCRIPTION
**I've broken something, do not merge!!!**

When a photon was not allowed to interact with the same resonance line twice within a small volume, the "running" optical depth was not reset like it would be if it scattered. This caused a problem where calculate_ds would return a negative distance and eventually resulted in a negative average frequency value in plasma cells.

The fix for this is to set the optical depth to zero when we reset a photon's istat from P_SCAT to P_INWIND. I've also added a number of extra checks to ensure quantities are not negative, this should make it clearer where an error, due to negative numbers, first develops.

Also included in this PR are changes to the code to stop check frame errors, due to photons being tagged as being in the wrong frame and I've renamed some variables to make their purpose clearer.

Unfortunately my text editor removed a lot of trailing whitespace on a number of comment lines as back traced my way through to the cause of the error in the source code... so the commit says I've edited more lines than I actually have.

(holding off from merging in until agn_macro finishes in the regress tests) 