### PR TITLE
Save photons - merge into dev

### DIFF
--- a/source/compton.c
+++ b/source/compton.c
@@ -113,11 +113,11 @@ compton_scatter (p)
 
 
   lorentz_transform (p, p, velocity_electron);
-  if (modes.save_extract_photons)
-    save_photons (p, "BeforeC");
+//  if (modes.save_extract_photons)
+//    save_photons (p, "BeforeC");
   compton_dir (p);
-  if (modes.save_extract_photons)
-    save_photons (p, "AfterC");
+//  if (modes.save_extract_photons)
+//    save_photons (p, "AfterC");
   rescale (velocity_electron, -1, vel);
   lorentz_transform (p, p, vel);
 

--- a/source/diag.c
+++ b/source/diag.c
@@ -196,8 +196,7 @@ get_extra_diagnostics ()
   n += modes.jumps_for_detailed_spectra = rdchoice ("@Diag.use_jumps_for_emissivities_in_detailed_spectra(yes,no)", "1,0", answer);
 
   strcpy (answer, "no");
-  n += modes.use_upweighting_of_simple_macro_atoms =
-    rdchoice ("@Diag.use_upweighting_of_simple_macro_atoms(yes,no)", "1,0", answer);
+  n += modes.use_upweighting_of_simple_macro_atoms = rdchoice ("@Diag.use_upweighting_of_simple_macro_atoms(yes,no)", "1,0", answer);
 
   strcpy (answer, "zero_densities");
   n += modes.partial_cells = rdchoice ("@Diag.partial_cells(include,zero_densities,extend_full_cells)", "0,1,2", answer);
@@ -368,7 +367,7 @@ init_extra_diagnostics ()
 
   if (eplinit == 0 && modes.extra_diagnostics)
   {
-    sprintf (files.extra, "%.50s.ext.txt", files.root);
+    //OLD sprintf (files.extra, "%.50s.ext.txt", files.root);
     epltptr = fopen (files.extra, "w");
     eplinit = 1;
   }

--- a/source/extract.c
+++ b/source/extract.c
@@ -402,6 +402,8 @@ extract (w, p, itype)
     }
 
     /* If one has reached this point, we extract the photon and increment the spectrum */
+    if (modes.save_extract_photons)
+      save_photons (&pp, "EXT_FIN");
 
 
     extract_one (w, &pp, n);

--- a/source/parse.c
+++ b/source/parse.c
@@ -176,7 +176,7 @@ parse_command_line (argc, argv)
       else if (strcmp (argv[i], "--version") == 0)
       {
         /* give information about the sirocco version, such as commit hash */
-        Log ("Sirocco Version %s \n", VERSION);  //54f -- ksl -- Now read from version.h
+        Log ("Sirocco Version %s \n", VERSION); //54f -- ksl -- Now read from version.h
         Log ("Built from git commit hash %s\n", GIT_COMMIT_HASH);
         /* warn the user if there are uncommited changes */
         int git_diff_status = GIT_DIFF_STATUS;
@@ -262,7 +262,7 @@ parse_command_line (argc, argv)
       else if (strcmp (argv[i], "--version") == 0)
       {
         /* give information about the pyhon version, such as commit hash */
-        Log ("Sirocco Version %s \n", VERSION);  //54f -- ksl -- Now read from version.h
+        Log ("Sirocco Version %s \n", VERSION); //54f -- ksl -- Now read from version.h
         Log ("Built from git commit hash %s\n", GIT_COMMIT_HASH);
         /* warn the user if there are uncommited changes */
         int git_diff_status = GIT_DIFF_STATUS;
@@ -299,6 +299,14 @@ parse_command_line (argc, argv)
     sprintf (dummy, "_%02d.diag", rank_global);
 
     sprintf (files.diag, "%.50s/%.50s%.50s", files.diagfolder, files.root, dummy);
+
+    /* Also set the names for extra diagnostics in case these are needed. */
+
+    sprintf (dummy, "_%02d.ext.txt", rank_global);
+
+    sprintf (files.extra, "%.50s%.50s", files.root, dummy);
+
+
 
     /* Set up the directory structure for storing the rng state */
 

--- a/source/sirocco.h
+++ b/source/sirocco.h
@@ -1669,7 +1669,7 @@ struct filenames
   char tprofile[LINELENGTH];    /**< non standard tprofile fname */
   char phot[LINELENGTH];        /**< photfile e.g. sirocco.phot */
   char windrad[LINELENGTH];     /**< wind rad file */
-  char extra[LINELENGTH];       /**< extra diagnositcs file opened by init_extra_diagnostics */
+  char extra[LINELENGTH];       /**< extra diagnositics file opened by init_extra_diagnostics */
 };
 
 extern struct filenames files;


### PR DESCRIPTION
The only substantive change is to cause extra diagnostics files to be created for each thread (if such files are created).  This addresses #1149 where the file was corrupted when multiple threads tried writing to the same file.