### PR TITLE
Bug1166 p option

### DIFF
--- a/docs/documentation_overview.html
+++ b/docs/documentation_overview.html
@@ -32,6 +32,22 @@
           tracked in git.</li>
         <li>To generate the Sphinx documentation one needs <a
             href="http://www.sphinx-doc.org/en/master/">sphinx</a></li>
+        <li>Because we use an package called <a moz-do-not-send="true"
+            href="https://pysi.readthedocs.io/en/stable/">PySi</a> in
+          conjunction with some of the Jupyter scripts and because this
+          code has some verison dependences, we recommend creating an
+          environment to encapsulate the version needed to compile all
+          of the documention.&nbsp; In conda, one can create this with:</li>
+        <ul>
+          <li>conda<span class="w"> </span>create<span class="w"> </span>-n<span
+              class="w"> </span>xsphinx<span class="w"> </span><span
+              class="nv">python</span><span class="o">=</span><span
+              class="m">3</span>.1</li>
+          <li>conda<span class="w"> </span>activate<span class="w"> </span>xsphinx</li>
+          <li>cd docs/sphinx</li>
+          <li>pip3<span class="w"> </span>install<span class="w"> </span>-r<span
+              class="w"> </span>requirements.txt</li>
+        </ul>
       </ul>
       <ul>
       </ul>
@@ -78,6 +94,7 @@
 
 
 
+
         provides information about the source code.</li>
       <ul>
         <li>Like the other documentation, the Doxygen information is not
@@ -102,6 +119,7 @@
         </li>
         <ul>
           <li>The Doxygen home page is <a href="http://www.doxygen.nl/">here</a>.&nbsp;
+
 
 
 

--- a/docs/sphinx/source/meta.rst
+++ b/docs/sphinx/source/meta.rst
@@ -20,7 +20,23 @@ We require the **Python 3** version of **Sphinx**. Install it, and the other mod
     cd docs/sphinx
     pip3 install -r requirements.txt
 
-Building the documentation
+If you use conda/minconda or a similar environment management tool, we recommend you create a new enviroment 
+for compoling the sphinx documentation.  This is because there are some version dependences in the package
+[pysi](https://pysi.readthedocs.io/en/stable/) which is used in some of the Jupyter scripts.  
+
+And example that is known to work, if you are in the sphinx directory:
+
+.. code :: bash
+
+    conda create -n xsphinx python=3.10
+    conda activate xsphinx
+    pip3 install -r requirements.txt
+
+
+In the absence of installing this package, you can still edit and recompile the sphinx documentation, but
+you will see errors associated with this missing package.  This should not prevent you from improving other
+parts of the documenation. 
+
 --------------------------
 
 Once **Sphinx** is installed, you can make the documentation using a **Makefile** as:
@@ -28,6 +44,8 @@ Once **Sphinx** is installed, you can make the documentation using a **Makefile*
 .. code :: bash
 
     make html
+
+
 
 You can tell if the documentation was built successfully by looking at the output of ``make html``.
 You should see:

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -912,12 +912,16 @@ photo_gen_star (p, r, t, weight, f1, f2, spectype, istart, nphot)
     Error ("photo_gen_star: Cannot generate photons if freqmax %g < freqmin %g\n", f2, f1);
   }
   Log ("photo_gen_star creates nphot %5d photons from %5d to %5d \n", nphot, istart, iend);
-  Log_silent ("photo_gen_star creates nphot %5d photons from %5d to %5d \n", nphot, istart, iend);
+  // Log_silent ("photo_gen_star creates nphot %5d photons from %5d to %5d \n", nphot, istart, iend);
+  Log_flush ();
+
   freqmin = f1;
   freqmax = f2;
   r = (1. + EPSILON) * r;       /* Generate photons just outside the photosphere */
   for (i = istart; i < iend; i++)
   {
+    Log ("phot %6d %6d -  %6d for %6d\n", i, istart, iend, NPHOT);
+    Log_flush ();
     p[i].origin = PTYPE_STAR;   // For BL photons this is corrected in photon_gen
     p[i].frame = F_OBSERVER;    // Stellar photons are not redshifted
     p[i].w = weight;

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -912,7 +912,6 @@ photo_gen_star (p, r, t, weight, f1, f2, spectype, istart, nphot)
     Error ("photo_gen_star: Cannot generate photons if freqmax %g < freqmin %g\n", f2, f1);
   }
   Log ("photo_gen_star creates nphot %5d photons from %5d to %5d \n", nphot, istart, iend);
