### PR TITLE
Speed up matrix_multi

### DIFF
--- a/source/ionization.c
+++ b/source/ionization.c
@@ -132,18 +132,29 @@ ion_abundances (PlasmaPtr xplasma, int mode)
 
     spectral_estimators (xplasma);
     update_old_plasma_variables (xplasma);
-    int kkk;
+    int kkk, jjj;
     double xte[MAX_MULTISHOT + 1];
+    double delta[MAX_MULTISHOT + 1];
 
     for (kkk = 0; kkk < MAX_MULTISHOT; kkk++)
     {
       ireturn = one_shot (xplasma, NEBULARMODE_MATRIX_SPECTRALMODEL);
       xte[kkk] = xplasma->t_e;
+      if (kkk > 1)
+      {
+        delta[kkk] = (xte[kkk] - xte[kkk - 1]) / (0.5 * (xte[kkk] + xte[kkk - 1]));
+        if (fabs (delta[kkk]) < DELTA_MULTISHOT)
+          break;
+      }
+      else
+      {
+        delta[kkk] = 1.0;
+      }
     }
 
-    for (kkk = 0; kkk < MAX_MULTISHOT; kkk++)
+    for (jjj = 0; jjj < kkk; jjj++)
     {
-      Log ("XXXXX %5d %10.3e\n", kkk, xte[kkk]);
+      Log ("XXXXX %5d %10.3e %8.3f\n", jjj, xte[jjj], delta[jjj]);
     }
 
     convergence (xplasma);

--- a/source/sirocco.h
+++ b/source/sirocco.h
@@ -1243,6 +1243,7 @@ extern int size_Jbar_est, size_gamma_est, size_alpha_est;
                                                * get the ion balance and t_e.  This is under development */
 
 #define MAX_MULTISHOT  10  /**< Maximum number of iterations in MULTISHOT Mode */
+#define DELTA_MULTISHOT  0.01  /**<Fractional change in temperarute to stop interations in MULTISHOT Mode*/
 
 // and the corresponding modes in nebular_concentrations
 #define NEBULARMODE_TR 0        /**< LTE using t_r */


### PR DESCRIPTION
This update affects matrix_multi only.  

The change is to see if the temperature calculated with one shot is changing significantly with each iteration, and if not to break out of the loop.  

The maximum number of one shots and the parameter that controls when one breaks out are both in sirocco.h

For a short calculation using agn_matrix (with 8 processors) in the regression directory

* single one shot - 76 sec
* multi_shot w/out change 274 sec
* multi_shot with change  176 sec

so the improvement is significant.  One would expect the gain in efficiency would be greater once one gets closer to convergence.