### PR TITLE
Updates to LTE mode

### DIFF
--- a/docs/sphinx/source/input/parameters/wind/Wind/Wind.ionization.rst
+++ b/docs/sphinx/source/input/parameters/wind/Wind/Wind.ionization.rst
@@ -9,20 +9,36 @@ Type
 
 Values
   on.the.spot
-    Use a simple on the spot approximation to calculated the ionization.
+    Use a simple on-the-spot approximation to calculate the ionization.
 
   LTE_te
-    Calculate ionization based on the Saha equation using
-    the electron temperature.  (This is intended as a diagnostic
-    mode.)
+    Calculate ionization assuming Local Thermodynamic Equilibrium (LTE)
+    using the Saha equation with the electron temperature t_e. The electron
+    temperature is set equal to the initial radiation temperature (twind),
+    or from the imported model if available, and remains fixed throughout
+    the simulation. The partition functions are evaluated at t_e. This mode
+    forces Saha ionization for all species, including macro atoms.
+    (This is intended as a diagnostic mode.)
 
   LTE_tr
-    Calculate ionization based on the Saha equation using
-    the radiation temperature. (This is intended as a diagnstic mode)
+    Calculate ionization assuming Local Thermodynamic Equilibrium (LTE)
+    using the Saha equation with the radiation temperature t_r. The
+    radiation temperature is updated each ionization cycle based on the
+    mean frequency of the radiation field. The electron temperature is
+    set to t_e = 0.9 * t_r each cycle. The partition functions are
+    evaluated at t_r. This mode forces Saha ionization for all species,
+    including macro atoms. (This is intended as a diagnostic mode.)
 
   ML93
-    Use the modified on the spot approimation  described by 
-    `Mazzli & Lucy 1993 <https://ui.adsabs.harvard.edu/abs/1993A%26A...279..447M/abstract>`_  
+    Use the modified on-the-spot approximation described by
+    `Mazzali & Lucy 1993 <https://ui.adsabs.harvard.edu/abs/1993A%26A...279..447M/abstract>`_.
+    At each ionization cycle, the electron temperature is set to
+    t_e = 0.9 * t_r. Ionization fractions are first computed using
+    the Saha equation at t_r, then corrected using the Lucy-Mazzali
+    estimators which account for the dilute, non-Planckian radiation field.
+    The partition functions are evaluated using the dilution factor W.
+    This mode does not attempt to balance heating and cooling to determine
+    t_e self-consistently.  
 
   fixed
     Read the ion aboundances in from a file.  All cells will have

--- a/source/define_wind.c
+++ b/source/define_wind.c
@@ -214,11 +214,15 @@ set_plasma_temperature (PlasmaPtr cell, int ndom, double xcen[3])
 
   /* The next lines set the electron temperature to 0.9 times the radiation temperature (which is a bit
      odd since the input is the wind temperature, but is taken to be the radiation temperature). If we have
-     a fixed temperature calculation,then the wind temperature is set to be the wind temperature so the
-     user gets what they are expecting */
+     a fixed temperature calculation, then the wind temperature is set to be the wind temperature so the
+     user gets what they are expecting. For LTE_TE mode, t_e is set to t_r and remains fixed. */
   if (dom->wind_type == IMPORT)
   {
     cell->t_e = import_temperature (ndom, xcen, TRUE);
+  }
+  else if (geo.ioniz_mode == IONMODE_LTE_TE)
+  {
+    cell->t_e = cell->t_e_old = cell->t_r;      // LTE_TE: t_e fixed at initial t_r
   }
   else if (modes.fixed_temp == FALSE && modes.zeus_connect == FALSE)
   {
@@ -303,13 +307,17 @@ create_plasma_grid (void)
     }
 
     /* Determine the initial ion abundances, using either LTE or fixed concentrations */
-    if (geo.ioniz_mode != IONMODE_FIXED)
-    {                           /* Carry out an LTE determination of the ionization (using T_r) */
-      ierr = ion_abundances (&plasmamain[n_plasma], IONMODE_LTE_TR);
-    }
-    else
+    if (geo.ioniz_mode == IONMODE_FIXED)
     {                           /* Set the concentrations to specified values */
       ierr = ion_abundances (&plasmamain[n_plasma], IONMODE_FIXED);
+    }
+    else if (geo.ioniz_mode == IONMODE_LTE_TE)
+    {                           /* LTE using t_e (which is fixed at initial t_r) */
+      ierr = ion_abundances (&plasmamain[n_plasma], IONMODE_LTE_TE);
+    }
+    else
+    {                           /* Carry out an LTE determination of the ionization (using T_r) */
+      ierr = ion_abundances (&plasmamain[n_plasma], IONMODE_LTE_TR);
     }
     if (ierr != 0)
     {

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -75,15 +75,18 @@ ion_abundances (PlasmaPtr xplasma, int mode)
   }
   else if (mode == IONMODE_LTE_TR)
   {
-    /* LTE using t_r - force Saha equation for all ions including macro atoms */
+    /* LTE using t_r - force Saha equation for all ions including macro atoms.
+       Update t_e to 0.9 * t_r each cycle, similar to ML93. */
     int save_macro_ioniz_mode = geo.macro_ioniz_mode;
     geo.macro_ioniz_mode = MACRO_IONIZ_MODE_NO_ESTIMATORS;
+    xplasma->t_e = 0.9 * xplasma->t_r;
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TR);
     geo.macro_ioniz_mode = save_macro_ioniz_mode;
   }
   else if (mode == IONMODE_LTE_TE)
   {
-    /* LTE using t_e - force Saha equation for all ions including macro atoms */
+    /* LTE using t_e - force Saha equation for all ions including macro atoms.
+       t_e remains fixed at the initial temperature (set in define_wind.c). */
     int save_macro_ioniz_mode = geo.macro_ioniz_mode;
     geo.macro_ioniz_mode = MACRO_IONIZ_MODE_NO_ESTIMATORS;
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TE);

