### PR TITLE
Fixes for negative calculated ds values when photon forced to not interact with same resonance 

### DIFF
--- a/source/estimators_simple.c
+++ b/source/estimators_simple.c
@@ -84,6 +84,18 @@ update_banded_estimators (xplasma, p, ds, w_ave, ndom)
   int i;
   double log_freq;
 
+  if (ds < 0)
+  {
+    Error("updated_banded_estimators: ds %e < 0 in plasma cell %d when it has to be positive\n", ds, xplasma->nplasma);
+    Exit(1);
+  }
+
+  if (w_ave < 0)
+  {
+    Error("updated_banded_estimators: w_ave %e < 0 in plasma cell %d when it has to be positive\n", w_ave, xplasma->nplasma);
+    Exit(1);
+  }
+
   /*photon weight times distance in the shell is proportional to the mean intensity */
 
   xplasma->j += w_ave * ds;

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -516,6 +516,7 @@ return and record an error */
       Error ("translate_in_wind: nres %5d repeat after motion of %10.3e of phot %6d in ion cycle %2d spec cycle %2d stat(%d -> %d)\n",
              *nres, ds_current, p->np, geo.wcycle, geo.pcycle, p->istat, istat);
       istat = P_INWIND;
+      *tau = 0;
     }
   }
 


### PR DESCRIPTION
This error occurred when a photon is not allowed to interact with the same resonance scatter within a small volume. The crux of the problem was that we kept the photon in the wind, rather than allowing it to scatter, but we did not reset the optical depth value as if it was scattered.

This meant there were situations where a photon completely over stepped the scattering optical depth, so the code calculated a negative distance to that scattering point. This eventually lead to a negative radiation temperature! 

The fix here is to set the optical depth to zero when this edge case is met. I have also added additional checks to the inputs of `update_banded_estimators` to help flag errors like this earlier on in the code.