### PR TITLE
Allow GSL RNG to be continued where it left off from on model restarts

### DIFF
--- a/source/parse.c
+++ b/source/parse.c
@@ -185,12 +185,17 @@ parse_command_line (argc, argv)
         Log ("Invoking fixed temperature mode\n");
         j = i;
       }
-
       else if (strcmp (argv[i], "--rseed") == 0)
       {
         modes.rand_seed_usetime = 1;
         j = i;
         Log ("Using a random seed in random number generator\n");
+      }
+      else if (strcmp (argv[i], "--prng") == 0)
+      {
+        modes.persistent_rng = 1;
+        j = i;
+        Log ("Using a persistent RNG state\n");
       }
       else if (strcmp (argv[i], "-z") == 0)
       {

--- a/source/parse.c
+++ b/source/parse.c
@@ -325,6 +325,7 @@ and the switches have the following meanings \n\
  --version      Print out python version, commit hash and if there were files with uncommitted \n\
                 changes and stop \n\
  --rseed        Set the random number seed to be time-based, rather than fixed. \n\
+ --prng         Save or load the RNG state to file, to allow persistent RNG states between restarts\n\
 \n\
 Other switches exist but these are not intended for the general user.\n\
 These are largely diagnostic or for special cases. These include\n\

--- a/source/parse.c
+++ b/source/parse.c
@@ -191,9 +191,10 @@ parse_command_line (argc, argv)
         j = i;
         Log ("Using a random seed in random number generator\n");
       }
-      else if (strcmp (argv[i], "--prng") == 0)
+      else if (strcmp (argv[i], "--rng") == 0)
       {
-        modes.persistent_rng = 1;
+        modes.save_rng = 1;
+        modes.load_rng = 1;
         j = i;
         Log ("Using a persistent RNG state\n");
       }
@@ -255,7 +256,6 @@ parse_command_line (argc, argv)
       exit (1);
     }
 
-
     strcpy (dummy, argv[argc - 1]);
     get_root (files.root, dummy);
 
@@ -270,7 +270,12 @@ parse_command_line (argc, argv)
     strcat (files.diag, files.root);
     strcat (files.diag, dummy);
 
+    /* Set up the directory structure for storing the rng state */
 
+    if (modes.save_rng)
+    {
+      init_rng_directory ();
+    }
   }
 
   return (restart_stat);
@@ -325,7 +330,7 @@ and the switches have the following meanings \n\
  --version      Print out python version, commit hash and if there were files with uncommitted \n\
                 changes and stop \n\
  --rseed        Set the random number seed to be time-based, rather than fixed. \n\
- --prng         Save or load the RNG state to file, to allow persistent RNG states between restarts\n\
+ --rng          Save or load the RNG state to file, to allow persistent RNG states between restarts\n\
 \n\
 Other switches exist but these are not intended for the general user.\n\
 These are largely diagnostic or for special cases. These include\n\

--- a/source/python.c
+++ b/source/python.c
@@ -593,10 +593,6 @@ main (argc, argv)
     init_rand (n);
 
   }
-  else if (modes.save_rng && restart_stat == TRUE)
-  {
-    reload_gsl_rng_state ();
-  }
   else
   {
     init_rand (1084515760 + (13 * rank_global));

--- a/source/python.c
+++ b/source/python.c
@@ -587,11 +587,15 @@ main (argc, argv)
    * to use the same phtons in ezch cycle.  There we initiate the seeds unsing
    * the clock
    */
-  if (modes.rand_seed_usetime == 1)
+  if (modes.rand_seed_usetime)
   {
     n = (unsigned int) clock () * (rank_global + 1);
     init_rand (n);
 
+  }
+  else if (modes.persistent_rng && restart_stat == TRUE)
+  {
+    reload_gsl_rng_state ();
   }
   else
   {
@@ -602,7 +606,6 @@ main (argc, argv)
      sets the push through distance depending on the size of the system.
    */
 
-//  DFUDGE = setup_dfudge ();
   DFUDGE = setup_dfudge ();
 
   /* Next line finally defines the wind if this is the initial time this model is being run */

--- a/source/python.c
+++ b/source/python.c
@@ -593,7 +593,7 @@ main (argc, argv)
     init_rand (n);
 
   }
-  else if (modes.persistent_rng && restart_stat == TRUE)
+  else if (modes.save_rng && restart_stat == TRUE)
   {
     reload_gsl_rng_state ();
   }

--- a/source/python.h
+++ b/source/python.h
@@ -1419,6 +1419,7 @@ struct advanced_modes
   int zeus_connect;             // We are connecting to zeus, do not seek new temp and output a heating and cooling file
   int rand_seed_usetime;        // default random number seed is fixed, not based on time
   int photon_speedup;
+  int persistent_rng;                 // save the GSL RNG stage
 }
 modes;
 

