### PR TITLE
don't call call qdisk_init if we are restarting

### DIFF
--- a/source/sirocco.c
+++ b/source/sirocco.c
@@ -645,7 +645,11 @@ main (argc, argv)
 
 
   disk_init (geo.disk_rad_min, geo.disk_rad_max, geo.mstar, geo.disk_mdot, freqmin, freqmax, 0, &geo.f_disk);
-  qdisk_init (geo.disk_rad_min, geo.disk_rad_max, geo.mstar, geo.disk_mdot);
+
+  /* we should not call qdisk_init if we are restarting, see #1134 */
+  if (geo.run_type != RUN_TYPE_RESTART)
+    qdisk_init (geo.disk_rad_min, geo.disk_rad_max, geo.mstar, geo.disk_mdot);
+
   xsignal (files.root, "%-20s Finished initialization for %s\n", "NOK", files.root);
   check_time (files.root);
 


### PR DESCRIPTION
This is designed to fix problems with the disk spectrum resetting when you restart - this should not happen. The solution is to only call qdisk_init if geo.run_type != RUN_TYPE_RESTART. This should help fix #1134 