### PR TITLE
Refactoring from static arrays to dynamically allocated arrays and protective change for MPI communication with uninitialised memory (Low Risk Changes)

### DIFF
--- a/source/atomic.h
+++ b/source/atomic.h
@@ -368,10 +368,10 @@ typedef struct topbase_phot
   double f, log_f, sigma, log_sigma;            /**< last freq, last x-section and log versions*/
 } Topbase_phot, *TopPhotPtr;
 
-extern Topbase_phot phot_top[NLEVELS];
+extern Topbase_phot *phot_top;
 extern TopPhotPtr phot_top_ptr[NLEVELS];       /**<  Pointers to phot_top in threshold frequency order - this */
 
-extern Topbase_phot inner_cross[N_INNER * NIONS];  /**< Pointer to inner shell cross sections which use the same structure type */
+extern Topbase_phot *inner_cross;  /**< Pointer to inner shell cross sections which use the same structure type */
 extern TopPhotPtr inner_cross_ptr[N_INNER * NIONS];  /**< Pointer to inner shell cross sections in frequency order */
 
 

--- a/source/atomic_extern_init.c
+++ b/source/atomic_extern_init.c
@@ -46,10 +46,10 @@ double inner_freq_min;          /*The lowest frequency for which inner shell ion
 int ntop_phot;                  /* The actual number of TopBase photoionzation x-sections */
 int nphot_total;                /* total number of photoionzation x-sections = nxphot + ntop_phot */
 
-Topbase_phot phot_top[NLEVELS];
+Topbase_phot *phot_top;
 TopPhotPtr phot_top_ptr[NLEVELS];       /* Pointers to phot_top in threshold frequency order - this */
 
-Topbase_phot inner_cross[N_INNER * NIONS];
+Topbase_phot *inner_cross;
 TopPhotPtr inner_cross_ptr[N_INNER * NIONS];
 
 Inner_elec_yield inner_elec_yield[N_INNER * NIONS];

--- a/source/atomicdata_init.c
+++ b/source/atomicdata_init.c
@@ -147,6 +147,42 @@ init_atomic_data ()
   }
 
 
+  if (phot_top != NULL)
+  {
+    free (phot_top);
+  }
+  phot_top = (Topbase_phot *) calloc (sizeof (Topbase_phot), NLEVELS);
+
+  if (phot_top == NULL)
+  {
+    Error ("There is a problem in allocating memory for the phot_top structure\n");
+    exit (0);
+  }
+  else
+  {
+    Log_silent
+      ("Allocated %10d bytes for each of %6d elements of   phot_top totaling %10.1f Mb \n",
+       sizeof (Topbase_phot), NLEVELS, 1.e-6 * NLEVELS * sizeof (Topbase_phot));
+  }
+
+  if (inner_cross != NULL)
+  {
+    free (inner_cross);
+  }
+  inner_cross = (Topbase_phot *) calloc (sizeof (Topbase_phot), N_INNER * NIONS);
+
+  if (inner_cross == NULL)
+  {
+    Error ("There is a problem in allocating memory for the inner_cross structure\n");
+    exit (0);
+  }
+  else
+  {
+    Log_silent
+      ("Allocated %10d bytes for each of %6d elements of inner_cross totaling %10.1f Mb \n",
+       sizeof (Topbase_phot), N_INNER * NIONS, 1.e-6 * N_INNER * NIONS * sizeof (Topbase_phot));
+  }
+
   /* Initialize variables */
 
 

--- a/source/bands_spec.c
+++ b/source/bands_spec.c
@@ -64,7 +64,11 @@ band_copy()
         for(nband=0;nband<xband.nbands;nband++){
             plasmamain[n].f1[nband]=xband.f1[nband];
             plasmamain[n].f2[nband]=xband.f2[nband];
-
+        }
+        /* Initialize remaining unused band frequencies to safe values */
+        for(nband=xband.nbands;nband<NXBANDS+1;nband++){
+            plasmamain[n].f1[nband]=0.0;
+            plasmamain[n].f2[nband]=0.0;
         }
     }
 }

--- a/source/wind_updates2d.c
+++ b/source/wind_updates2d.c
@@ -636,7 +636,7 @@ init_plasma_rad_properties (void)
     }
 
     /* Initialise  the frequency banded radiation estimators used for estimating the coarse spectra in each i */
-    for (j = 0; j < NXBANDS; j++)
+    for (j = 0; j < plasmamain[i].nbands; j++)
     {
       plasmamain[i].nxtot[j] = 0;
       plasmamain[i].xj[j] = 0.0;
@@ -644,6 +644,16 @@ init_plasma_rad_properties (void)
       plasmamain[i].xsd_freq[j] = 0.0;
       plasmamain[i].fmin[j] = plasmamain[i].f2[j];      /* Set the minium frequency to the max frequency in the band */
       plasmamain[i].fmax[j] = plasmamain[i].f1[j];      /* Set the maximum frequency to the min frequency in the band */
+    }
+    /* Initialize unused band elements to safe values for MPI communication */
+    for (j = plasmamain[i].nbands; j < NXBANDS; j++)
+    {
+      plasmamain[i].nxtot[j] = 0;
+      plasmamain[i].xj[j] = 0.0;
+      plasmamain[i].xave_freq[j] = 0.0;
+      plasmamain[i].xsd_freq[j] = 0.0;
+      plasmamain[i].fmin[j] = 0.0;
+      plasmamain[i].fmax[j] = 0.0;
     }
     for (j = 0; j < NBINS_IN_CELL_SPEC; ++j)
     {


### PR DESCRIPTION
OPTIONAL ADDITIONS

One is setting up refactoring Topbase_phot phot_top[NLEVELS] and inner_cross[N_INNER*NIONS] from static arrays to dynamically allocated arrays (in atomicdata_init.c, atomic_extern_init.c and atomic.h). The Valgrind (I think this is where I identified it from) has these two arrays as very large static arrays (dominate over everything else). My thought was that these were too large heap allocations that were overflowing memory (not the case). But this change does ensure we aren’t overly “wasting” resources.

The other is a protective change where the code zeros unused band slots from bands_spec.c / wind_updates2d.c, in case the MPI communicated uninitialised memory. This was when investigating the error was likely due to the macro atom banding.