### PR TITLE
himacro: changes to make it easy to include larger macro-atoms like the Fe17to27 dataset 

### DIFF
--- a/docs/sphinx/source/atomic.rst
+++ b/docs/sphinx/source/atomic.rst
@@ -23,26 +23,32 @@ it should be fairly clear from the code what the various routines do.
 
 The routines used to generate data for MacroAtoms are described in :doc:`Generating Macro Atom data <./py_progs/MakeMacro>`
 
-
-
+Choosing a dataset 
+-----------------------
 The "masterfile" that determines what data will be read into Python is determined by the
 line in the parameter file, which will read something like::
 
     Atomic_data                                data/standard80.dat
    
-where the file data/standard80.txt will contain names (one to a line) of files which will
+where the file `data/standard80.dat` will contain names (one to a line) of files which will
 be read in sequentially.  
-All of the atomic data that comes 
-standardly with Python is stored
-in the data directory (and its subdirectories) but users are not required to put their data
-there.  
 
-Every line in the atomic data files read by Python consists of a keyword that defines the type
+All of the atomic data that comes as standard with Python is stored in the `xdata` directory (and its subdirectories) but users are not required to put their data
+there. Various experimental or testing dataset masterfiles are stored in the `zdata` directory. Symbolic links to these directories
+are setup by running `Setup_Py_Dir`.
+
+.. todo::
+
+    Add table of recommended data sets
+
+Data hierarchy and I/O 
+-----------------------
+As mentioned above, the masterfile will contain names (one to a line) of files which will
+be read in sequentially. Every line in the atomic data files read by Python consists of a keyword that defines the type
 of data and various data values that are required for that particular data type.  Lines that
 beging with # or are empty are ignored.
 
-The data from the various files are read as if they were one long file,
-so how the data is split up into files is a matter of convenience.  
+The data from the various files are read as if they were one long file, so how the data is split up into files is a matter of convenience.  
 
 However, the data must be read in a logical order.  As an simple example, information about elements 
 must be read in prior to information about ions.  This allows one to remove all data about, say Si,

--- a/source/atomic.h
+++ b/source/atomic.h
@@ -30,6 +30,7 @@ extern int nlevels;                    /**< These are the actual number of level
 #define NLTE_LEVELS	12000   /**<  Maximum number of levels to treat explicitly */
 extern int nlte_levels;                /**<  Actual number of levels to treat explicityly */
 
+
 /* AUGER NOTE: recommended to increase NLEVELS_MACRO to at least 500 for Auger macro-atoms */
 #define NLEVELS_MACRO   600     /**<  Maximum number of macro atom levels. (SS, June 04) */
 extern int nlevels_macro;              /**<  Actual number of macro atom levels. (SS, June 04) */
@@ -45,11 +46,13 @@ extern int n_inner_tot;                /**< The actual number of inner shell ion
 #define NBBJUMPS         100    /**<  Maximum number of Macro Atom bound-bound jumps from any one configuration (SS) */
 #define NBFJUMPS         100    /**<  Maximum number of Macro Atom Bound-free jumps from any one configuration (SS) */
 
+extern int nauger_macro;        /* the number of auger processes read in associated with macro atoms */
+#define NAUGER_MACRO 200        /* number of Auger processes */
+#define NAUGER_ELECTRONS 4
+
+
 #define MAXJUMPS          1000000       /**<  The maximum number of Macro Atom jumps before emission (if this is exceeded
                                            it gives up (SS) */
-// XXXX  - the maxium number of jumps has been reduced for testing
-// #define MAXJUMPS          10000      /* The maximum number of Macro Atom jumps before emission (if this is exceeded
-//                                           it gives up (SS) */
 #define NAUGER 2                /**< Maximum number of "auger" processes */
 extern int nauger;                     /**< Actual number of innershell edges for which autoionization is to be computed */
 
@@ -203,11 +206,6 @@ typedef struct configurations
 config_dummy, *ConfigPtr;
 
 extern ConfigPtr xconfig;
