### PR TITLE
Bug1045 macro

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -9,6 +9,13 @@
 # a different compiler other than mpicc.
 #
 
+# MATOM_VER is a temporary switch that allows one to compile the code so that it will
+# use the gsl routines wheen computing alpha_sp.  It should be invoked from the commad line, e.g
+# make MATOM_VER=2 python (or all); the Makefile should not be altered unless we change our mind
+# about the integration approach to use. The default is set to use the newer brute force technique
+
+MATOM_VER := 1
+
 #MPICC is now default compiler
 CC = mpicc
 # CC = gcc	# can use GCC either from command line or by uncommenting this
@@ -17,7 +24,7 @@ FC = g77
 NVCC =
 # NVCC = nvcc  # default (and only?) CUDA compiler
 # specify any extra compiler flags here
-EXTRA_FLAGS = -Wno-deprecated-non-prototype
+EXTRA_FLAGS = -Wno-deprecated-non-prototype -DMATOM_VER=$(MATOM_VER)
 LDFLAGS =
 
 # Use the next line if you want to change the c compiler that mpicc uses, or
@@ -140,7 +147,7 @@ LDFLAGS+= -L$(LIB) -lm -lgsl -lgslcblas $(CUDA_LIBS)
 #Note that version should be a single string without spaces.
 
 
-VERSION = 87z
+VERSION = 88a
 
 
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -140,7 +140,7 @@ LDFLAGS+= -L$(LIB) -lm -lgsl -lgslcblas $(CUDA_LIBS)
 #Note that version should be a single string without spaces.
 
 
-VERSION = 87i
+VERSION = 87z
 
 
 

--- a/source/matom.c
+++ b/source/matom.c
@@ -486,11 +486,6 @@ matom (p, nres, escape)
 
 
 
-#define B12_CONSTANT 5.01983e25
-
-struct lines *b12_line_ptr;
-double b12_a;
-
 
 /************************************/
 /**
@@ -503,6 +498,11 @@ double b12_a;
  * ksl OK, Probably should be moved to lines.c for consistency, but that can be done
  * later.
 ***********************************/
+
+#define B12_CONSTANT 5.01983e25
+
+struct lines *b12_line_ptr;
+double b12_a;
 
 double
 b12 (line_ptr)
@@ -533,7 +533,6 @@ int temp_choice;                //choice of type of calcualation for alpha_sp
 
 
 
-#define ALPHA_SP_CONSTANT 5.79618e-36
 
 /**********************************************************/
 /**
@@ -561,9 +560,10 @@ int temp_choice;                //choice of type of calcualation for alpha_sp
  *  Energy weighted means that the integrand has an extra factor nu/nu_threshold
  *  The difference case is (nu-nu_threshold)/nu_threhold
 ***********************************************************/
+#define ALPHA_SP_CONSTANT 5.79618e-36
 
 double
-alpha_sp (cont_ptr, xplasma, ichoice)
+xalpha_sp (cont_ptr, xplasma, ichoice)
      struct topbase_phot *cont_ptr;
      PlasmaPtr xplasma;
      int ichoice;
@@ -584,8 +584,96 @@ alpha_sp (cont_ptr, xplasma, ichoice)
   // alpha_sp_value = qromb (alpha_sp_integrand, fthresh, flast, 1e-4);
   alpha_sp_value = num_int (alpha_sp_integrand, fthresh, flast, 1e-4);
 
