### PR TITLE
gcc-11 and optical depth code changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,8 +133,8 @@ set(RAD_HYDRO_SOURCE
         )
 
 set(OPTICAL_DEPTH_SOURCE
-        source/py_optical_depth.c source/py_optical_depth_transport.c
-        source/py_optical_depth_util.c source/py_optical_depth_output.c)
+        source/py_optd.c source/py_optd_trans.c
+        source/py_optd_util.c source/py_optd_output.c)
 
 # Create the executables for each program, and link the required libraries
 
@@ -151,8 +151,8 @@ add_executable(rad_hydro_files ${PYTHON_SOURCE} ${RAD_HYDRO_SOURCE})
 target_link_libraries(rad_hydro_files gsl gslcblas m)
 
 # py_optical_depth
-add_executable(py_optical_depth ${PYTHON_SOURCE} ${OPTICAL_DEPTH_SOURCE})
-target_link_libraries(py_optical_depth gsl gslcblas m)
+add_executable(py_optd ${PYTHON_SOURCE} ${OPTICAL_DEPTH_SOURCE})
+target_link_libraries(py_optd gsl gslcblas m)
 
 # Python
 add_executable(python source/python.c ${PYTHON_SOURCE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,8 @@ set(PYTHON_SOURCE
         source/wind2d.c source/wind_sum.c source/wind_updates2d.c
         source/wind_util.c source/windsave.c source/windsave2table_sub.c
         source/xlog.c source/xtest.c source/zeta.c source/macro_accelerate.c
-        source/macro_gen_f.c
+        source/macro_gen_f.c source/atomic_extern_init.c source/python_extern_init.c
+        source/models_extern_init.c
         )
 
 set(PY_WIND_SOURCE
@@ -132,9 +133,13 @@ set(RAD_HYDRO_SOURCE
         source/rad_hydro_files.c
         )
 
+set(INSPECT_WIND_SOURCE
+        source/inspect_wind.c
+        )
+
 set(OPTICAL_DEPTH_SOURCE
-        source/py_optd.c source/py_optd_trans.c
-        source/py_optd_util.c source/py_optd_output.c)
+        source/py_optd.c source/py_optd_trans.c source/py_optd_util.c
+        source/py_optd_output.c source/py_optd_extern_init.c)
 
 # Create the executables for each program, and link the required libraries
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -332,12 +332,12 @@ modify_wind_objects = modify_wind.o windsave.o  windsave2table_sub.o\
 
 
 modify_wind:  $(modify_wind_objects)
-	$(CC) $(CFLAGS) $(modify_wind_objects) $(LDFLAGS)  -o modify_wind               
+	$(CC) $(CFLAGS) $(modify_wind_objects) $(LDFLAGS) -o modify_wind
 	cp $@ $(BIN)                                                               
 	mv $@ $(BIN)/modify_wind$(VERSION)                                         
 	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi         
 
-py_optical_depth_objects = py_optical_depth.o py_optical_depth_transport.o py_optical_depth_output.o py_optical_depth_util.o \
+py_optd_obj = py_optd.o py_optd_output.o py_optd_trans.o py_optd_util.o \
 		bb.o atomicdata.o atomicdata_init.o atomicdata_sub.o photon2d.o photon_gen.o parse.o setup_files.o \
 		saha.o spectra.o wind2d.o wind.o  vvector.o recipes.o \
 		trans_phot.o phot_util.o resonate.o radiation.o estimators_simple.o\
@@ -357,10 +357,10 @@ py_optical_depth_objects = py_optical_depth.o py_optical_depth_transport.o py_op
 		setup_reverb.o setup_line_transfer.o rdpar_init.o cv.o import_calloc.o charge_exchange.o frame.o \
 		macro_accelerate.o
 
-py_optical_depth: startup $(py_optical_depth_objects)
-	$(CC) $(CFLAGS) $(py_optical_depth_objects) $(LDFLAGS)  -o py_optical_depth
+py_optd: startup $(py_optd_obj)
+	$(CC) $(CFLAGS) $(py_optd_obj) $(LDFLAGS) -o $@
 	cp $@ $(BIN)
-	mv $@ $(BIN)/py_optical_depth$(VERSION)
+	mv $@ $(BIN)/py_optd$(VERSION)
 	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi
 
 
@@ -368,7 +368,7 @@ py_optical_depth: startup $(py_optical_depth_objects)
 # The next line runs recompiles all of the routines after first cleaning the directory
 # all: clean run_indent python windsave2table py_wind
 
-all: clean python windsave2table py_wind indent rad_hydro_files modify_wind py_optical_depth
+all: clean python windsave2table py_wind indent rad_hydro_files modify_wind py_optd
 
 
 FILE = atomicdata.o atomicdata_init.o atomicdata_sub.o atomic.o

--- a/source/Makefile
+++ b/source/Makefile
@@ -338,8 +338,6 @@ modify_wind:  $(modify_wind_objects)
 	mv $@ $(BIN)/modify_wind$(VERSION)                                         
 	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi         
 
-py_optd_obj = py_optd.o py_optd_output.o py_optd_trans.o py_optd_util.o \
-
 
 inspect_wind_objects = inspect_wind.o windsave.o  windsave2table_sub.o\
 		emission.o recomb.o wind_util.o  \
@@ -366,7 +364,7 @@ inspect_wind:  $(inspect_wind_objects)
 	@if [ $(INDENT) = yes ] ; then  ../py_progs/run_indent.py -changed ; fi
 
 
-py_optical_depth_objects = py_optical_depth.o py_optical_depth_transport.o py_optical_depth_output.o py_optical_depth_util.o \
+py_optd_obj = py_optd.o py_optd_output.o py_optd_trans.o py_optd_util.o \
 		bb.o atomicdata.o atomicdata_init.o atomicdata_sub.o photon2d.o photon_gen.o parse.o setup_files.o \
 		saha.o spectra.o wind2d.o wind.o  vvector.o recipes.o \
 		trans_phot.o phot_util.o resonate.o radiation.o estimators_simple.o\
@@ -384,8 +382,8 @@ py_optical_depth_objects = py_optical_depth.o py_optical_depth_transport.o py_op
 		import.o import_spherical.o import_cylindrical.o import_rtheta.o  \
 		reverb.o paths.o setup.o run.o brem.o synonyms.o walls.o xtest.o \
 		setup_reverb.o setup_line_transfer.o rdpar_init.o cv.o import_calloc.o charge_exchange.o frame.o \
-		macro_accelerate.o \
-		atomic_extern_init.o python_extern_init.o  models_extern_init.o py_optical_depth_extern_init.o
+		macro_accelerate.o atomic_extern_init.o python_extern_init.o  models_extern_init.o \
+		py_optd_extern_init.o
 
 py_optd: startup $(py_optd_obj)
 	$(CC) $(CFLAGS) $(py_optd_obj) $(LDFLAGS) -o $@

--- a/source/atomic_proto.h
+++ b/source/atomic_proto.h
@@ -14,5 +14,6 @@ double a21(struct lines *line_ptr);
 double upsilon(int n_coll, double u0);
 int fraction(double value, double array[], int npts, int *ival, double *f, int mode);
 int linterp(double x, double xarray[], double yarray[], int xdim, double *y, int mode);
+void skiplines(FILE *fptr, int nskip);
 /* atomicdata_init.c */
 int init_atomic_data(void);

--- a/source/atomicdata.c
+++ b/source/atomicdata.c
@@ -302,7 +302,7 @@ structure does not have this property! */
             exit (0);
           }
           /* Immediate replace by number density relative to H */
-          ele[nelements].abun = pow (10., ele[nelements].abun - 12.0);  
+          ele[nelements].abun = pow (10., ele[nelements].abun - 12.0);
           nelements++;
           if (nelements > NELEMENTS)
           {
@@ -2389,8 +2389,7 @@ SCUPS    1.132e-01   2.708e-01   5.017e-01   8.519e-01   1.478e+00
           }
           if (match == 0)       //Fix for an error where a line match isn't found - this then causes the next two lines to be skipped
           {
-            fgets (aline, LINELENGTH, fptr);
-            fgets (aline, LINELENGTH, fptr);
+            skiplines (fptr, 2);
             cstren_no_line++;
           }
           break;

--- a/source/atomicdata_sub.c
+++ b/source/atomicdata_sub.c
@@ -927,3 +927,31 @@ linterp (x, xarray, yarray, xdim, y, mode)
   return (nelem);
 
 }
