### PR TITLE
Fix to classic mode transformations

### DIFF
--- a/source/disk_init.c
+++ b/source/disk_init.c
@@ -17,7 +17,7 @@
 #include "python.h"
 
 
-#define STEPS 100000
+#define STEPS 1000000
 
 
 

--- a/source/frame.c
+++ b/source/frame.c
@@ -710,7 +710,14 @@ lorentz_transform (p_in, p_out, v)
 
   if (rel_mode == REL_MODE_LINEAR)
   {
-    f_out = p_out->freq = f_in * (1. - vel / VLIGHT);
+    if (p_in->frame == F_LOCAL)
+    {
+      f_out = p_out->freq = f_in * (1. - vel / VLIGHT);
+    }
+    else
+    {
+      f_out = p_out->freq = f_in / (1. + vel / VLIGHT);
+    }
     return (ierr);
   }
 

--- a/source/setup_disk.c
+++ b/source/setup_disk.c
@@ -78,6 +78,18 @@ get_disk_params ()
   sprintf (values, "%d,%d", DISK_TPROFILE_STANDARD, DISK_TPROFILE_READIN);
   geo.disk_tprofile = rdchoice ("Disk.temperature.profile(standard,readin)", values, answer);
 
+  /*Initialize disk rmin to something plausible */
+
+  geo.disk_rad_min = geo.rstar;
+  if (geo.disk_rad_min < GRAV * geo.mstar / (VLIGHT * VLIGHT))
+  {
+    Error ("disk_init: Central object size %.1e is less than R_g %.1e, so initialising to R_g \n", geo.rstar,
+           GRAV * geo.mstar / (VLIGHT * VLIGHT));
+    geo.disk_rad_min = GRAV * geo.mstar / (VLIGHT * VLIGHT);
+  }
+
+
+
 
   if (geo.disk_tprofile == DISK_TPROFILE_STANDARD)
   {
@@ -97,14 +109,22 @@ get_disk_params ()
 
     if (geo.disk_type == DISK_WITH_HOLE)
     {
-      geo.disk_rad_min = geo.rstar;
+// geo.disk_rad_min has already been intialized
+//      geo.disk_rad_min = geo.rstar;
       rddoub ("Disk.radmin(cm)", &geo.disk_rad_min);
-    }
-    else
-    {
-      geo.disk_rad_min = geo.rstar;
-    }
 
+      if (geo.disk_rad_min < GRAV * geo.mstar / (VLIGHT * VLIGHT))
+      {
+        Error ("disk_init: disk rad min %.1e is less than R_g %.1e, so exiting \n", geo.disk_rad_min, GRAV * geo.mstar / (VLIGHT * VLIGHT));
+        Exit (1);
+      }
+    }
+//    else
+//    {
+//      geo.disk_rad_min = geo.rstar;
+//    }
+
+    geo.disk_rad_max = 30 * geo.disk_rad_min;
     rddoub ("Disk.radmax(cm)", &geo.disk_rad_max);
 
   }

--- a/source/setup_star_bh.c
+++ b/source/setup_star_bh.c
@@ -91,7 +91,16 @@ get_stellar_params ()
   }
 
   rddoub ("Central_object.radius(cm)", &geo.rstar);
-  geo.disk_rad_min = geo.rstar; //Normally this is what we want
+  if (geo.rstar < 6. * GRAV * geo.mstar / (VLIGHT * VLIGHT))
+  {
+    Log ("Warning: Central object size %.1e is less than ISCO %.1e\n", geo.rstar, 6. * GRAV * geo.mstar / (VLIGHT * VLIGHT));
+    geo.disk_rad_min = 6. * GRAV * geo.mstar / (VLIGHT * VLIGHT);
+
+  }
+  else
+  {
+    geo.disk_rad_min = geo.rstar;       //Normally this is what we want
+  }
 
 
   geo.rstar_sq = geo.rstar * geo.rstar;


### PR DESCRIPTION
Fix to classic mode frame transformations to avoid second order 
effects that cause photons transforming into and out of the local frame
to preferentially acquire a redshift.

(Note that this was an error that occur ed when frame.c was refactored)

Better checking of disk parameters, especially for situations
where the central object and disk are separated to prevent the
disk from having velocities exceed the speed of light