### PR TITLE
Fix for problem #967 with incorrect temperatures of disk when disk inner radius exceeds r_star

### DIFF
--- a/source/disk.c
+++ b/source/disk.c
@@ -25,7 +25,9 @@
 /** 
  * @brief      Calculate the temperature of the disk at a normalised distance x
  *
- * @param [in] double  x   distance from center of disk in units of r/rstar
+ * @param [in] double  x   distance from center of disk in units of the minimum
+ * radius of the disk
+
  * @return     The temperature
  *
  * The routine returns the effective temperature for the disk as a distance
@@ -43,6 +45,9 @@
  *
  *
  * ###Notes###
+ *
+ * For disks that start at a radius that is larger than r_star, the temperature
+ * is based on the minimum radius.
  *
  * A reference for the standard steady state disk is Wade, 1984 MNRAS 208, 381
  *
@@ -70,12 +75,12 @@ teff (x)
   }
 
 
-  if ((geo.disk_tprofile == DISK_TPROFILE_READIN) && ((x * geo.rstar) < blmod.r[blmod.n_blpts - 1]))
+  if ((geo.disk_tprofile == DISK_TPROFILE_READIN) && ((x * geo.disk_rad_min) < blmod.r[blmod.n_blpts - 1]))
   {
     /* This is the case where the temperature profile is read in as an array, and so we
        simply find the array elements that bracket the requested radius and do a linear
        interpolation to calcualte the temperature at the requested radius. */
-    if ((r = (x * geo.rstar)) < blmod.r[0])
+    if ((r = (x * geo.disk_rad_min)) < blmod.r[0])
     {
       return (blmod.t[0]);
     }
@@ -87,11 +92,11 @@ teff (x)
   }
   else
   {
-    double t, r;
-    r = geo.rstar;
-    t = 3. * GRAV / (8. * PI * STEFAN_BOLTZMANN) * geo.mstar * geo.disk_mdot / (r * r * r);
-    t = pow (t, 0.25);
     /* This is a standard accretion disk */
+    double t, r;
+    r = geo.disk_rad_min;
+    t = 3. * GRAV / (8. * PI * STEFAN_BOLTZMANN) * geo.mstar * geo.disk_mdot / (r * r * r);
+    t = pow (t, 0.25);          /*This is the chaacteristic temperature */
 
     q = (1.e0 - pow (x, -0.5e0)) / (x * x * x);
     q = t * pow (q, 0.25e0);
@@ -110,7 +115,7 @@ teff (x)
        * the requested r
        * 
        */
-      r = x * geo.rstar;        // 04aug -- Requires fix if disk does not extend to rstar
+      r = x * geo.disk_rad_min;
       kkk = 1;                  // photon cannot hit the disk at r<qdisk.r[0]
       while (r > qdisk.r[kkk] && kkk < NRINGS - 1)
         kkk++;

--- a/source/knigge.c
+++ b/source/knigge.c
@@ -432,9 +432,9 @@ double
 kn_vzero (r)
      double r;
 {
-  double t, teff ();
+  double t;
   double ratio, v;
-  ratio = r / geo.rstar;
+  ratio = r / geo.disk_rad_min;
   if (ratio < kfudge)
     ratio = kfudge;
   t = teff (ratio);
@@ -476,7 +476,7 @@ kn_wind_mdot_integral (double r, void *params)
   double x, ratio;
 
 
-  ratio = r / geo.rstar;
+  ratio = r / geo.disk_rad_min;
   if (ratio < kfudge)
     ratio = kfudge;
   t = teff (ratio);
@@ -515,7 +515,7 @@ kn_rho_zero (ndom, r)
   one_dom = &zdom[ndom];
 
 
-  ratio = r / geo.rstar;
+  ratio = r / geo.disk_rad_min;
 
   if (ratio < kfudge)
     ratio = kfudge;

--- a/source/macro_gen_f.c
+++ b/source/macro_gen_f.c
@@ -26,7 +26,7 @@
 /** 
  * @brief      returns the specific band-limited luminosity in macro-atoms
  *
- * @param [in] int  mode   vvariable which controls whether or not we need to compute the
+ * @param [in] int  mode   variable which controls whether or not we need to compute the
  *            emissivities (CALCULATE_MATOM_EMISSIVITIES) or use stored ones
  *            because we are restarting a spectral cycle (USE_STORED_MATOM_EMISSIVITIES)
  *            see #define statements in python.h and code in xdefine_phot().

--- a/source/python.h
+++ b/source/python.h
@@ -112,9 +112,9 @@ extern int NWAVE_NOW;                  //Either NWAVE_IONIZ or NWAVE_EXTRACT dep
 #include "math_struc.h"
 
 
-/* Geometry is an actual structure which exists at the beginning of th program
+/* Geometry is an actual structure which exists at the beginning of the program
    It carries the variables which define the geometry.  Reasonable values of each of
-   these should be defined before it is altered with inputs fromt eh terminal. 
+   these should be defined before it is altered with inputs from the terminal. 
    The geometry structure is used to transfer all of the information about a wind
 
 


### PR DESCRIPTION
The basic problem was that the wrong numbers were being passed to t_eff and that t_eff had not been modified to recognize the situation where the inner disk radius was greater than r_star