### PR TITLE
Fixes failure to restart when a readin disk temperature profile, see …

### DIFF
--- a/source/disk_init.c
+++ b/source/disk_init.c
@@ -430,7 +430,7 @@ qdisk_save (diskfile, ztot)
  *
  * Each line of the input file
  * a radius and a temperature in the first two columns.
- * An optinional 3rd column can contain a gravity
+ * An optional 3rd column can contain a gravity
  * for use with stellar atmospheres models
  *
  * Comment lines (and other lines) that can not
@@ -441,7 +441,7 @@ qdisk_save (diskfile, ztot)
  * The temperature in degrees Kelvin
  *
  * The minimum and maximum radius of the disk is set to the minimum
- * and maximum radius of the disk.  If the 
+ * and maximum radius of the disk.  e 
  *
  * ###Notes###
  *
@@ -452,7 +452,6 @@ qdisk_save (diskfile, ztot)
  * mdot and a standard model to describe the disk.  This has been
  * changed so that if one reads in a non standard temperature
  * profile, it must include the entire disk..
- *
  *
  **********************************************************/
 
@@ -501,7 +500,7 @@ read_non_standard_disk_profile (tprofile)
     }
     else
     {
-      Error ("read_non_standard_disk_file: could not convert a line in %s, OK if comment\n", tprofile);
+      Error ("read_non_standard_disk_file: Could not convert a line in %s, OK if comment\n", tprofile);
     }
 
     if (blmod.n_blpts == NBLMODEL)
@@ -538,7 +537,6 @@ read_non_standard_disk_profile (tprofile)
   }
 
 
-
   fclose (fptr);
 
   geo.disk_rad_min = 0;
@@ -566,7 +564,10 @@ read_non_standard_disk_profile (tprofile)
       geo.disk_rad_min = geo.rstar;;
     }
   }
+
   geo.disk_rad_max = blmod.r[blmod.n_blpts - 1];
+      geo.disk_mdot = 0;
+
 
   return (0);
 }

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -104,14 +104,15 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
   }
 
   if (freq_sampling == 0)
-  {                             /* Original approach, uniform sampling of entire wavelength interval,
-                                   still used for detailed spectrum calculation */
+  {
+    /* Original approach, uniform sampling of entire wavelength interval,
+       still used for detailed spectrum calculation */
 
     if (f1 != f1_old || f2 != f2_old || iwind != iwind_old)
     {                           // The reinitialization is required
       xdefine_phot (f1, f2, ioniz_or_final, iwind, PRINT_ON, 1);
     }
-    /* The weight of each photon is designed §so that all of the photons add up to the
+    /* The weight of each photon is designed so that all of the photons add up to the
        luminosity of the photosphere.  This implies that photons must be generated in such
        a way that it mimics the energy distribution of the star. */
 
@@ -123,9 +124,10 @@ define_phot (p, f1, f2, nphot_tot, ioniz_or_final, iwind, freq_sampling)
     xmake_phot (p, f1, f2, ioniz_or_final, iwind, weight, 0, nphot_rad);
   }
   else
-  {                             /* Use banding, create photons with different weights in different wavelength
-                                   bands.  This is used for the for ionization calculation where one wants to assure
-                                   that you have "enough" photons at high energy */
+  {
+    /* Use banding, create photons with different weights in different wavelength
+       bands.  This is used for the for ionization calculation where one wants to assure
+       that you have "enough" photons at high energy */
 
     ftot = populate_bands (ioniz_or_final, iwind, &xband);
 

--- a/source/python.c
+++ b/source/python.c
@@ -199,8 +199,7 @@ main (argc, argv)
     if (geo.disk_tprofile == DISK_TPROFILE_READIN)      //We also need to re-read in any previously used disk temperature profile
     {
       rdstr ("Disk.T_profile_file", files.tprofile);
-      geo.disk_rad_max = read_non_standard_disk_profile (files.tprofile);
-      geo.disk_mdot = 0;
+      read_non_standard_disk_profile (files.tprofile);
     }
     if (geo.pcycle > 0)
     {

--- a/source/setup_disk.c
+++ b/source/setup_disk.c
@@ -132,7 +132,6 @@ get_disk_params ()
   {
     rdstr ("Disk.T_profile_file", files.tprofile);
     read_non_standard_disk_profile (files.tprofile);
-    geo.disk_mdot = 0;
   }
   else
   {


### PR DESCRIPTION
… #987

The problem was that lines in python.c expected the geo.disk_rad_max to be returned, but read_non_standard_disk always returns 0, having set geo.disk_rad_max at the end of the subroutine.