+
+
+
+
+/**********************************************************/
+/**
+ * @brief Skip the specified number of lines in a file
+ *
+ * @param[in, out] FILE *fptr  The file to skip lines for
+ * @param[in] int nskip        The number of lines to skip
+ *
+ * @details
+ * Reads a line in character by character until reaching the end of the line
+ * (denoted by a new line character \n) or until reaching the end of the
+ * file.
+ *
+ **********************************************************/
+
+void
+skiplines (FILE * fptr, int nskip)
+{
+  int i, c;
+
+  for (i = 0; i < nskip; ++i)
+  {
+    while (c = fgetc (fptr), c != '\n' && c != EOF);
+  }
+}

--- a/source/extract.c
+++ b/source/extract.c
@@ -398,14 +398,14 @@ extract_one (w, pp, itype, nspec)
   }
   else if (geo.binary == TRUE)
   {
-    istat = hit_secondary(pp); /* Check to see if it hit secondary */
+    istat = hit_secondary (pp); /* Check to see if it hit secondary */
   }
 
 /* Preserve the starting position of the photon so one can use this to determine whether the
  * photon encountered the disk or star as it tried to exist the wind.
  */
 
- tau = 0;
+  tau = 0;
   pp->ds = 0;
   icell = 0;
 /* Now we can actually extract the reweighted photon */