-  // Log_silent ("photo_gen_star creates nphot %5d photons from %5d to %5d \n", nphot, istart, iend);
   Log_flush ();
 
   freqmin = f1;
@@ -920,8 +919,6 @@ photo_gen_star (p, r, t, weight, f1, f2, spectype, istart, nphot)
   r = (1. + EPSILON) * r;       /* Generate photons just outside the photosphere */
   for (i = istart; i < iend; i++)
   {
-    Log ("phot %6d %6d -  %6d for %6d\n", i, istart, iend, NPHOT);
-    Log_flush ();
     p[i].origin = PTYPE_STAR;   // For BL photons this is corrected in photon_gen
     p[i].frame = F_OBSERVER;    // Stellar photons are not redshifted
     p[i].w = weight;

--- a/source/run.c
+++ b/source/run.c
@@ -158,6 +158,23 @@ calculate_ionization (restart_stat)
   while (geo.wcycle < geo.wcycles)
   {                             /* This allows you to build up photons in bunches */
 
+    /* If we are using photon speed up mode then the number of photons varies by cycle in the
+     * ionization phase.  We set this up here
+     */
+
+    if (modes.photon_speedup)
+    {
+      nphot_min = NPHOT_MAX / pow (10., PHOT_RANGE);
+
+      x = log10 (NPHOT_MAX / nphot_min) / (geo.wcycles - 1);
+      NPHOT = nphot_min * pow (10., (x * geo.wcycle));
+      if (NPHOT > NPHOT_MAX)
+      {
+        NPHOT = NPHOT_MAX;
+      }
+    }
+
+
     photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT + 1);
     photmain_allocated = TRUE;
     Log ("CCC - Allocated photmain for wcycle %d with NPHOT of %d\n", geo.wcycle, NPHOT);
@@ -214,23 +231,6 @@ calculate_ionization (restart_stat)
       iwind = -1;               /* Do not generate photons from wind */
     else
       iwind = 1;                /* Create wind photons and force a reinitialization of wind parms */
-
-
-    /* If we are using photon speed up mode then the number of photons varies by cycle in the
-     * ionization phase.  We set this up here
-     */
-
-    if (modes.photon_speedup)
-    {
-      nphot_min = NPHOT_MAX / pow (10., PHOT_RANGE);
-
-      x = log10 (NPHOT_MAX / nphot_min) / (geo.wcycles - 1);
-      NPHOT = nphot_min * pow (10., (x * geo.wcycle));
-      if (NPHOT > NPHOT_MAX)
-      {
-        NPHOT = NPHOT_MAX;
-      }
-    }
 
     Log ("!!Sirocco: %1.2e photons will be transported for cycle %i\n", (double) NPHOT, geo.wcycle + 1);
 

--- a/source/run.c
+++ b/source/run.c
@@ -84,7 +84,6 @@ calculate_ionization (restart_stat)
   /* What is here is just a test, that we can allocate and then deallocate photmain.
      With a little more logic, this could  be put inside the ioniation loop. */
 
-  //OLD photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT);
   photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT + 1);
   photmain_allocated = TRUE;
   Log ("CCC - Allocated photmain for memory check with NPHOT set to %d\n", NPHOT);
@@ -117,7 +116,6 @@ calculate_ionization (restart_stat)
 
 
 
-//OLD  p = photmain;
   w = wmain;
 
   freqmin = xband.f1[0];
@@ -160,7 +158,6 @@ calculate_ionization (restart_stat)
   while (geo.wcycle < geo.wcycles)
   {                             /* This allows you to build up photons in bunches */
 
-    // photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT);
     photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT + 1);
     photmain_allocated = TRUE;
     Log ("CCC - Allocated photmain for wcycle %d with NPHOT of %d\n", geo.wcycle, NPHOT);
@@ -494,7 +491,6 @@ make_spectra (restart_stat)
    * and in the somewhat abnormal case where additional ionization cycles
    * were calculated for the wind
    */