--- a/source/python.h
+++ b/source/python.h
@@ -1419,7 +1419,8 @@ struct advanced_modes
   int zeus_connect;             // We are connecting to zeus, do not seek new temp and output a heating and cooling file
   int rand_seed_usetime;        // default random number seed is fixed, not based on time
   int photon_speedup;
-  int persistent_rng;                 // save the GSL RNG stage
+  int save_rng;                 // save the GSL RNG stage
+  int load_rng;                 // load the GSL RNG state
 }
 modes;
 
@@ -1452,6 +1453,7 @@ struct filenames
   char tprofile[LINELENGTH];    // non standard tprofile fname
   char phot[LINELENGTH];        // photfile e.g. python.phot
   char windrad[LINELENGTH];     // wind rad file
+  char rngsave[LINELENGTH];     // .gsl_save file for restarting RNG
 }
 files;
 

--- a/source/random.c
+++ b/source/random.c
@@ -374,7 +374,7 @@ reload_gsl_rng_state ()
     Exit (1);
   }
 
-  Log ("RNG state saved to %s\n", files.rngsave);
+  Log ("RNG state loaded from %s\n", files.rngsave);
 
   if (fclose (file))
   {

--- a/source/reverb.c
+++ b/source/reverb.c
@@ -241,7 +241,7 @@ delay_dump (PhotPtr p, int np)
      * more scatters
      */
     i = delay_dump_spec[nphot];
-    if (((mscat = xxspec[i].nscat) > 999 ||
+    if (((mscat = xxspec[i].nscat) > MAXSCAT ||
          p[nphot].nscat == mscat ||
          (mscat < 0 && p[nphot].nscat >= (-mscat))) && ((mtopbot = xxspec[i].top_bot) == 0 || (mtopbot * p[nphot].x[2]) > 0))
     {

--- a/source/run.c
+++ b/source/run.c
@@ -590,6 +590,10 @@ make_spectra (restart_stat)
 #endif
       wind_save (files.windsave);       // This is only needed to update pcycle
       spec_save (files.specsave);
+      if (modes.persistent_rng)
+      {
+        save_gsl_rng_state ();
+      }
 #ifdef MPI_ON
     }
 #endif

--- a/source/run.c
+++ b/source/run.c
@@ -357,6 +357,10 @@ calculate_ionization (restart_stat)
         sprintf (dummy, "diag_%s/%s.%02d", files.root, files.root, geo.wcycle);
         do_windsave2table (dummy, 0);
       }
+      if (modes.persistent_rng)
+      {
+        save_gsl_rng_state ();
+      }
 
 #ifdef MPI_ON
     }

--- a/source/run.c
+++ b/source/run.c
@@ -111,6 +111,12 @@ calculate_ionization (restart_stat)
 
 /* BEGINNING OF CYCLE TO CALCULATE THE IONIZATION OF THE WIND */
 
+  if (modes.load_rng && geo.wcycle > 0)
+  {
+    reload_gsl_rng_state ();
+    modes.load_rng = FALSE;
+  }
+
   while (geo.wcycle < geo.wcycles)
   {                             /* This allows you to build up photons in bunches */
 
@@ -357,15 +363,16 @@ calculate_ionization (restart_stat)
         sprintf (dummy, "diag_%s/%s.%02d", files.root, files.root, geo.wcycle);
         do_windsave2table (dummy, 0);
       }
-      if (modes.persistent_rng)
-      {
-        save_gsl_rng_state ();
-      }
 
 #ifdef MPI_ON
     }
     MPI_Barrier (MPI_COMM_WORLD);
 #endif
+
+    if (modes.save_rng)
+    {
+      save_gsl_rng_state ();
+    }
 
     check_time (files.root);
     Log_flush ();               /*Flush the logfile */
@@ -506,6 +513,11 @@ make_spectra (restart_stat)
     spectrum_restart_renormalise (geo.nangles);
   }
 