--- a/source/ionization.c
+++ b/source/ionization.c
@@ -75,13 +75,19 @@ ion_abundances (PlasmaPtr xplasma, int mode)
   }
   else if (mode == IONMODE_LTE_TR)
   {
-    /* LTE using t_r */
+    /* LTE using t_r - force Saha equation for all ions including macro atoms */
+    int save_macro_ioniz_mode = geo.macro_ioniz_mode;
+    geo.macro_ioniz_mode = MACRO_IONIZ_MODE_NO_ESTIMATORS;
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TR);
+    geo.macro_ioniz_mode = save_macro_ioniz_mode;
   }
   else if (mode == IONMODE_LTE_TE)
   {
-    /* LTE using t_e */
+    /* LTE using t_e - force Saha equation for all ions including macro atoms */
+    int save_macro_ioniz_mode = geo.macro_ioniz_mode;
+    geo.macro_ioniz_mode = MACRO_IONIZ_MODE_NO_ESTIMATORS;
     ireturn = nebular_concentrations (xplasma, NEBULARMODE_TE);
+    geo.macro_ioniz_mode = save_macro_ioniz_mode;
   }
   else if (mode == IONMODE_FIXED)
   {                             //  Hardwired concentrations

--- a/source/partition.c
+++ b/source/partition.c
@@ -110,8 +110,21 @@ partition_functions (xplasma, mode)
   for (nion = 0; nion < nions; nion++)
   {
 
-    if (ion[nion].nlevels > 0)
-      //Calculate data on levels using a weighed BB assumption
+    if (ion[nion].macro_info == TRUE && ion[nion].nlte > 0)
+      // Macro atom with macro levels: use macro levels for partition function
+    {
+      m = ion[nion].first_nlte_level;
+      m_ground = m;
+      z = xconfig[m].g;
+
+      for (n = 1; n < ion[nion].nlte; n++)
+      {
+        m++;
+        z += weight * xconfig[m].g * exp ((-xconfig[m].ex + xconfig[m_ground].ex) / kt);
+      }
+    }
+    else if (ion[nion].nlevels > 0)
+      // Simple atom: calculate using simple levels with weighted BB assumption
     {
       m = ion[nion].firstlevel;
       m_ground = m;
@@ -126,7 +139,7 @@ partition_functions (xplasma, mode)
       }
     }
     else if (ion[nion].nlte > 0)
-      //Calculate using "non-lte" levels
+      // Fallback: calculate using "non-lte" levels
     {
       m = ion[nion].first_nlte_level;
       m_ground = m;
@@ -222,8 +235,21 @@ partition_functions_2 (xplasma, xnion, temp, weight)
   for (nion = xnion - 1; nion < xnion + 1; nion++)
   {
 
-    if (ion[nion].nlevels > 0)
-      //Calculate data on levels using a weighed BB assumption
+    if (ion[nion].macro_info == TRUE && ion[nion].nlte > 0)
+      // Macro atom with macro levels: use macro levels for partition function
+    {
+      m = ion[nion].first_nlte_level;
+      m_ground = m;
+      z = xconfig[m].g;
+
+      for (n = 1; n < ion[nion].nlte; n++)
+      {
+        m++;
+        z += weight * xconfig[m].g * exp ((-xconfig[m].ex + xconfig[m_ground].ex) / kt);
+      }
+    }
+    else if (ion[nion].nlevels > 0)
+      // Simple atom: calculate using simple levels with weighted BB assumption
     {
       m = ion[nion].firstlevel;
       m_ground = m;
@@ -238,7 +264,7 @@ partition_functions_2 (xplasma, xnion, temp, weight)
       }
     }
     else if (ion[nion].nlte > 0)
-      //Calculate using "non-lte" levels
+      // Fallback: calculate using "non-lte" levels
     {
       m = ion[nion].first_nlte_level;
       m_ground = m;


### PR DESCRIPTION
This corrects issues with calculation of partition functions in LTE modes and with macro atom inputs, as well as sets the t_e = to tinit, instead of 0.9 of that value