### PR TITLE
Fixing a memory allocation overflow bug with higher number of processors utilised when the -p option use. Fixed a possible memory leak fix in reduce_simple_estimators() and removal of duplicate semicolon

### DIFF
--- a/source/communicate_plasma.c
+++ b/source/communicate_plasma.c
@@ -1236,6 +1236,9 @@ reduce_simple_estimators (void)
   free (inner_ion_helper);
   free (inner_ion_helper2);
 
+  free (flux_helper);
+  free (flux_helper2);
+
   /* allocate the integer helper arrays, set a barrier, then do all the integers. */
   iqdisk_helper = calloc (sizeof (int), NRINGS * 2);
   iqdisk_helper2 = calloc (sizeof (int), NRINGS * 2);

--- a/source/communicate_spectra.c
+++ b/source/communicate_spectra.c
@@ -34,7 +34,7 @@ normalize_spectra_across_ranks (void)
   int i;
   int j;
   int nspec;
-  int size_of_commbuffer;;
+  int size_of_commbuffer;
   double *spectrum_buffer;
 
   d_xsignal (files.root, "%-20s Begin spectrum reduction\n", "NOK");

--- a/source/run.c
+++ b/source/run.c
@@ -490,7 +490,13 @@ make_spectra (restart_stat)
    * standard one where one is calulating the spectrum for the first time
    * and in the somewhat abnormal case where additional ionization cycles
    * were calculated for the wind
+   *
+   * Note: We must allocate using NPHOT_MAX, not NPHOT, because NPHOT may
+   * still hold a reduced value from the last photon_speedup ionization cycle.
+   * Inside the spectral cycle loop, NPHOT is set to NPHOT_MAX before photon
+   * generation, so the array must be large enough to hold NPHOT_MAX photons.
    */
+  NPHOT = NPHOT_MAX;
   photmain = p = (PhotPtr) calloc (sizeof (p_dummy), NPHOT + 1);
   photmain_allocated = TRUE;
   Log ("CCC - Allocated photmain at beginning of detailed spectrum, with NPHOt %d\n", NPHOT);


### PR DESCRIPTION
The main issue looks to be exclusively in run.c

There was an overflow in the photmain allocation during spectral cycles when the -p option was used. When the photon_speedup mode is ON, the photon numbers ramp up slowly over ionisation cycles. Depending on the division of the number of processes, there are scenarios where the final ionisation cycle NPHOT might NOT exactly match NPHOT_MAX.

As a result, define_phot and trans_phot is writing (in my case) 5208 photons (NPHOT_MAX) into arrays sized at 5201 elements (NPHOT+1), corrupting the array. This is detected later when the spectral cycles tries to use these lists with  NPHOT_MAX.

Line 565 recognises this with the comment NPHOT = NPHOT_MAX;          // Assure that we really are creating as many photons as we expect.  However, we allocate photmain’s memory allocation before this line with NPHOT + 1. The fix is to add another NPHOT = NPHOT_MAX before this allocation on line 500.

I am preparing a pull request with a couple of other fixes (one potential source of memory leaking, a harmless typo).