-  // photmain = (PhotPtr) calloc (sizeof (p_dummy), NPHOT);
   photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT + 1);
   photmain_allocated = TRUE;
   Log ("CCC - Allocated photmain at beginning of detailed spectrum, with NPHOt %d\n", NPHOT);

--- a/source/setup.c
+++ b/source/setup.c
@@ -610,7 +610,6 @@ init_observers ()
 PhotPtr
 init_photons ()
 {
-//OLD PhotPtr p;
 
   /* Although Photons_per_cycle is really an integer,
      read in as a double so it is easier for input
@@ -626,10 +625,6 @@ init_photons ()
   }
 
 
-//OLD #ifdef MPI_ON
-//OLD   Log ("Photons per cycle per MPI task will be %d\n", NPHOT / np_mpi_global);
-//OLD   NPHOT /= np_mpi_global;
-//OLD #endif
 
   rdint ("Ionization_cycles", &geo.wcycles);
 
@@ -656,33 +651,6 @@ init_photons ()
     Log ("After that, the windsave file will be written to disk but then the program will exit\n");
   }
 
-//OLD  /* Allocate the memory for the photon structure now that NPHOT is established */
-//OLD
-//OLD  photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT);
-//OLD  /* If the number of photons per cycle is changed, NPHOT can be less, so we define NPHOT_MAX
-//OLD   * to the maximum number of photons that one can create.  NPHOT is used extensively with
-//OLD   * Sirocco.  It is the NPHOT in a particular cycle, in a given thread.
-//OLD   */
-
-//OLF  NPHOT_MAX = NPHOT;
-
-
-//OLD  if (p == NULL)
-//OLD  {
-//OLD    Error ("init_photons: There is a problem in allocating memory for the photon structure\n");
-//OLD    Exit (0);
-//OLD  }
-//OLD  else
-//OLD  {
-//OLD    /* large photon numbers can cause problems / runs to crash. Report to use (see #209) */
-//OLD    Log
-//OLD      ("Allocated %10d bytes for each of %5d elements of photon structure totaling %10.1f Mb \n",
-//OLD       sizeof (p_dummy), NPHOT, 1.e-6 * NPHOT * sizeof (p_dummy));
-//OLD    if ((NPHOT * sizeof (p_dummy)) > 1e9)
-//OLD      Error ("Over 1 GIGABYTE of photon structure allocated. Could cause serious problems.\n");
-//OLD  }
-
-//OLD return (p);
   return (0);
 }
 

