### PR TITLE
Adding in a truly isotropic central source

### DIFF
--- a/docs/parameters/Central_object.geometry_for_source.yaml
+++ b/docs/parameters/Central_object.geometry_for_source.yaml
@@ -13,6 +13,13 @@ values:
     Emission is cosine-weighted in the direction of the sphere normal at the point of emission.
     Photons that would be spawned in an extended disk (if :ref:`Disk.type` is `vertically.extended`)
     are re-generated.
+  bubble: |
+    The central source radiates from between two spheres, one with radius :ref:`Central_object.radius` 
+    and one with radius :ref:`Central_object.bubble_size`. The photon directions are individually isotropic but do not necessarily
+    create a truly isotropic source.
+  iso: |
+    The central source radiates from the surface of a sphere with radius :ref:`Central_object.radius`.
+    Emission is truly isotropic, so photons are emitted in the same direction as the random point on the sphere surface where they are emitted.
 parent:
   System_type: [agn, bh]
   Central_object.radiation: true

--- a/docs/sphinx/source/input/parameters/central_object/Central_object/Central_object.geometry_for_source.rst
+++ b/docs/sphinx/source/input/parameters/central_object/Central_object/Central_object.geometry_for_source.rst
@@ -20,8 +20,13 @@ Values
     are re-generated.
 
   bubble
-    The central source radiates from random positions within a sphere of a given radius. 
-    This model generates isotropic photons.
+    The central source radiates from between two spheres, one with radius :ref:`Central_object.radius` 
+    and one with radius :ref:`Central_object.bubble_size`. The photon directions are individually isotropic but do not necessarily
+    create a truly isotropic source.
+
+  iso 
+    The central source radiates from the surface of a sphere with radius :ref:`Central_object.radius`.
+    Emission is truly isotropic, so photons are emitted in the same direction as the random point on the sphere surface where they are emitted.
 
 File
   `setup_star_bh.c <https://github.com/sirocco-rt/sirocco/blob/master/source/setup_star_bh.c>`_
@@ -35,4 +40,5 @@ Parent(s)
 
 Child(ren)
   * :ref:`Central_object.lamp_post_height`
+  * :ref:`Central_object.bubble_size`
 

--- a/docs/sphinx/source/input/system_description.rst
+++ b/docs/sphinx/source/input/system_description.rst
@@ -26,7 +26,7 @@ The first set of parameters which SIROCCO needs are information about the overal
    Central_object.rad_type_to_make_wind(bb,models,power,cloudy,brems,mono)                power
    Central_object.luminosity(ergs/s)          4.72063e+37
    Central_object.power_law_index                 -1.5
-   Central_object.geometry_for_source(sphere,lamp_post,bubble)               sphere
+   Central_object.geometry_for_source(sphere,lamp_post,bubble,iso)               sphere
 
 :ref:`System_type` is starting point, a basic classification of the type of object one is trying to model.
 This is used to guide further questions about the object and to set defaults.

--- a/docs/sphinx/source/plotting.rst
+++ b/docs/sphinx/source/plotting.rst
@@ -10,7 +10,21 @@ It can be installed from its `own Github repository <https://github.com/sirocco-
 under the sirocco-rt organisation. We recommend installing this package for reading code outputs.:
 instructions to do so can be found in the README of that repository. 
 
-The API documentation for PySi can be found :doc:`here <py_progs/pysi>`,
+The API documentation for PySi can be found :doc:`here <py_progs/pysi>`.
+
+PySi can also be used from the command line. For example, the command 
+
+.. code-block:: bash
+
+    pysi plot spectrum observer [model_name]
+
+will allow you to plot a spectrum, whereas 
+
+.. code-block:: bash
+
+    pysi plot wind property [model_name] [variable]
+
+will allow you to plot the wind property specified by [variable]. For more flexibility, see the tutorials. 
 
 .. admonition :: Warning to users! 
 

--- a/source/agn.c
+++ b/source/agn.c
@@ -522,7 +522,16 @@ photo_gen_agn (p, r, alpha, weight, f1, f2, spectype, istart, nphot)
       randvec (p[i].lmn, 1.0);  // lamp-post geometry is isotropic, so completely random vector
     }
 
-    /* This is set up for looking at photons in spectral cycles at present */
+    else if (geo.pl_geometry == PL_GEOMETRY_ISO)
+    {
+      /* We want to generate photons isotropically from the surface of a sphere, 
+        but with radial direction so it resembles an isotropic point source */
+      randvec (p[i].x, r);            // Simple random coordinate on the surface of a sphere
+      stuff_v (p[i].x, p[i].lmn);     // we want photon to travel in the same direction as the random point on the sphere so it is isotropic
+      renorm (p[i].lmn, 1.0);         // turn into a unit vector
+    }
+
+    /* This is a diagnostic mode one can use to look at photon origins  */
     //if (modes.save_photons && geo.ioniz_or_extract == CYCLE_EXTRACT)
     //  save_photons (&p[i], "AGN");
   }

--- a/source/setup_star_bh.c
+++ b/source/setup_star_bh.c
@@ -337,7 +337,7 @@ get_bl_and_agn_params (lstar)
       rddoub ("@Central_object.power_law_cutoff", &geo.pl_low_cutoff);
 
     strcpy (answer, "sphere");
-    geo.pl_geometry = rdchoice ("Central_object.geometry_for_source(sphere,lamp_post,bubble)", "0,1,2", answer);
+    geo.pl_geometry = rdchoice ("Central_object.geometry_for_source(sphere,lamp_post,bubble,iso)", "0,1,2,3", answer);
 
 
     if (geo.pl_geometry == PL_GEOMETRY_LAMP_POST)
@@ -352,7 +352,7 @@ get_bl_and_agn_params (lstar)
       geo.bubble_size *= GRAV * geo.mstar / VLIGHT / VLIGHT;    //get it in CGS units
       Log ("bubble size  in cm is %g\n", geo.bubble_size);
     }
-    else if (geo.pl_geometry != PL_GEOMETRY_SPHERE)     // only three options at the moment
+    else if (geo.pl_geometry != PL_GEOMETRY_SPHERE && geo.pl_geometry != PL_GEOMETRY_ISO)     // only four options at the moment
     {
       Error ("Did not understand power law geometry %i. Fatal.\n", geo.pl_geometry);
       Exit (0);

--- a/source/sirocco.h
+++ b/source/sirocco.h
@@ -689,6 +689,7 @@ struct geometry
 #define PL_GEOMETRY_SPHERE 0
 #define PL_GEOMETRY_LAMP_POST 1
 #define PL_GEOMETRY_BUBBLE 2
+#define PL_GEOMETRY_ISO 3
   double lamp_post_height;      /**<  height of X-ray point source if lamp post */
   double bubble_size;           /**<  size of a bubble if any */
 


### PR DESCRIPTION
@James Matthews has added documentation and code for a central source to emit without an inclination dependent photon weighting (foreshortening/limb darkening). This means that the drop in continuum flux with increasing inclinations (face-on -> edge-on) should now only depend on the geometric obscuration of the central source by the disc when there is no wind mass loss rate , i.e. no wind. 
@Austen Wallis has run tests with these new isotropic model settings and confirmed to be true and the drop in flux now does corresspond with the obscuration of the disc following, F proto (1+cos(i))