### PR TITLE
added a fix for bug#863

### DIFF
--- a/source/python.c
+++ b/source/python.c
@@ -199,6 +199,12 @@ main (argc, argv)
         get_models (geo.model_list[n], 2, &dummy_spectype);
       }
     }
+    if (geo.disk_tprofile == DISK_TPROFILE_READIN) //We also need to re-read in any previously used disk temperature profile
+    {
+      rdstr ("Disk.T_profile_file", files.tprofile);
+      geo.diskrad = read_non_standard_disk_profile (files.tprofile);
+      geo.disk_mdot = 0;
+    }
     if (geo.pcycle > 0)
     {
       spec_read (files.specsave);


### PR DESCRIPTION
Small change to python.c to fix bug #863 where a read-in temperature profile for the disk wasn't read in on restart, so the disk had zero emissivity