### PR TITLE
Don't record Compton heating as a contributor to kpkt_abs

### DIFF
--- a/source/estimators_macro.c
+++ b/source/estimators_macro.c
@@ -223,7 +223,13 @@ bf_estimators_increment (one, p, ds)
 
   y = weight_of_packet * kappa_ff (xplasma, freq_av) * ds;
 
-  xplasma->heat_ff += heat_contribution = y;    // record ff hea        
+  xplasma->heat_ff += heat_contribution = y;    // record ff hea   
+
+  /* This heat contribution is also the contibution to making k-packets in this volume. So we record it. */
+  /* JM 2402 note that previously we incorrectly included Compton processes in kpkt_abs, which could lead to large 
+     amounts of radiation coming out incorrectly in other k->r channels in spectral cycles */
+  xplasma->kpkt_abs += heat_contribution;
+     
 
 
   /* Now for contribution to heating due to compton processes. (JM, Sep 013) */
@@ -244,32 +250,6 @@ bf_estimators_increment (one, p, ds)
 
 
   xplasma->heat_tot += heat_contribution;       // heat contribution is the contribution from compton, ind comp and ff processes
-
-
-
-  /* This heat contribution is also the contibution to making k-packets in this volume. So we record it. */
-
-  xplasma->kpkt_abs += heat_contribution;
-
-
-  /* Now for contribution to inner shell ionization estimators (SS, Dec 08) */
-  /* Commented out by NSH 2018 - data no longer used */
-  // for (n = 0; n < nauger; n++)
-  // {
-  //   ft = augerion[n].freq_t;
-  //   if (freq_av > ft)
-  //   {
-  //     Log ("estimators: Adding a packet to AUGER %g \n", freq_av);
-
-  //     weight_of_packet = p->w;
-  //     x = sigma_phot_verner (&augerion[n], freq_av);    //this is the cross section
-  //     y = weight_of_packet * x * ds;
-
-  //     xplasma->gamma_inshl[n] += y / freq_av / PLANCK / xplasma->vol;
-  //   }
-  // }
-
-
 
   return (0);
 }


### PR DESCRIPTION
This is a (hopefully temporary) fix for the problems we have been having with TDE models where the wind (or k->r) luminosity in spectral cycles is much higher than it should be (or compared to the ion cycles). 

The issue is that we include Compton and induced Compton heating as a contributor to ```kpkt_abs```, although we don't actually allow r->k transitions from Compton, or k->r transitions. This means the ionization cycles were sort of doing things "correctly" in that they aren't modelling the flow of energy through the thermal pool from Compton processes (correctly in the case that they are dominant and roughly balance each other, or are both negligible). However, in the spectral cycles we have all this extra energy in kpkt_abs which has to come out somewhere, so it comes out in all the free-free and bound-free processes and so on. 

Note, that we do reweight packets when Compton scatters happen, the thing that is missing is the machinery to allow Compton processes to communcate correctly/self-consistently with the k-packet pool.  

This current fix simply moves a line of code up so that kpkt_abs is not incremented by Compton heating. This should be considered a "bandaid" solution and in the near future we should improve this. 

See also #53 and #295 
