### PR TITLE
fix extract for bubble and lamp-post PL sources

### DIFF
--- a/source/extract.c
+++ b/source/extract.c
@@ -287,7 +287,7 @@ extract (w, p, itype)
        * thesis
      */
 
-    if (itype == PTYPE_STAR || itype == PTYPE_BL || itype == PTYPE_AGN)
+    if (itype == PTYPE_STAR || itype == PTYPE_BL || (itype == PTYPE_AGN && geo.pl_geometry == PL_GEOMETRY_SPHERE))
     {
       stuff_v (pp.x, x);
       renorm (x, 1.);


### PR DESCRIPTION
In extract, a reweighting is applied which applies the Eddington approximation. The lines that do this are as follows:

```C
    if (itype == PTYPE_STAR || itype == PTYPE_BL ||itype == PTYPE_AGN)
    {
      stuff_v (pp.x, x);
      renorm (x, 1.);
      zz = fabs (dot (x, pp.lmn));
      pp.w *= zz * (2.0 + 3.0 * zz);
    }
```

This is applied for all central sources of type AGN, BL or STAR, regardless of the "geometry" of the AGN (i.e. whether ```geo.pl_geometry``` has been set to BUBBLE, LAMPPOST or SPHERE). This should only really be applied when the SPHERE source is being used (since all the others used random isotropic directions and no weighting factor here is applied.

This bug will lead to a factor ~2 flux difference (because zz averages to 1/2) at low inclinations, but only for BUBBLE or LAMPPOST, which are "beta" modes that haven't been used in anger. The fix is simply to make the if statement
```if (itype == PTYPE_STAR || itype == PTYPE_BL || (itype == PTYPE_AGN && geo.pl_geometry == PL_GEOMETRY_SPHERE))```