+  if (modes.load_rng && geo.pcycle > 0)
+  {
+    reload_gsl_rng_state ();
+    modes.load_rng = FALSE;
+  }
 
   while (geo.pcycle < geo.pcycles)
   {                             /* This allows you to build up photons in bunches */
@@ -590,13 +602,14 @@ make_spectra (restart_stat)
 #endif
       wind_save (files.windsave);       // This is only needed to update pcycle
       spec_save (files.specsave);
-      if (modes.persistent_rng)
-      {
-        save_gsl_rng_state ();
-      }
 #ifdef MPI_ON
     }
 #endif
+    if (modes.save_rng)
+    {
+      save_gsl_rng_state ();
+    }
+
     check_time (files.root);
   }
 

--- a/source/spectra.c
+++ b/source/spectra.c
@@ -664,7 +664,7 @@ spectrum_create (p, nangle, select_extract)
 
   for (j = 0; j <= max_scat; j++)
   {
-    Log ("%-6g", (double) nscat[j]);
+    Log ("%-6.3g", (double) nscat[j]);
     if ((j % 10) == 9)
       Log ("\n");
   }
@@ -672,14 +672,14 @@ spectrum_create (p, nangle, select_extract)
   Log ("\nNumber of photons resonantly scattering n times.  The max number of scatters seen was %d\n", max_res);
   for (j = 0; j <= max_res; j++)
   {
-    Log ("%-6g", (double) nres[j]);
+    Log ("%-6.3g", (double) nres[j]);
     if ((j % 10) == 9)
       Log ("\n");
   }
   Log ("\nNo of photons and their fates\n!!PhotFate: ");
   for (j = 0; j < NSTAT; j++)
   {
-    Log ("%-6g", (double) nstat[j]);
+    Log ("%-6.3g", (double) nstat[j]);
     if ((j % 10) == 9)
       Log ("\n");
   }
@@ -693,7 +693,7 @@ spectrum_create (p, nangle, select_extract)
   {
     Log ("%20s ", xxspec[n].name);
     for (j = 0; j < NSTAT; j++)
-      Log (" %-7g", (double) xxspec[n].nphot[j]);
+      Log (" %-7.3g", (double) xxspec[n].nphot[j]);
     Log ("\n");
 
   }

--- a/source/templates.h
+++ b/source/templates.h
@@ -180,6 +180,7 @@ int randvec(double a[], double r);
 int randvcos(double lmn[], double north[]);
 double vcos(double x, void *params);
 int init_rand(int seed);
+void init_rng_directory(void);
 void save_gsl_rng_state(void);
 void reload_gsl_rng_state(void);
 double random_number(double min, double max);

--- a/source/templates.h
+++ b/source/templates.h
@@ -59,8 +59,8 @@ int lucy_mazzali1(double nh, double t_r, double t_e, double www, int nelem, doub
 int fix_concentrations(PlasmaPtr xplasma, int mode);
 double get_ne(double density[]);
 /* spectra.c */
-int spectrum_init(double f1, double f2, int nangle, double angle[], double phase[], int scat_select[], int top_bot_select[], int select_extract, double rho_select[], double z_select[], double az_select[], double r_select[]);
 void spectrum_allocate(int nspec);
+int spectrum_init(double f1, double f2, int nangle, double angle[], double phase[], int scat_select[], int top_bot_select[], int select_extract, double rho_select[], double z_select[], double az_select[], double r_select[]);
 int spectrum_create(PhotPtr p, int nangle, int select_extract);
 int spec_add_one(PhotPtr p, int spec_type);
 int spectrum_summary(char filename[], int nspecmin, int nspecmax, int select_spectype, double renorm, int loglin, int iwind);
@@ -180,6 +180,8 @@ int randvec(double a[], double r);
 int randvcos(double lmn[], double north[]);
 double vcos(double x, void *params);
 int init_rand(int seed);
+void save_gsl_rng_state(void);
+void reload_gsl_rng_state(void);
 double random_number(double min, double max);
 /* stellar_wind.c */
 int get_stellar_wind_params(int ndom);


### PR DESCRIPTION
By using the `--rng` flag, the GSL RNG state is saved at the end of each ion/spectral cycle. On model restart, the RNG is reloaded and also requires the `--rng` flag.

The RNG is saved in a hidden directory named `.rng_root/` and the files take the form `root_X.rng_save` where X is the process number. My tests have shown that the RNG reloading mode works, as identical "Photons contributing to the various spectra" tables and etc are obtained when using `--rng` to restart a model. When `--rng` is not used, this table is diffrent.

The regression tests, which don't use `--rng`, are unchanged by changes in this PR.