### PR TITLE
Turn off upweighting of simple atoms in indivisible ("macro-atom") line transfer mode

### DIFF
--- a/source/diag.c
+++ b/source/diag.c
@@ -196,8 +196,8 @@ get_extra_diagnostics ()
   n += modes.jumps_for_detailed_spectra = rdchoice ("@Diag.use_jumps_for_emissivities_in_detailed_spectra(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  n += modes.turn_off_upweighting_of_simple_macro_atoms =
-    rdchoice ("@Diag.turn_off_upweighting_of_simple_macro_atoms(yes,no)", "1,0", answer);
+  n += modes.use_upweighting_of_simple_macro_atoms =
+    rdchoice ("@Diag.use_upweighting_of_simple_macro_atoms(yes,no)", "1,0", answer);
 
   strcpy (answer, "zero_densities");
   n += modes.partial_cells =

--- a/source/matom.c
+++ b/source/matom.c
@@ -876,7 +876,7 @@ kpkt (p, nres, escape, mode)
            approach to choosing photon weights - this means we
            multipy down the photon weight by a factor nu/(nu-nu_0)
            and we force a kpkt to be created */
-        if (!modes.turn_off_upweighting_of_simple_macro_atoms)
+        if (modes.use_upweighting_of_simple_macro_atoms)
         {
           if (phot_top[i].macro_info == FALSE || geo.macro_simple == TRUE)
           {

--- a/source/python.h
+++ b/source/python.h
@@ -1604,7 +1604,7 @@ struct advanced_modes
                                       * cyles, which is currently controlled directly
                                       * from the normal .pf file
                                       */
-  int turn_off_upweighting_of_simple_macro_atoms; /**< If TURE, use the deprecated method for simple atoms
+  int use_upweighting_of_simple_macro_atoms; /**< If TURE, use the deprecated method for simple atoms
                                                     *in macro scheme
                                                     */
   int run_xtest_diagnostics;     /**< If TRUE, then xtest is being run, which is

--- a/source/resonate.c
+++ b/source/resonate.c
@@ -1111,7 +1111,7 @@ scatter (p, nres, nnscat)
            then the photon weight gets multiplied down by a factor (nu-nu_0)/nu
            and we force a kpkt to be created */
 
-        if (!modes.turn_off_upweighting_of_simple_macro_atoms)
+        if (modes.use_upweighting_of_simple_macro_atoms)
         {
           /* This is the new approach which does not explicityly conserve energy.
              Re record the amount of energy going into the simple ion ionization pool.  This

--- a/source/setup.c
+++ b/source/setup.c
@@ -336,7 +336,7 @@ init_advanced_modes ()
 
   modes.jumps_for_detailed_spectra = FALSE;     //use old jumps mode for calculating macro atom
   //emissivites
-  modes.turn_off_upweighting_of_simple_macro_atoms = FALSE;     //use old mode for handling 
+  modes.use_upweighting_of_simple_macro_atoms = FALSE;     //use upweighting mode for handling 
   //bf interactions with simple macro atoms
 
   modes.store_matom_matrix = TRUE;      /* default is to store the macro-atom matrix */

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -984,10 +984,10 @@ WindPtr (w);
     ("!!wind_update: Wind cooling     %8.2e (recomb %8.2e ff %8.2e compton %8.2e DR %8.2e DI %8.2e lines %8.2e adiabatic %8.2e) after update\n",
      cool_sum, geo.cool_rr, geo.lum_ff, geo.cool_comp, geo.cool_dr, geo.cool_di, geo.lum_lines, geo.cool_adiabatic);
 
-  if (!modes.turn_off_upweighting_of_simple_macro_atoms)
+  if (modes.use_upweighting_of_simple_macro_atoms)
   {
     /* If we have "indivisible packet" mode on but are using the 
-       new BF_SIMPLE_EMISSIVITY_APPROACH then we report the flows into and out of the ion pool */
+       upweighting scheme for simple atoms then we report the flows into and out of the ion pool */
     if (geo.rt_mode == RT_MODE_MACRO)
       report_bf_simple_ionpool ();
   }


### PR DESCRIPTION
This is a proposed change to make "upweighting off" be the default behaviour in the code and invert the logic accordingly. The upweighting scheme could be turned on by using the ```@Diag.use_upweighting_of_simple_macro_atoms(yes,no)``` advanced option, accessible with ```py -d``` and selecting extra diagnostics. 