@@ -516,7 +516,7 @@ extract_one (w, pp, itype, nspec)
       /* Records the total distance travelled by extracted photon if in reverberation mode */
       if (geo.reverb != REV_NONE)
       {
-        if (pstart.nscat > 0 || pstart.origin > 9 || (pstart.nres > -1 && pstart.nres < nlines))
+        if (geo.reverb_filter_lines == -2 || pstart.nscat > 0 || pstart.origin > 9 || (pstart.nres > -1 && pstart.nres < nlines))
         {                       //If this photon has scattered, been reprocessed, or originated in the wind it's important
           pstart.w = pp->w * exp (-(tau));
           stuff_v (xxspec[nspec].lmn, pstart.lmn);

--- a/source/macro_gov.c
+++ b/source/macro_gov.c
@@ -77,10 +77,10 @@ macro_gov (p, nres, matom_or_kpkt, which_out)
     {
 
       /* if it's a bb transition of a full macro atom  */
-      if (*nres > (-1) && *nres < NLINES && geo.macro_simple == FALSE && lin_ptr[*nres]->macro_info == TRUE)
+      if (*nres > NRES_ES && *nres < NRES_BF && geo.macro_simple == FALSE && lin_ptr[*nres]->macro_info == TRUE)
       {
 
-        if (geo.matom_radiation == 1)
+        if (geo.matom_radiation == TRUE)
         {
           /* During the spectrum cycles we want to throw these photons away. */
           p->w = 0.0;
@@ -106,16 +106,16 @@ macro_gov (p, nres, matom_or_kpkt, which_out)
       }
 
       /*  if it's a bb transition  without the full macro atom treatment. */
-      else if (*nres > (-1) && *nres < NLINES && (geo.macro_simple == TRUE || lin_ptr[*nres]->macro_info == FALSE))
+      else if (*nres > NRES_ES && *nres < NRES_BF && (geo.macro_simple == TRUE || lin_ptr[*nres]->macro_info == FALSE))
       {
         fake_matom_bb (p, nres, &escape);
       }
 
       /* if it's bf tranisition of a full macro atom. */
-      else if (*nres > NLINES && phot_top[*nres - NLINES - 1].macro_info == TRUE && geo.macro_simple == FALSE)
+      else if (*nres > NRES_BF && phot_top[*nres - NLINES - 1].macro_info == TRUE && geo.macro_simple == FALSE)
       {
 
-        if (geo.matom_radiation == 1)
+        if (geo.matom_radiation == TRUE)
         {
           /* During the spectrum cycles we want to throw these photons away. */
           p->w = 0.0;
@@ -154,7 +154,7 @@ macro_gov (p, nres, matom_or_kpkt, which_out)
          In the new "simple emissivity" approach, we should never satisfy the do loop, and so an error
          is thrown and we exit. */
 
-      else if (*nres > NLINES && (phot_top[*nres - NLINES - 1].macro_info == FALSE || geo.macro_simple == TRUE))
+      else if (*nres > NRES_BF && (phot_top[*nres - NLINES - 1].macro_info == FALSE || geo.macro_simple == TRUE))
       {
         if (!modes.turn_off_upweighting_of_simple_macro_atoms)
         {
@@ -176,7 +176,7 @@ macro_gov (p, nres, matom_or_kpkt, which_out)
        section of the loop that deals with kpts */
     else if (matom_or_kpkt == KPKT)
     {
-      if (geo.matom_radiation == 1)
+      if (geo.matom_radiation == TRUE)
       {
         /* During the spectrum cycles we want to throw these photons away. */
         p->w = 0.0;

--- a/source/macro_gov.c
+++ b/source/macro_gov.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <stdint.h>
 #include <gsl/gsl_block.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_matrix.h>

--- a/source/matom.c
+++ b/source/matom.c
@@ -898,7 +898,7 @@ kpkt (p, nres, escape, mode)
     /* If reached this point, it is a FF destruction event */
     /* consult issues #187, #492 regarding free-free */
     *escape = TRUE;
-    *nres = -2;
+    *nres = NRES_FF;
     p->freq = one_ff (one, freqmin, freqmax);
     return (0);
   }
@@ -906,7 +906,7 @@ kpkt (p, nres, escape, mode)
   {
     /*this is ff at a frequency that is so low frequency that it is not worth tracking further */
     *escape = TRUE;
-    *nres = -2;
+    *nres = NRES_FF;
     p->istat = P_LOFREQ_FF;
     return (0);
   }
@@ -922,7 +922,7 @@ kpkt (p, nres, escape, mode)
       Error ("kpkt: Destroying kpkt by adiabatic cooling even though it is turned off.\n");
     }
     *escape = TRUE;
-    *nres = -2;
+    *nres = NRES_FF;
     p->istat = P_ADIABATIC;
 
     return (0);

--- a/source/phot_util.c
+++ b/source/phot_util.c
@@ -98,6 +98,7 @@ stuff_phot (pin, pout)
   pout->istat = pin->istat;
   pout->frame = pin->frame;
   pout->nres = pin->nres;
+  pout->line_res = pin->line_res;
   pout->nmacro = pin->nmacro;
   pout->nrscat = pin->nrscat;
   pout->nscat = pin->nscat;

--- a/source/photo_gen_matom.c
+++ b/source/photo_gen_matom.c
@@ -212,7 +212,7 @@ photo_gen_kpkt (p, weight, photstart, nphot)
     }
 
     p[n].freq = pp.freq;
-    p[n].nres = nres;
+    p[n].nres = p[n].line_res = nres;
     p[n].w = pp.w;
 
 
@@ -394,7 +394,7 @@ photo_gen_matom (p, weight, photstart, nphot)
 
 
     p[n].freq = pp.freq;
-    p[n].nres = nres;
+    p[n].nres = p[n].line_res = nres;
     p[n].frame = F_LOCAL;
 
 

--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -484,6 +484,8 @@ translate_in_wind (w, p, tau_scat, tau, nres)
   }
 
   p->nres = *nres;
+  if (p->nres > -1 && p->nres < nlines)
+    p->line_res = p->nres;
 
   return (p->istat = istat);
 }

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -195,6 +195,7 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     p[n].origin_orig = p[n].origin;
     p[n].np = n;
     p[n].ds = 0;
+    p[n].line_res = NRES_NOT_SET;
     p[n].frame = F_OBSERVER;
     if (geo.reverb != REV_NONE && p[n].path < 0.0)      // SWM - Set path lengths for disk, star etc.
       simple_paths_gen_phot (&p[n]);

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -870,7 +870,7 @@ photo_gen_star (p, r, t, weight, f1, f2, spectype, istart, nphot)
     p[i].istat = p[i].nscat = p[i].nrscat = p[i].nmacro = 0;
     p[i].grid = 0;
     p[i].tau = 0.0;
-    p[i].nres = -1;             // It's a continuum photon
+    p[i].nres = p[i].line_res = -1;     // It's a continuum photon
     p[i].nnscat = 1;
 
     if (spectype == SPECTYPE_BB)
@@ -978,7 +978,7 @@ photo_gen_disk (p, weight, f1, f2, spectype, istart, nphot)
     p[i].w = weight;
     p[i].istat = p[i].nscat = p[i].nrscat = p[i].nmacro = 0;
     p[i].tau = 0;
-    p[i].nres = -1;             // It's a continuum photon
+    p[i].nres = p[i].line_res = -1;     // It's a continuum photon
     p[i].nnscat = 1;
     if (geo.reverb_disk == REV_DISK_UNCORRELATED)
       p[i].path = 0;            //If we're assuming disk photons are uncorrelated, leave them at 0

--- a/source/py_optd.c
+++ b/source/py_optd.c
@@ -477,7 +477,7 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-freq_min"))    //NOTE: lower frequency boundary for optical depth spectrum
+    else if (!strcmp (argv[i], "-freq-min"))    //NOTE: lower frequency boundary for optical depth spectrum
     {
       char *check;
       arguments.u_freq_min = strtod (argv[i + 1], &check);
@@ -488,7 +488,7 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-freq_max"))    //NOTE: upper frequency boundary for optical depth spectrum
+    else if (!strcmp (argv[i], "-freq-max"))    //NOTE: upper frequency boundary for optical depth spectrum
     {
       char *check;
       arguments.u_freq_max = strtod (argv[i + 1], &check);

--- a/source/py_optd.c
+++ b/source/py_optd.c
@@ -199,6 +199,8 @@ evaluate_photoionization_edges (void)
   double c_frequency, c_optical_depth, c_column_density;
   double *optical_depth_values = NULL, *column_density_values = NULL;
   struct photon photon;
+  enum RunModeEnum original_run_mode = RUN_MODE;
+  RUN_MODE = RUN_MODE_NO_ES_OPACITY;
 
   Edges_t edges[] = {
     {"HLymanEdge", 3.387485e+15},
@@ -259,6 +261,7 @@ evaluate_photoionization_edges (void)
   free (inclinations);
   free (optical_depth_values);
   free (column_density_values);
+  RUN_MODE = original_run_mode;
 }
 
 /* ************************************************************************* */

--- a/source/py_optd.c
+++ b/source/py_optd.c
@@ -12,18 +12,18 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <math.h>
 #include <unistd.h>
 
 #include "atomic.h"
 #include "python.h"
-#include "py_optical_depth.h"
+#include "py_optd.h"
 
 struct CommandlineArguments
 {
   double u_freq_min;
   double u_freq_max;
 };
-
 
 /* ************************************************************************* */
 /**
@@ -129,7 +129,7 @@ create_optical_depth_spectrum (double u_freq_min, double u_freq_max)
     }
   }
 
-  d_freq = (freq_max - freq_min) / N_FREQ_BINS;
+  d_freq = (log10 (freq_max) - log10 (freq_min)) / N_FREQ_BINS;
   kbf_need (freq_min, freq_max);
 
   /*
@@ -139,17 +139,17 @@ create_optical_depth_spectrum (double u_freq_min, double u_freq_max)
   for (i = 0; i < n_inclinations; i++)
   {
     printf ("  - Creating spectrum: %s\n", inclinations[i].name);
-    c_frequency = freq_min;
+    c_frequency = log10 (freq_min);
 
     for (j = 0; j < N_FREQ_BINS; j++)
     {
       c_optical_depth = 0.0;
       c_column_density = 0.0;
 
-      err = create_photon (&photon, c_frequency, inclinations[i].lmn);
+      err = create_photon (&photon, pow (10, c_frequency), inclinations[i].lmn);
       if (err == EXIT_FAILURE)
       {
-        errormsg ("skipping photon of frequency %e\n", c_frequency);
+        errormsg ("skipping photon of frequency %e\n", pow (10, c_frequency));
         continue;
       }
 
@@ -342,14 +342,18 @@ print_help (void)
     "can also find the surface of the electron scattering photosphere using the -p\n"
     "option.\n\n"
     "Please see below for a list of all flags.\n\n"
-    "-h             Print this help message and exit.\n"
-    "-d ndom        Set the domain to launch photons from.\n"
-    "-p tau_stop    Integrate from outwards to find the electron scattering photosphere.\n"
+    "-h             Print this help message and exit\n"
+    "-d ndom        Set the domain to launch photons from\n"
+    "-p tau_stop    Integrate from outwards to find the electron scattering photosphere\n"
     "-cion nion     Extract the column density for an ion of number nion\n"
     "-freq_min min  The lower frequency boundary for optical depth spectra\n"
     "-freq_max max  The upper frequency boundary for optical depth spectra\n"
     "-classic       Use linear frequency transforms, to be used when Python was run\n"
-    "               in classic mode.\n" "--version    Print the version information and exit.\n";
+    "               in classic mode\n"
+    "--smax frac    Set the maximum fraction a photon can move in terms of cell distances\n"
+    "--version      Print the version information and exit.\n"
+    "--no-es        Do not include opacity contributions from electron scattering\n";
+
   printf ("%s", help);
 }
 
@@ -367,8 +371,6 @@ print_help (void)
  * default mode and query the user for the root name of the simulation.
  *
  * ************************************************************************** */
-
-#define ARGUMENT_LENGTH 24
 
 struct CommandlineArguments
 get_arguments (int argc, char *argv[])
@@ -403,17 +405,17 @@ get_arguments (int argc, char *argv[])
   n_read = 0;
   for (i = 1; i < argc; ++i)
   {
-    if (!strcmp (argv[i], "-h"))
+    if (!strcmp (argv[i], "-h"))        //NOTE: print help text
     {
       print_help ();
       exit (EXIT_SUCCESS);
     }
-    else if (!strcmp (argv[i], "-classic"))
+    else if (!strcmp (argv[i], "-classic"))     //NOTE: use linear frequency transforms
     {
       rel_mode = REL_MODE_LINEAR;
       n_read = i;
     }
-    else if (!strcmp (argv[i], "--version"))
+    else if (!strcmp (argv[i], "--version"))    //NOTE: print version number
     {
       printf ("Python version %s\n", VERSION);
       printf ("Built from git commit %s\n", GIT_COMMIT_HASH);
@@ -421,7 +423,7 @@ get_arguments (int argc, char *argv[])
         printf ("This version was compiled with %d files with uncommited changes\n", GIT_DIFF_STATUS);
       exit (EXIT_SUCCESS);
     }
-    else if (!strcmp (argv[i], "-cion"))
+    else if (!strcmp (argv[i], "-cion"))        //NOTE: extract column density for specific ion, rather than H
     {
       char *check;
       COLUMN_MODE = COLUMN_MODE_ION;
@@ -438,9 +440,9 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-p"))
+    else if (!strcmp (argv[i], "-p"))   //NOTE: run in photosphere mode
     {
-      MODE = RUN_MODE_ES_PHOTOSPHERE;
+      RUN_MODE = RUN_MODE_ES_PHOTOSPHERE;
       char *check;
       TAU_DEPTH = strtod (argv[i + 1], &check);
       if (*check != '\0')
@@ -450,7 +452,18 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-d"))
+    else if (!strcmp (argv[i], "--smax"))
+    {
+      char *check;
+      SMAX_FRAC = strtod (argv[i + 1], &check);
+      if (*check != '\0')
+      {
+        printf ("Unable to convert argument for -smax into a double");
+        exit (EXIT_FAILURE);
+      }
+      n_read = i++;
+    }
+    else if (!strcmp (argv[i], "-d"))   //NOTE: change the lanching domain for photons
     {
       char *check;
       N_DOMAIN = (int) strtol (argv[i + 1], &check, 10);
@@ -461,7 +474,7 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-freq_min"))
+    else if (!strcmp (argv[i], "-freq_min"))    //NOTE: lower frequency boundary for optical depth spectrum
     {
       char *check;
       arguments.u_freq_min = strtod (argv[i + 1], &check);
@@ -472,7 +485,7 @@ get_arguments (int argc, char *argv[])
       }
       n_read = i++;
     }
-    else if (!strcmp (argv[i], "-freq_max"))
+    else if (!strcmp (argv[i], "-freq_max"))    //NOTE: upper frequency boundary for optical depth spectrum
     {
       char *check;
       arguments.u_freq_max = strtod (argv[i + 1], &check);
@@ -481,6 +494,11 @@ get_arguments (int argc, char *argv[])
         printf ("Unable to convert argument provided for -freq_max to a double\n");
         exit (EXIT_FAILURE);
       }
+      n_read = i++;
+    }
+    else if (!strcmp (argv[i], "--no-es"))
+    {
+      RUN_MODE = RUN_MODE_NO_ES_OPACITY;
       n_read = i++;
     }
     else if (!strncmp (argv[i], "-", 1))
@@ -502,18 +520,18 @@ get_arguments (int argc, char *argv[])
   return arguments;
 }
 
-/* ************************************************************************* */
-/**
- * @brief  The main function of the program.
- *
- * @param  argc  The number of command line arguments
- * @param  argv  The command line arguments
- *
- * @return  EXIT_SUCCESS
- *
- * @details
- *
- * ************************************************************************** */
+  /* ************************************************************************* */
+  /**
+   * @brief  The main function of the program.
+   *
+   * @param  argc  The number of command line arguments
+   * @param  argv  The command line arguments
+   *
+   * @return  EXIT_SUCCESS
+   *
+   * @details
+   *
+   * ************************************************************************** */
 
 int
 main (int argc, char *argv[])
@@ -534,10 +552,10 @@ main (int argc, char *argv[])
   init_rand ((int) time (NULL));
 
   rel_mode = REL_MODE_FULL;     // this is updated in get_arguments if required
-  SMAX_FRAC = 0.01;
+  SMAX_FRAC = 1.0;
   DENSITY_PHOT_MIN = 1.e-10;
   COLUMN_MODE = COLUMN_MODE_RHO;
-  MODE = RUN_MODE_TAU_INTEGRATE;
+  RUN_MODE = RUN_MODE_TAU_INTEGRATE;
   N_DOMAIN = 0;
 
   struct CommandlineArguments arguments;
@@ -556,7 +574,7 @@ main (int argc, char *argv[])
 
   if (wind_read (windsave_filename) < 0)
   {
-    printf ("Unable to open %s\n", windsave_filename);
+    errormsg ("unable to open %s\n", windsave_filename);
     exit (EXIT_FAILURE);
   }
 
@@ -586,7 +604,7 @@ main (int argc, char *argv[])
    */
 
   printf ("\n");
-  if (MODE != RUN_MODE_ES_PHOTOSPHERE)
+  if (RUN_MODE != RUN_MODE_ES_PHOTOSPHERE)
   {
     if (COLUMN_MODE == COLUMN_MODE_ION)
     {
@@ -614,18 +632,18 @@ main (int argc, char *argv[])
    * to atomic data, which we should not need to worry about for this program
    */
 
-  if (MODE == RUN_MODE_TAU_INTEGRATE)
+  if (RUN_MODE == RUN_MODE_TAU_INTEGRATE || RUN_MODE == RUN_MODE_NO_ES_OPACITY)
   {
     evaluate_photoionization_edges ();
     create_optical_depth_spectrum (arguments.u_freq_min, arguments.u_freq_max);
   }
-  else if (MODE == RUN_MODE_ES_PHOTOSPHERE)
+  else if (RUN_MODE == RUN_MODE_ES_PHOTOSPHERE)
   {
     find_photosphere ();
   }
   else
   {
-    errormsg ("Mode %d is an unknown run mode, not sure how you got here so exiting the program\n", MODE);
+    errormsg ("Mode %d is an unknown run mode, not sure how you got here so exiting the program\n", RUN_MODE);
     exit (EXIT_FAILURE);
   }
 

--- a/source/py_optd.h
+++ b/source/py_optd.h
@@ -11,7 +11,7 @@
  *
  * ************************************************************************** */
 
-#define N_FREQ_BINS 100000  // todo: make this variable, as well
+#define N_FREQ_BINS 10000
 #define NAMELEN 32
 
 // Error message macro, adds the file name and line to the start of the error
@@ -74,7 +74,8 @@ int N_DOMAIN;
 enum {
   RUN_MODE_TAU_INTEGRATE = 0,
   RUN_MODE_ES_PHOTOSPHERE = 1,
-} MODE;
+  RUN_MODE_NO_ES_OPACITY = 2,
+} RUN_MODE;
 
 double TAU_DEPTH;
 

--- a/source/py_optd.h
+++ b/source/py_optd.h
@@ -77,7 +77,7 @@ typedef enum RunModeEnum {
   RUN_MODE_NO_ES_OPACITY = 2,
 } RunMode_t;
 
-extern RunMode_t MODE;
+extern RunMode_t RUN_MODE;
 
 extern double TAU_DEPTH;
 

--- a/source/py_optd.h
+++ b/source/py_optd.h
@@ -71,7 +71,7 @@ int N_DOMAIN;
 // integrated tau mode, which gets the integrated tau along the path. The other
 // mode aims to find the surface of the electron scattering photosphere
 
-enum {
+enum RunModeEnum {
   RUN_MODE_TAU_INTEGRATE = 0,
   RUN_MODE_ES_PHOTOSPHERE = 1,
   RUN_MODE_NO_ES_OPACITY = 2,

--- a/source/py_optd_extern_init.c
+++ b/source/py_optd_extern_init.c
@@ -6,15 +6,14 @@
 #include "atomic.h"
 #include "python.h"
 
-#include "py_optical_depth.h" 
+#include "py_optd.h"
 
- 
+
 int COLUMN_MODE;
 int COLUMN_MODE_ION_NUMBER;
 
 int N_DOMAIN;
 
-xmode MODE;
+RunMode_t RUN_MODE;
 
 double TAU_DEPTH;
-

--- a/source/py_optd_output.c
+++ b/source/py_optd_output.c
@@ -10,10 +10,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "atomic.h"
 #include "python.h"
-#include "py_optical_depth.h"
+#include "py_optd.h"
 
 /* ************************************************************************* */
 /**
@@ -154,11 +155,11 @@ write_optical_depth_spectrum (SightLines_t * inclinations, int n_inclinations, d
   }
   fprintf (fp, "\n");
 
-  c_frequency = freq_min;
+  c_frequency = log10 (freq_min);
   for (i = 0; i < N_FREQ_BINS; i++)
   {
-    c_wavelength = VLIGHT / c_frequency / ANGSTROM;
-    fprintf (fp, "%-15e %-15e ", c_frequency, c_wavelength);
+    c_wavelength = VLIGHT / pow (10, c_frequency) / ANGSTROM;
+    fprintf (fp, "%-15e %-15e ", pow (10, c_frequency), c_wavelength);
 
     for (j = 0; j < n_inclinations; j++)
     {

--- a/source/py_optd_trans.c
+++ b/source/py_optd_trans.c
@@ -15,7 +15,7 @@
 
 #include "atomic.h"
 #include "python.h"
-#include "py_optical_depth.h"
+#include "py_optd.h"
 
 static const double MAXDIFF = VCHECK / VLIGHT;  // For linear velocity requirement for photon transport
 
@@ -78,7 +78,7 @@ integrate_tau_across_cell (PhotPtr photon, double *c_column_density, double *c_o
     density = c_plasma_cell->density[COLUMN_MODE_ION_NUMBER];
   }
 
-  smax = smax_in_cell (photon);
+  smax = smax_in_cell (photon) * SMAX_FRAC;
   if (smax < 0)
   {
     errormsg ("smax %e < 0 in cell %d\n", smax, photon->grid);
@@ -130,7 +130,7 @@ integrate_tau_across_cell (PhotPtr photon, double *c_column_density, double *c_o
 
   kappa_total = 0;
 
-  if (MODE != RUN_MODE_ES_PHOTOSPHERE)
+  if (RUN_MODE != RUN_MODE_ES_PHOTOSPHERE)
   {
     if (geo.rt_mode == RT_MODE_2LEVEL)
     {
@@ -146,7 +146,10 @@ integrate_tau_across_cell (PhotPtr photon, double *c_column_density, double *c_o
     }
   }
 
-  kappa_total += klein_nishina (mean_freq) * c_plasma_cell->ne * zdom[n_domain].fill;
+  if(RUN_MODE != RUN_MODE_NO_ES_OPACITY)
+  {
+    kappa_total += klein_nishina (mean_freq) * c_plasma_cell->ne * zdom[n_domain].fill;
+  }
 
   /*
    * Increment the optical depth and column density variables and move the
@@ -226,7 +229,7 @@ integrate_tau_across_wind (PhotPtr photon, double *c_column_density, double *c_o
 
     p_istat = walls (&p_extract, photon, norm);
 
-    if (MODE == RUN_MODE_ES_PHOTOSPHERE)
+    if (RUN_MODE == RUN_MODE_ES_PHOTOSPHERE)
     {
       if (*c_optical_depth >= TAU_DEPTH)
       {
@@ -240,7 +243,7 @@ integrate_tau_across_wind (PhotPtr photon, double *c_column_density, double *c_o
    * star or disc, since we are aiming for the origin of the system
    */
 
-  if (MODE == RUN_MODE_TAU_INTEGRATE)
+  if (RUN_MODE == RUN_MODE_TAU_INTEGRATE)
   {
     if (p_istat == P_HIT_STAR || p_istat == P_HIT_DISK)
     {

--- a/source/py_optd_util.c
+++ b/source/py_optd_util.c
@@ -16,7 +16,7 @@
 
 #include "atomic.h"
 #include "python.h"
-#include "py_optical_depth.h"
+#include "py_optd.h"
 
 /* ************************************************************************* */
 /**
@@ -263,18 +263,7 @@ initialize_inclination_angles (int *n_angles)
 {
   SightLines_t *inclinations;
 
-  if (MODE == RUN_MODE_TAU_INTEGRATE)
-  {
-    if (zdom[N_DOMAIN].coord_type == SPHERICAL)
-    {
-      inclinations = outward_initialize_1d_model_angles (n_angles);
-    }
-    else
-    {
-      inclinations = outward_initialize_2d_model_angles (n_angles);
-    }
-  }
-  else
+  if (RUN_MODE == RUN_MODE_ES_PHOTOSPHERE)
   {
     if (zdom[N_DOMAIN].coord_type == SPHERICAL)
     {
@@ -283,6 +272,17 @@ initialize_inclination_angles (int *n_angles)
     else
     {
       inclinations = photosphere_2d_initialize_angles (n_angles);
+    }
+  }
+  else
+  {
+    if (zdom[N_DOMAIN].coord_type == SPHERICAL)
+    {
+      inclinations = outward_initialize_1d_model_angles (n_angles);
+    }
+    else
+    {
+      inclinations = outward_initialize_2d_model_angles (n_angles);
     }
   }
 
@@ -334,17 +334,18 @@ create_photon (PhotPtr p_out, double freq, double *lmn)
   p_out->x[0] = p_out->x[1] = p_out->x[2] = 0.0;
   stuff_v (lmn, p_out->lmn);
 
-  if (MODE == RUN_MODE_TAU_INTEGRATE)
-  {
-    move_phot (p_out, geo.rstar + DFUDGE);
-  }
-  else
+  if (RUN_MODE == RUN_MODE_ES_PHOTOSPHERE)
   {
     move_phot (p_out, zdom[N_DOMAIN].rmax - DFUDGE);
     for (i = 0; i < 3; ++i)
     {
       p_out->lmn[i] *= -1.0;    // Make the photon point inwards
     }
+
+  }
+  else
+  {
+    move_phot (p_out, geo.rstar + DFUDGE);
   }
 
   return EXIT_SUCCESS;

--- a/source/py_optical_depth.h
+++ b/source/py_optical_depth.h
@@ -11,7 +11,7 @@
  *
  * ************************************************************************** */
 
-#define N_FREQ_BINS 10000
+#define N_FREQ_BINS 100000  // todo: make this variable, as well
 #define NAMELEN 32
 
 // Error message macro, adds the file name and line to the start of the error

--- a/source/python.h
+++ b/source/python.h
@@ -1166,6 +1166,8 @@ typedef struct photon
                                    for continuum scattering, meaning 
                                    depends on matom vs non-matom. See headers of emission.c 
                                    or matom.c for details. */
+  int line_res;                 /* The line which a photon belongs to. A photon can tagged as a line, then continuum
+                                   scatter. line_res will still be tagged as the same line until it scatters off another line. */
   int nnscat;                   /* Used for the thermal trapping model of
                                    anisotropic scattering to carry the number of
                                    scattering to "extract" when needed for wind
@@ -1203,6 +1205,11 @@ typedef struct photon
   double ds;                    /* the distance a photon has moved since its creation or last interaction */
 }
 p_dummy, *PhotPtr;
+
+#define NRES_ES (-1)
+#define NRES_FF (-2)
+#define NRES_NOT_SET (-3)
+#define NRES_BF NLINES
 
 PhotPtr photmain;               /* A pointer to all of the photons that have been created in a subcycle. Added to ease 
                                    breaking the main routine of python into separate rooutines for inputs and 

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -490,7 +490,6 @@ string_process_from_command_line (question, dummy)
   {
     printf ("Exiting since rdpar got EOF in interactive mode\n");
     exit (0);
-    return (0);
   }
   else if (tdummy[0] == '\n')
   {                             //Use the current value

--- a/source/rdpar.c
+++ b/source/rdpar.c
@@ -502,7 +502,9 @@ string_process_from_command_line (question, dummy)
   }
   else if (tdummy[0] == '!')
   {
-    system (&tdummy[1]);        /* Send a command to the system */
+    if (system (&tdummy[1]) == -1)      /* Send a command to the system */
+      Error ("string_process_from_command_line: '%s' returned error code", tdummy[1]);
+
     return (REISSUE);
   }
   else if (strncmp (tdummy, "done", 4) == 0)

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -1113,7 +1113,7 @@ scatter (p, nres, nnscat)
         Exit (0);
       }
     }
-    else if (*nres == -2)
+    else if (*nres == NRES_FF)
     {                           /* This is a ff event (SS). */
       macro_gov (p, nres, 2, &which_out);       //ff always make a k-packet
     }
@@ -1129,7 +1129,7 @@ scatter (p, nres, nnscat)
      for a resonanant scatter. Note that nres may have changed especially for macro-atoms */
 
   p->nres = *nres;
-  if (*nres > -1 && *nres < nlines)
+  if (*nres > NRES_ES && *nres < nlines)
   {
     p->freq = lin_ptr[*nres]->freq;
   }
@@ -1141,11 +1141,11 @@ scatter (p, nres, nnscat)
      that ff and bf are only treated as scattering processes in macro-atom mode.
    */
 
-  if (*nres == -1)
+  if (*nres == NRES_ES)
   {
     compton_dir (p);
   }
-  else if (*nres == -2 || *nres > NLINES || geo.scatter_mode == SCATTER_MODE_ISOTROPIC)
+  else if (*nres == NRES_FF || *nres > NRES_BF || geo.scatter_mode == SCATTER_MODE_ISOTROPIC)
   {
     randvec (z_prime, 1.0);
     stuff_v (z_prime, p->lmn);
@@ -1164,7 +1164,7 @@ scatter (p, nres, nnscat)
   /* If we are in macro-atom mode, add the photon to the created wind spectrum.  For simple
      atoms the wind spectrum is constructed in sectra.c */
 
-  if (geo.rt_mode == RT_MODE_MACRO && *nres != -1)
+  if (geo.rt_mode == RT_MODE_MACRO && *nres != NRES_ES)
   {
     p->nmacro++;
     spec_add_one (p, SPEC_CWIND);

--- a/source/reverb.c
+++ b/source/reverb.c
@@ -108,7 +108,8 @@ delay_dump_prep (int restart_stat)
       fprintf (fptr, "# Python Version %s\n", VERSION);
       get_time (s_time);
       fprintf (fptr, "# Date	%s\n#  \n", s_time);
-      fprintf (fptr, "# \n#    Freq.     Lambda     Weight      Last X      Last Y      Last Z Scat. RScat      Delay Spec. Orig.  Res.\n");
+      fprintf (fptr, "#\n# %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s %-12s\n", "Np", "Freq.", "Lambda",
+               "Weight", "LastX", "LastY", "LastZ", "Scat.", "RScat.", "Delay", "Spec.", "Orig.", "Res.", "LineRes.");
     }
     fclose (fptr);
     Log ("delay_dump_prep: Thread %d successfully prepared file '%s' for writing\n", rank_global, delay_dump_file);
@@ -249,11 +250,9 @@ delay_dump (PhotPtr p, int np)
       if (delay < 0)
         subzero++;
 
-      fprintf (fptr,
-               "%10.5g %12.7g %10.5g %+10.5g %+10.5g %+10.5g %3d     %3d     %10.5g %5d %5d %5d\n",
-               p[nphot].freq, VLIGHT * 1e8 / p[nphot].freq, p[nphot].w,
-               p[nphot].x[0], p[nphot].x[1], p[nphot].x[2],
-               p[nphot].nscat, p[nphot].nrscat, delay, i - MSPEC, p[nphot].origin, p[nphot].nres);
+      fprintf (fptr, "%-12d %-12.5g %-12.7g %-12.5g %-12.5g %-12.5g %-12.5g %-12d %-12d %-12.5g %-12d %-12d %-12d %-12d\n",
+               p[nphot].np, p[nphot].freq, VLIGHT * 1e8 / p[nphot].freq, p[nphot].w, p[nphot].x[0], p[nphot].x[1], p[nphot].x[2],
+               p[nphot].nscat, p[nphot].nrscat, delay, i - MSPEC, p[nphot].origin, p[nphot].nres, p[nphot].line_res);
     }
   }
 

--- a/source/setup_reverb.c
+++ b/source/setup_reverb.c
@@ -193,8 +193,9 @@ get_meta_params (void)
   {
     //Should we filter any lines out?
     //If -1, blacklist continuum, if >0 specify lines as above and whitelist
+    //-2 dumps everything to disk, can be big!
     //Automatically include matom_lines
-    rdint ("Reverb.filter_lines(0=off,-1=continuum,>0=count)", &geo.reverb_filter_lines);
+    rdint ("Reverb.filter_lines(0=off,-1=continuum,-2=dumpall,>0=count)", &geo.reverb_filter_lines);
     if (geo.reverb_filter_lines > 0)
     {                           //If we're given a whitelist, allocate temp storage (up to 256 lines!)
       int temp[256], bFound;

--- a/source/signal.c
+++ b/source/signal.c
@@ -181,7 +181,9 @@ xsignal_rm (char *root)
 
     strcpy (command, "rm ");
     strcat (command, filename);
-    system (command);
+
+    if (system (command) == -1)
+      Error ("xsignal_rm: '%s' returned error status\n", command);
 
 #ifdef MPI_ON
   }

--- a/source/synonyms.c
+++ b/source/synonyms.c
@@ -109,7 +109,7 @@ char *new_names[] = { "Central_object.mass", "Central_object.radius",
   NULL
 };
 
-int number_of_names = 121;
+int number_of_names = 122;
 int synonyms_validated = 0;
 
 #define MIN(a,b) ((a)<b ? a:b)

--- a/source/synonyms.c
+++ b/source/synonyms.c
@@ -59,7 +59,7 @@ char *old_names[] = { "mstar", "rstar", "Disk.illumination.treatment", "disk.typ
   "BH.rad_type_to_make_wind", "BH.rad_type_in_final_spectrum", "BH.power_law_index",
   "low_energy_break", "high_energy_break",
   "lum_agn", "AGN.power_law_index", "@AGN.power_law_cutoff",
-  "AGN.lamp_post_height",
+  "AGN.lamp_post_height", "Reverb.filter_lines(0=off,-1=continuum,>0=count)",
   NULL
 };
 
@@ -105,7 +105,7 @@ char *new_names[] = { "Central_object.mass", "Central_object.radius",
   "Central_object.rad_type_to_make_wind", "Central_object.rad_type_in_final_spectrum", "Central_object.power_law_index",
   "Central_object.cloudy.low_energy_break", "Central_object.cloudy.high_energy_break",
   "Boundary_layer.luminosity", "Boundary_layer.power_law_index", "@Boundary_layer.power_law_cutoff",
-  "Central_object.lamp_post_height",
+  "Central_object.lamp_post_height","Reverb.filter_lines(0=off,-1=continuum,-2=dumpall,>0=count)",
   NULL
 };
 

--- a/source/templates.h
+++ b/source/templates.h
@@ -26,6 +26,7 @@ double a21(struct lines *line_ptr);
 double upsilon(int n_coll, double u0);
 int fraction(double value, double array[], int npts, int *ival, double *f, int mode);
 int linterp(double x, double xarray[], double yarray[], int xdim, double *y, int mode);
+void skiplines(FILE *fptr, int nskip);
 /* python.c */
 int main(int argc, char *argv[]);
 /* photon2d.c */


### PR DESCRIPTION
This PR contains a few changes to do with gcc-11, cleaning up some warning messages and:

- Adds a missing include
- The optical depth program has some new features, and has been renamed to py_optd. The new features are explained in `py_optd -h`
- Adds a new delay dump "dump all" mode which can be used to create the figures Matt and I use to display photon weight by wind cell (i.e. the contour plot in my optical paper), or to re-construct spectra of only certain interactions (optical paper again)
- Removed some trailing whitespace (oops) and indented, so the PR looks bigger than it is

No changes in the regression tests (with fixed seed) compared to the current dev I am merging into