-
-
-extern int nauger_macro;        /* the number of auger processes read in associated with macro atoms */
-#define NAUGER_MACRO 200        /* number of Auger processes */
-#define NAUGER_ELECTRONS 4
 
 typedef struct auger
 {

--- a/source/atomic.h
+++ b/source/atomic.h
@@ -42,12 +42,20 @@ extern int nlines_macro;               /**<  Actual number of Macro Atom lines t
 extern int n_inner_tot;                /**< The actual number of inner shell ionization cross sections in total */
 
 
-/* AUGER NOTE: recommended to increase these values to at least 200 for Auger macro-atoms */
-#define NBBJUMPS         100    /**<  Maximum number of Macro Atom bound-bound jumps from any one configuration (SS) */
-#define NBFJUMPS         100    /**<  Maximum number of Macro Atom Bound-free jumps from any one configuration (SS) */
+#define LARGE_MACRO_ATOMS FALSE 
+/* sometimes we have to compile with larger hardwired values here for large macro-atoms e.g. Fe17to27 dataset */
+#if LARGE_MACRO_ATOMS
+  #define NBBJUMPS         200    /**<  Maximum number of Macro Atom bound-bound jumps from any one configuration (SS) */
+  #define NBFJUMPS         200    /**<  Maximum number of Macro Atom Bound-free jumps from any one configuration (SS) */
+  #define NAUGER_MACRO     2000        /* number of Auger processes */
+#else
+  /* AUGER NOTE: recommended to increase these values to at least 200 for Auger macro-atoms */
+  #define NBBJUMPS         100    /**<  Maximum number of Macro Atom bound-bound jumps from any one configuration (SS) */
+  #define NBFJUMPS         100    /**<  Maximum number of Macro Atom Bound-free jumps from any one configuration (SS) */
+  #define NAUGER_MACRO     200        /* number of Auger processes */
+#endif
 
 extern int nauger_macro;        /* the number of auger processes read in associated with macro atoms */
-#define NAUGER_MACRO 200        /* number of Auger processes */
 #define NAUGER_ELECTRONS 4
 
 
@@ -312,8 +320,13 @@ extern double phot_freq_min;           /**< The lowest frequency for which photo
 extern double inner_freq_min;          /**< The lowest frequency for which inner shell ionization can take place */
 
 #define NCROSS 3000            /**<  Maximum number of x-sections for a single photionization process */
-#define NTOP_PHOT 600           /**<  Maximum number of photoionisation processes.  */
-/* AUGER NOTE: recommended to increase NTOP_PHOT to 1000 for Auger macro-atoms */
+
+#if LARGE_MACRO_ATOMS
+  #define NTOP_PHOT 600           /**<  Maximum number of photoionisation processes.  */
+#else
+  /* AUGER NOTE: recommended to increase NTOP_PHOT to 1000 for Auger macro-atoms */
+  #define NTOP_PHOT 1000           /**<  Maximum number of photoionisation processes.  */
+#endif
 extern int ntop_phot;                  /**<  The actual number of TopBase photoionzation x-sections */
 extern int nphot_total;                /**<  total number of photoionzation x-sections = nxphot + ntop_phot */
 

--- a/source/atomicdata.c
+++ b/source/atomicdata.c
@@ -1430,7 +1430,8 @@ described as macro-levels. */
                 target_istate = istate + 1 + m;
 
                 n_augertarget = 0;
-                while ((xconfig[n_augertarget].z != z || xconfig[n_augertarget].istate != target_istate || xconfig[n_augertarget].ilv != 1) && n_augertarget < nlevels)
+                while ((xconfig[n_augertarget].z != z || xconfig[n_augertarget].istate != target_istate || xconfig[n_augertarget].ilv != 1)
+                       && n_augertarget < nlevels)
                   n_augertarget++;
                 if (n_augertarget == nlevels)
                 {
@@ -1448,8 +1449,8 @@ described as macro-levels. */
           }
           else
           {
-            Error ("getatomic_data: file %s line %d: More Auger macro-atom records than allowed. Increase NAUGER_MACRO in atomic.h\n", file,
-                   lineno);
+            Error ("getatomic_data: file %s line %d: More Auger macro-atom records than allowed. Increase NAUGER_MACRO (%d) in atomic.h\n",
+                   file, lineno, NAUGER_MACRO);
             exit (0);
           }
 


### PR DESCRIPTION
This change allows one to quickly recompile the code for larger macro-atoms by changing 

```
#define LARGE_MACRO_ATOMS FALSE
```
to 
```
#define LARGE_MACRO_ATOMS TRUE
```

in atomic.h. 