### PR TITLE
Fix for an empty array being passed to renorm when finding max/min velocity gradient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ set(PYTHON_SOURCE
         source/phot_util.c source/photo_gen_matom.c source/photon2d.c
         source/photon_gen.c source/pi_rates.c source/radiation.c source/random.c
         source/rdpar.c source/rdpar_init.c source/recipes.c source/recomb.c
-        source/reposition.c source/resonate.c source/reverb.c source/roche.c
+        source/resonate.c source/reverb.c source/roche.c
         source/rtheta.c source/run.c source/saha.c source/setup.c
         source/setup_disk.c source/setup_domains.c source/setup_files.c
         source/setup_line_transfer.c source/setup_reverb.c

--- a/source/gradv.c
+++ b/source/gradv.c
@@ -326,14 +326,12 @@ int
 dvds_max ()
 {
   struct photon p;
-  double delta[3];
-  double sum, dvds;
+  double dvds;
   double dvds_max, lmn[3];
   int n;
   int icell;
   double dvds_min, lmn_min[3];
   char filename[LINELENGTH];
-  int ndom;
 
   /* Open a diagnostic file if print_dvds_info is non-zero */
 
@@ -345,8 +343,6 @@ dvds_max ()
 
   for (icell = 0; icell < NDIM2; icell++)
   {
-    ndom = wmain[icell].ndom;
-
     dvds_max = 0.0;
     dvds_min = 1.e30;
 
@@ -363,7 +359,6 @@ dvds_max ()
 
     p.grid = icell;
 
-    sum = 0.0;
     for (n = 0; n < N_DVDS_AVE; n++)
     {
       randvec (p.lmn, 1);
@@ -376,14 +371,14 @@ dvds_max ()
       if (dvds > dvds_max)
       {
         dvds_max = dvds;
-        renorm (delta, 1.0);
-        stuff_v (delta, lmn);
+        renorm (p.lmn, 1.0);
+        stuff_v (p.lmn, lmn);
       }
       if (dvds < dvds_min)
       {
         dvds_min = dvds;
-        renorm (delta, 1.0);
-        stuff_v (delta, lmn_min);
+        renorm (p.lmn, 1.0);
+        stuff_v (p.lmn, lmn_min);
       }
 
 

--- a/source/gradv.c
+++ b/source/gradv.c
@@ -371,13 +371,11 @@ dvds_max ()
       if (dvds > dvds_max)
       {
         dvds_max = dvds;
-        renorm (p.lmn, 1.0);
         stuff_v (p.lmn, lmn);
       }
       if (dvds < dvds_min)
       {
         dvds_min = dvds;
-        renorm (p.lmn, 1.0);
         stuff_v (p.lmn, lmn_min);
       }
 

--- a/source/vvector.c
+++ b/source/vvector.c
@@ -143,22 +143,22 @@ length (a)
 
 int
 renorm (a, scalar)
-     double a[], scalar;
+  double a[], scalar;
 {
   double x;
-  double dot ();
-  x = (dot (a, a));
+
+  x = dot (a, a);
   if (x < EPS)
   {
-    Log ("renorm: Cannot renormalize a vector of length 0\n");
-    Log ("renorm: %e %e %e\n", a[0], a[1], a[2]);
-    Log ("renorm returning -1\n");
-    return (-1);
+    Log ("renorm: Cannot renormalize a vector [%e, %e, %e] of length 0\n", a[0], a[1], a[2]);
+    return -EXIT_FAILURE;
   }
+
   x = scalar / sqrt (x);
   a[0] *= x;
   a[1] *= x;
   a[2] *= x;
+
   return (0);
 }
 


### PR DESCRIPTION
There was a small issue when calculating dv/ds_max at the start of a simulation. The wrong variable (an empty array) was being used to keep track of the direction of dv/ds_max and dv/ds_min causing `renorm()` to report an error and the directions not be recorded.

This didn't affect the calculation of dv/ds_{max/min}, but was a problem for recording the directions of the gradients.