### PR TITLE
Grid save: allow user to save wind grid & quit without running cycles

### DIFF
--- a/source/parse.c
+++ b/source/parse.c
@@ -253,6 +253,12 @@ parse_command_line (argc, argv)
         j = i;
       }
 
+      else if (strcmp (argv[i], "--grid-only") == 0)
+      {
+        modes.quit_after_wind_defined = 1;
+        j = i;
+      }
+
       else if (strcmp (argv[i], "--version") == 0)
       {
         /* give information about the pyhon version, such as commit hash */
@@ -362,6 +368,7 @@ and the switches have the following meanings \n\
                         the amount printed; smaller numbers decrease it.   \n\
  --dry-run              Create a new .pf file and stop \n\
  -i                     Same as --dry-run \n\
+ --grid-only            Define the wind grid and save to wind_save file, then stop \n\
  --version              Print out python version, commit hash and if there were files with uncommitted \n\
                         changes and stop \n\
  --rseed                Set the random number seed to be time-based, rather than fixed. \n\

--- a/source/python.c
+++ b/source/python.c
@@ -620,6 +620,16 @@ main (argc, argv)
   xsignal (files.root, "%-20s Finished initialization for %s\n", "NOK", files.root);
   check_time (files.root);
 
+  /* allow the user to quit after the wind has been defined */
+  if (modes.quit_after_wind_defined)
+  {
+    wind_save (files.windsave);
+    Log ("This was was run with the ---grid-only flag set, so quitting now wind has been defined.\n");
+    error_summary ("wind definition only (--grid-only).");
+    exit (0);
+  }
+
+
   /* Allow for the possibility of running a special diagnostic mode in
      a stand alone routine xtest. This will happen with the command line
      option -xtest.  */

--- a/source/python.h
+++ b/source/python.h
@@ -1560,6 +1560,7 @@ struct advanced_modes
   int quit_after_inputs;        /**< when TRUE, quit after inputs are read in.  Note that
                                   ** this flag is set from the command line with the -i option
                                   */
+  int quit_after_wind_defined;  /**< when TRUE, quit after the wind grid has been defined and saved */
   int fixed_temp;               /**< do not alter temperature from that set in the parameter file */
   int zeus_connect;             /**< We are connecting to zeus, do not seek new temp and output 
                                   * a heating and cooling file

--- a/source/setup.c
+++ b/source/setup.c
@@ -323,6 +323,7 @@ init_advanced_modes ()
   modes.use_debug = FALSE;
   modes.print_dvds_info = FALSE;        // print information on velocity gradients
   modes.quit_after_inputs = FALSE;      // check inputs and quit
+  modes.quit_after_wind_defined = FALSE;      // define wind and quit
   modes.fixed_temp = FALSE;     // do not attempt to change temperature 
   modes.zeus_connect = FALSE;   // connect with zeus
 


### PR DESCRIPTION
This proposed change adds a new flag, ```--grid-only``` to be used from the CL. If this flag is on, it sets ```modes.quit_after_wind_defined = 1```. 

If this mode is on, the code quits before running any cycles or producing any spectra, but will save a wind_save file. Much of that wind save file will be useless, but it will allow a user to check the wind grid and the populated densities and velocities, which could be useful for verifying imported models, or for seeing how different wind parameters change the density-velocity space populated by the model. 