-  // Log ("Xxxx %e  %e %d %d %d %d %e %e \n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev,
-  //     cont_ptr->freq[0], cont_ptr->x[0]);
+  /* The lines above evaluate the integral in alpha_sp. Now we just want to multiply
+     through by the appropriate constant. */
+  if (cont_ptr->macro_info == TRUE && geo.macro_simple == FALSE)
+  {
+    alpha_sp_value = alpha_sp_value * xconfig[cont_ptr->nlev].g / xconfig[cont_ptr->uplev].g * pow (xplasma->t_e, -1.5);
+  }
+  else                          //case for simple element
+  {
+    alpha_sp_value = alpha_sp_value * xconfig[cont_ptr->nlev].g / ion[cont_ptr->nion + 1].g * pow (xplasma->t_e, -1.5); //g for next ion up used
+  }
+
+  alpha_sp_value = alpha_sp_value * ALPHA_SP_CONSTANT;
+
+
+  return (alpha_sp_value);
+}
+
+
+double
+alpha_sp (cont_ptr, xplasma, ichoice)
+     struct topbase_phot *cont_ptr;
+     PlasmaPtr xplasma;
+     int ichoice;
+{
+  double alpha_sp_value, integrand;
+  double fthresh, flast;
+  int n, nmax;
+  double freq, dfreq;
+  double temp;
+  double x;
+  double freq1, freq2;
+
+  temp_choice = ichoice;
+  temp = temp_ext = xplasma->t_e;       //external for use in alph_sp_integrand
+  cont_ext_ptr = cont_ptr;      //"
+
+  fthresh = cont_ptr->freq[0];  //first frequency in list
+  flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
+  if ((H_OVER_K * (flast - fthresh) / temp) > ALPHA_MATOM_NUMAX_LIMIT)
+  {
+    //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
+    flast = fthresh + temp * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
+  }
+  /* This is the line we want to replace */
+  // alpha_sp_value = num_int (alpha_sp_integrand, fthresh, flast, 1e-4);
+  alpha_sp_value = 0;
+  //nmax = cont_ptr->np - 2;      // so that there is one past this poit
+
+  nmax = 10000;
+  double log_fmin, dlog_freq;
+  log_fmin = log10 (cont_ptr->freq[0]);
+  dlog_freq = log10 (flast / cont_ptr->freq[0]) / nmax;
+
+  freq1 = cont_ptr->freq[0];
+  for (n = 1; n < nmax; n++)
+  {
+    freq2 = pow (10., log_fmin + n * dlog_freq);
+    freq = 0.5 * (freq1 + freq2);
+    dfreq = freq2 - freq1;
+    x = sigma_phot (cont_ptr, freq);
+    freq1 = freq2;
+
+
+
+    if (freq > flast)
+    {
+      break;
+    }
+
+    integrand = x * freq * freq * exp (H_OVER_K * (fthresh - freq) / temp);
+
+    if (ichoice == 1)
+    {
+      integrand *= freq / fthresh;
+
+    }
+    else if (ichoice == 2)
+    {
+      integrand *= (freq - fthresh) / fthresh;  // difference case
+    }
+
+    alpha_sp_value += integrand * dfreq;
+
+  }
+
+
+  Log ("Xxxx %e  %e %d %d %d %d %e %e \n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev,
+       cont_ptr->freq[0], cont_ptr->x[0]);
+
+  /* This is the end of the modification */
 
   /* The lines above evaluate the integral in alpha_sp. Now we just want to multiply
      through by the appropriate constant. */
@@ -600,12 +688,14 @@ alpha_sp (cont_ptr, xplasma, ichoice)
 
   alpha_sp_value = alpha_sp_value * ALPHA_SP_CONSTANT;
 
-//  Log ("Xxxx %e  %e %d %d %d %d\n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev);
+  if (sane_check (alpha_sp_value))
+  {
+    Error ("alpha_sp:sane_check value is %e\n", alpha_sp_value);
+
+  }
 
   return (alpha_sp_value);
 }
-
-#define ALPHA_SP_CONSTANT 5.79618e-36
 
 /**********************************************************/
 /**
@@ -638,6 +728,7 @@ alpha_sp (cont_ptr, xplasma, ichoice)
  * ###Notes###
  *
 ***********************************************************/
+#define ALPHA_SP_CONSTANT 5.79618e-36
 
 double
 scaled_alpha_sp_integral_band_limited (cont_ptr, xplasma, ichoice, freq_min, freq_max)
