### PR TITLE
Bug916 static

### DIFF
--- a/source/get_models.c
+++ b/source/get_models.c
@@ -58,6 +58,48 @@
 /// Needed so can initialize nmods_tot the first time this routine is called
 int get_models_init = 0;
 
+
+/**********************************************************/
+/**
+ * @brief      Allocate space for detialed models
+ *
+ * @param [in] nmods   The number of elements in the model domain to allocate
+ * @return     Returns 0 unless there is insufficient space, in which
+ * case the routine will call the program to exits
+ *
+ * @details
+ *
+ * ### Notes ###
+ *
+ **********************************************************/
+
+int
+calloc_models (nmods)
+     int nmods;
+{
+
+  if (mods != NULL)
+  {
+    free (mods);
+  }
+
+  mods = (ModelPtr) calloc (sizeof (model_dummy), nmods);
+
+  if (mods == NULL)
+  {
+    Error ("There is a problem in allocating memory for the detailed model spectra\n");
+    Exit (0);
+  }
+  else
+  {
+    Log
+      ("Allocated %10d bytes for each of %5d elements of             totaling %10.1f Mb\n",
+       sizeof (model_dummy), nmods, 1.e-6 * nmods * sizeof (model_dummy));
+  }
+
+  return (0);
+}
+
 /**********************************************************/
 /**
  * @brief     This routine reads in a set of models for use in generation of spectra,
@@ -139,6 +181,7 @@ get_models (modellist, npars, spectype)
     nmods_tot = 0;
     ncomps = 0;                 // The number of different sets of models that have been read in
     get_models_init = 1;
+    calloc_models (NMODS);
   }
 
   /* Now check if this set of models has been read in previously.  If so return the

--- a/source/models.h
+++ b/source/models.h
@@ -28,15 +28,15 @@ extern int nmods_tot;                  // The total number of models that have b
 /* This is the structure that describes an individual continuum model. 
  * mods is the set of all models that are read
  */
-struct Model
+typedef struct Model
 {
   char name[LINELEN];
   double par[NPARS];
   double w[NWAVES];
   double f[NWAVES];
   int nwaves;
-};
-extern struct Model mods[NMODS];
+} model_dummy, *ModelPtr;
+extern ModelPtr  mods;
 
 /* There is one element of comp for each set of models of the same type, i.e. if
 one reads in a list of WD atmosphers this will occupy one componenet here */

--- a/source/models_extern_init.c
+++ b/source/models_extern_init.c
@@ -6,13 +6,12 @@
 
 #include "atomic.h"
 #include "python.h"
-#include "models.h" 
+#include "models.h"
 
- 
+
 int ncomps;                     // The number of components that have been read.  
 int nmods_tot;                  // The total number of models that have been read in 
 
-struct Model mods[NMODS];
+ModelPtr mods;
 
 struct ModSum comp[NCOMPS];
-


### PR DESCRIPTION
This change uses calloc to add space for detailed models instead of having this part of static memory.  It is intended to adderess #916