--- a/source/windsave2table_sub.c
+++ b/source/windsave2table_sub.c
@@ -153,8 +153,8 @@ create_master_table (ndom, rootname)
      char rootname[];
 {
   char filename[132];
-  double *c[50], *converge;
-  char column_name[50][24];
+  double *c[51], *converge;
+  char column_name[51][24];
   char one_line[1024], start[1024], one_value[24];
   char name[132];               /* file name extension */
 
@@ -181,67 +181,70 @@ create_master_table (ndom, rootname)
   c[2] = get_one (ndom, "ne");
   strcpy (column_name[2], "ne");
 
-  c[3] = get_one (ndom, "t_e");
-  strcpy (column_name[3], "t_e");
+  c[3] = get_one (ndom, "nh");
+  strcpy (column_name[3], "nh");
 
-  c[4] = get_one (ndom, "t_r");
-  strcpy (column_name[4], "t_r");
+  c[4] = get_one (ndom, "t_e");
+  strcpy (column_name[4], "t_e");
 
-  c[5] = get_ion (ndom, 1, 1, 0, name);
-  strcpy (column_name[5], "h1");
+  c[5] = get_one (ndom, "t_r");
+  strcpy (column_name[5], "t_r");
 
-  c[6] = get_ion (ndom, 2, 2, 0, name);
-  strcpy (column_name[6], "he2");
+  c[6] = get_ion (ndom, 1, 1, 0, name);
+  strcpy (column_name[6], "h1");
 
-  c[7] = get_ion (ndom, 6, 4, 0, name);
-  strcpy (column_name[7], "c4");
+  c[7] = get_ion (ndom, 2, 2, 0, name);
+  strcpy (column_name[7], "he2");
 
-  c[8] = get_ion (ndom, 7, 5, 0, name);
-  strcpy (column_name[8], "n5");
+  c[8] = get_ion (ndom, 6, 4, 0, name);
+  strcpy (column_name[8], "c4");
 
-  c[9] = get_ion (ndom, 8, 6, 0, name);
-  strcpy (column_name[9], "o6");
+  c[9] = get_ion (ndom, 7, 5, 0, name);
+  strcpy (column_name[9], "n5");
 
-  c[10] = get_one (ndom, "dmo_dt_x");
-  strcpy (column_name[10], "dmo_dt_x");
+  c[10] = get_ion (ndom, 8, 6, 0, name);
+  strcpy (column_name[10], "o6");
+
+  c[11] = get_one (ndom, "dmo_dt_x");
+  strcpy (column_name[11], "dmo_dt_x");
 
 
-  c[11] = get_one (ndom, "dmo_dt_y");
-  strcpy (column_name[11], "dmo_dt_y");
+  c[12] = get_one (ndom, "dmo_dt_y");
+  strcpy (column_name[12], "dmo_dt_y");
 
-  c[12] = get_one (ndom, "dmo_dt_z");
-  strcpy (column_name[12], "dmo_dt_z");
+  c[13] = get_one (ndom, "dmo_dt_z");
+  strcpy (column_name[13], "dmo_dt_z");
 
-  c[13] = get_one (ndom, "ip");
-  strcpy (column_name[13], "ip");
+  c[14] = get_one (ndom, "ip");
+  strcpy (column_name[14], "ip");
 
-  c[14] = get_one (ndom, "xi");
-  strcpy (column_name[14], "xi");
+  c[15] = get_one (ndom, "xi");
+  strcpy (column_name[15], "xi");
 
-  c[15] = get_one (ndom, "ntot");
-  strcpy (column_name[15], "ntot");
+  c[16] = get_one (ndom, "ntot");
+  strcpy (column_name[16], "ntot");
 
-  c[16] = get_one (ndom, "nrad");
-  strcpy (column_name[16], "nrad");
+  c[17] = get_one (ndom, "nrad");
+  strcpy (column_name[17], "nrad");
 
-  c[17] = get_one (ndom, "nioniz");
-  strcpy (column_name[17], "nioniz");
+  c[18] = get_one (ndom, "nioniz");
+  strcpy (column_name[18], "nioniz");
 
-  c[18] = get_one (ndom, "nscat_es");
-  strcpy (column_name[18], "nscat_es");
+  c[19] = get_one (ndom, "nscat_es");
+  strcpy (column_name[19], "nscat_es");
 
-  c[19] = get_one (ndom, "nscat_res");
-  strcpy (column_name[19], "nscat_res");
+  c[20] = get_one (ndom, "nscat_res");
+  strcpy (column_name[20], "nscat_res");
 
-  c[20] = get_one (ndom, "nscat_ff");
-  strcpy (column_name[20], "nscat_ff");
+  c[21] = get_one (ndom, "nscat_ff");
+  strcpy (column_name[21], "nscat_ff");
 
-  c[21] = get_one (ndom, "nscat_bf");
-  strcpy (column_name[21], "nscat_bf");
+  c[22] = get_one (ndom, "nscat_bf");
+  strcpy (column_name[22], "nscat_bf");
 
 
   /* This should be the maxium number above +1 */
-  ncols = 22;
+  ncols = 23;
 
 
   converge = get_one (ndom, "converge");
@@ -1606,6 +1609,8 @@ get_one (ndom, variable_name)
       {
         x[n] = wmain[n].dfudge;
       }
+      else if (strcmp (variable_name, "nh") == 0)
+        x[n] = rho2nh * plasmamain[nplasma].rho;
       else
       {
         Error ("get_one: Unknown variable %s\n", variable_name);


### PR DESCRIPTION
This should fix the problem with the -p option, which had to do with how size in photmain vary with ionization cycle. The problem exposes an issue with how we use NPHOT through the program, as we adjust its size both for the number of threads and in the case of the -p option with ionization cycle.  A better approach would be to define NPHOT_MAX as what one reads in .pf file, but I have not re-engineered this. A second issue is the way NPHOT is passed around externally of subroutine calls.

Additonally:
* adds documentation for how to get Sphinx to run
* adds nh to the master table produced by windsave2table.