@@ -651,7 +742,7 @@ scaled_alpha_sp_integral_band_limited (cont_ptr, xplasma, ichoice, freq_min, fre
 
   temp_choice = ichoice;
   temp_ext = xplasma->t_e;      //external for use in alph_sp_integrand
-  cont_ext_ptr = cont_ptr;
+  cont_ext_ptr = cont_ptr;      //"
   fthresh = cont_ptr->freq[0];  //first frequency in list
   flast = cont_ptr->freq[cont_ptr->np - 1];     //last frequency in list
   if ((H_OVER_K * (flast - fthresh) / temp_ext) > ALPHA_MATOM_NUMAX_LIMIT)
@@ -1026,8 +1117,8 @@ kpkt (p, nres, escape, mode)
 
 
 
-/************************************************************/
-/**
+/************************************************************
+ **
  * @brief routine for dealing with bound-bound "simple ions" within the hybrid macro-atom framework
  *
  * @param [in,out] PhotPtr p   the packet at the point of activation
@@ -1125,8 +1216,8 @@ fake_matom_bb (p, nres, escape)
 }
 
 
-/************************************************************/
-/**
+/************************************************************
+ **
  * @brief calculate the frequency with for a bound-free transition for "simple ions"
  * within the hybrid macro-atom framework
  *
@@ -1160,8 +1251,10 @@ fake_matom_bf (p, nres, escape)
      int *escape;
 {
   WindPtr one;
+//OLD  PlasmaPtr xplasma;
 
   one = &wmain[p->grid];
+//OLD  xplasma = &plasmamain[one->nplasma];
 
   *escape = TRUE;
 

--- a/source/matom.c
+++ b/source/matom.c
@@ -608,13 +608,9 @@ alpha_sp (cont_ptr, xplasma, ichoice)
      PlasmaPtr xplasma;
      int ichoice;
 {
-  double alpha_sp_value, integrand;
+  double alpha_sp_value;
   double fthresh, flast;
-  int n, nmax;
-  double freq, dfreq;
   double temp;
-  double x;
-  double freq1, freq2;
 
   temp_choice = ichoice;
   temp = temp_ext = xplasma->t_e;       //external for use in alph_sp_integrand
@@ -627,10 +623,16 @@ alpha_sp (cont_ptr, xplasma, ichoice)
     //flast is currently very far into the exponential tail: so reduce flast to limit value of h nu / k T.
     flast = fthresh + temp * ALPHA_MATOM_NUMAX_LIMIT / H_OVER_K;
   }
+
+#if MATOM_VER == 1
   /* This is the line we want to replace */
   // alpha_sp_value = num_int (alpha_sp_integrand, fthresh, flast, 1e-4);
+  double freq, dfreq;
+  double freq1, freq2;
+  double x, integrand;
+  int n, nmax;
+
   alpha_sp_value = 0;
-  //nmax = cont_ptr->np - 2;      // so that there is one past this poit
 
   nmax = 10000;
   double log_fmin, dlog_freq;
@@ -668,6 +670,13 @@ alpha_sp (cont_ptr, xplasma, ichoice)
     alpha_sp_value += integrand * dfreq;
 
   }
+
+#elif MATOM_VER == 2
+  alpha_sp_value = num_int (alpha_sp_integrand, fthresh, flast, 1e-4);
+#warning "Using old gsl routine for alpha_sp"
+#else
+#error "Unsupported MATOM_VER value"
+#endif
 
 
 //  Log ("Xxxx %e  %e %d %d %d %d %e %e \n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev,

--- a/source/matom.c
+++ b/source/matom.c
@@ -670,8 +670,8 @@ alpha_sp (cont_ptr, xplasma, ichoice)
   }
 
 
-  Log ("Xxxx %e  %e %d %d %d %d %e %e \n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev,
-       cont_ptr->freq[0], cont_ptr->x[0]);
+//  Log ("Xxxx %e  %e %d %d %d %d %e %e \n", alpha_sp_value, temp_ext, ichoice, cont_ptr->nion, cont_ptr->nlev, cont_ptr->uplev,
+//       cont_ptr->freq[0], cont_ptr->x[0]);
 
   /* This is the end of the modification */
 


### PR DESCRIPTION
This allows for one to use the old gsl integration routines in matom.c when one compiles with a switch, namely 

```
make MATOM_VER=2 py
````