### PR TITLE
Proposed smax fix for W_IGNORE cells, see #973 #974

### DIFF
--- a/source/photon2d.c
+++ b/source/photon2d.c
@@ -445,7 +445,7 @@ translate_in_wind (w, p, tau_scat, tau, nres)
      Note that ds_current does not alter p in any way */
 
 
-  if (modes.partial_cells == PC_EXTEND && one->inwind == W_PART_INWIND)
+  if ( (modes.partial_cells == PC_EXTEND && one->inwind == W_PART_INWIND) || one->inwind == W_IGNORE)
   {
     ds_current = smax;
     istat = 0;
@@ -457,7 +457,6 @@ translate_in_wind (w, p, tau_scat, tau, nres)
   else
   {
     ds_current = calculate_ds (w, p, tau_scat, tau, nres, smax, &istat);
-//  }
 
     if (p->nres < 0)
       xplasma->nscat_es++;
@@ -567,8 +566,8 @@ smax_in_cell (PhotPtr p)
   else if (one->inwind == W_IGNORE)
   {
     smax += one->dfudge;
-    move_phot (p, smax);
-    return (p->istat);
+    //move_phot (p, smax);
+    return (smax);
   }
   else if (one->inwind == W_NOT_INWIND)
   {                             /* The cell is not in the wind at all */
@@ -576,7 +575,7 @@ smax_in_cell (PhotPtr p)
     Error ("translate_in_wind: Grid cell %d of photon is not in wind, moving photon %.2e\n", n, smax);
     Error ("translate_in_wind: photon %d position: x %g y %g z %g\n", p->np, p->x[0], p->x[1], p->x[2]);
     move_phot (p, smax);
-    return (p->istat);
+    return (smax);
 
   }
 


### PR DESCRIPTION
This is a proposed fix/workaround for issues #973 and #974. The segfault was happening because we were trying to move a photon through a cell that had been flagged as W_IGNORE and presumably not everything had been initialised properly in that cell. In the process I also realised we were moving the photon by smax twice because smax_in_cell was moving the photon as well as translate_in_wind. 

This fix adds a clause to the if statement so that we treat W_IGNORE cells like not in wind cells, which seems reasonable, and also removes the move_phot call in smax_in_cell. 

Caveats/questions here are:
* currently the smax_in_cell routine still moves the photon in the not in wind case - perhaps we should removed this too? As far as I can tell smax_in_cell only gets called by translate_in_wind, and is also used by Ed's optical depth program. 
* The W_IGNORE cell was ignored because it had "zero volume but one corner in wind". I don't understand why this situation hapenned in the first place. 