### PR TITLE
corrections to matom and kpkt emissivities in the accelerated/matrix scheme 

### DIFF
--- a/source/macro_gen_f.c
+++ b/source/macro_gen_f.c
@@ -614,6 +614,7 @@ get_matom_f_accelerate (mode)
         {
           macromain[n].matom_emiss[j] += macromain[n].matom_abs[i] * matom_matrix[i][j];
         }
+        plasmamain[n].kpkt_emiss += macromain[n].matom_abs[i] * matom_matrix[i][nlevels_macro];
       }
 
       /* do the same for the thermal pool. we also normalise by banded_emiss_frac here */


### PR DESCRIPTION
This corrects a few errors in the accelerated/matrix scheme for obtaining macro-atom level emissivities. My understanding is that this has been the default macro-atom mode in the code recently (since 20 April by the looks of it), so these errors could be in various runs. 

The basic problems were:
* **Problem:** in the construction of the matrix (calc_matom_matrix), we were adding recombination cooling contributions as a jump from the thermal pool to continuum level, but this should only be a k->r transition. The error was really a typo, as it should have been using cooling_bf_col (collisional ionization) in this location - the recombination cooling is counted already.
    * **Solution:** simply change  cooling_bf to cooling_bf_col  around l.246 of macro_accelerate.c
* **Problem:** a closing bracket was in the wrong place in f_kpkt_emit_accelerate so that for loops were embedded inside for loops. Might have accidentally worked, but wrong and inefficient. 
    * **Solution:** move to correct place
* **Problem:** matom collisional ionization was being included in the normalisation of the banded k->r channels, and it shouldn't have been as this is a k->kappa contribution. 
    * **Solution:** only include this for simple ions (because collisional excitation of bf simple ions is, in effect, a k->r transition). 
* **Problem:** the kpkt emissivity wasn't including the contribution from packets absorbed into macro-atom levels that come out as k->r transitions (e.g. via r->A*->k->r). 
    * **Solution:** increment via: ```plasmamain[n].kpkt_emiss += macromain[n].matom_abs[i] * matom_matrix[i][nlevels_macro];``` statement in macro_gen_f.c 

This have all been fixed and the attached parameter file star_h10.pf now produces more or less identical emissivities with ACCELERATED_MACRO set to TRUE and FALSE. We should test the impact on Ed's continuum levels in the TDE models. 
[star_h10.pf.txt](https://github.com/agnwinds/python/files/6936755/star_h10.pf.txt)
