### PR TITLE
Mpich

### DIFF
--- a/source/janitor.c
+++ b/source/janitor.c
@@ -40,9 +40,8 @@ free_plasma_block (void **ptr, int is_shared)
 #ifdef MPI_ON
   if (is_shared && np_mpi_global > 1)
   {
-    /* Shared memory is freed via MPI_Win_free, which is handled
-     * by the cleanup in calloc_dyn_plasma/calloc_estimators when
-     * re-allocating, or by MPI_Finalize at exit. */
+    /* MPI_Win_free for shared blocks is called explicitly in free_plasma_grid /
+     * free_macro_grid before reaching here; just NULL the data pointer. */
     *ptr = NULL;
     return;
   }
@@ -152,6 +151,26 @@ free_plasma_grid (void)
   /* state blocks (shared in MPI mode) */
   if (plasma_block_ptrs.density_block != NULL)
   {
+#ifdef MPI_ON
+    if (is_shared && np_mpi_global > 1)
+    {
+      MPI_Win_free (&plasma_block_ptrs.win_density);
+      MPI_Win_free (&plasma_block_ptrs.win_partition);
+      MPI_Win_free (&plasma_block_ptrs.win_levden);
+      MPI_Win_free (&plasma_block_ptrs.win_recomb_simple);
+      MPI_Win_free (&plasma_block_ptrs.win_recomb_simple_upweight);
+      MPI_Win_free (&plasma_block_ptrs.win_kbf_use);
+      MPI_Win_free (&plasma_block_ptrs.win_recomb);
+      MPI_Win_free (&plasma_block_ptrs.win_cool_rr_ion);
+      MPI_Win_free (&plasma_block_ptrs.win_lum_rr_ion);
+      MPI_Win_free (&plasma_block_ptrs.win_cool_dr_ion);
+      MPI_Win_free (&plasma_block_ptrs.win_inner_recomb);
+      MPI_Win_free (&plasma_block_ptrs.win_state_xbands_d);
+      MPI_Win_free (&plasma_block_ptrs.win_state_spec_mod_type);
+      MPI_Win_free (&plasma_block_ptrs.win_derived_persist_force);
+      MPI_Win_free (&plasma_block_ptrs.win_derived_persist_angle);
+    }
+#endif
     free_plasma_block ((void **) &plasma_block_ptrs.density_block, is_shared);
     free_plasma_block ((void **) &plasma_block_ptrs.partition_block, is_shared);
     free_plasma_block ((void **) &plasma_block_ptrs.levden_block, is_shared);
@@ -207,6 +226,17 @@ free_macro_grid (void)
 
   if (macro_block_ptrs.jbar_block != NULL)
   {
+#ifdef MPI_ON
+    if (is_shared && np_mpi_global > 1)
+    {
+      MPI_Win_free (&macro_block_ptrs.win_jbar_old);
+      MPI_Win_free (&macro_block_ptrs.win_gamma_old);
+      MPI_Win_free (&macro_block_ptrs.win_gamma_e_old);
+      MPI_Win_free (&macro_block_ptrs.win_alpha_st_old);
+      MPI_Win_free (&macro_block_ptrs.win_alpha_st_e_old);
+      MPI_Win_free (&macro_block_ptrs.win_matom_emiss);
+    }
+#endif
     /* state blocks (shared in MPI mode) */
     free_plasma_block ((void **) &macro_block_ptrs.jbar_old_block, is_shared);
     free_plasma_block ((void **) &macro_block_ptrs.gamma_old_block, is_shared);
@@ -234,6 +264,10 @@ free_macro_grid (void)
   /* matom_matrix flat data block (shared in MPI mode) */
   if (macro_block_ptrs.matom_matrix_block != NULL)
   {
+#ifdef MPI_ON
+    if (is_shared && np_mpi_global > 1)
+      MPI_Win_free (&macro_block_ptrs.win_matom_matrix);
+#endif
     free_plasma_block ((void **) &macro_block_ptrs.matom_matrix_block, is_shared);
     free (macro_block_ptrs.matom_matrix_rowptrs);
     macro_block_ptrs.matom_matrix_rowptrs = NULL;

--- a/source/signal.c
+++ b/source/signal.c
@@ -303,6 +303,10 @@ check_time (char *root)
     xsignal (root, "\nCOMMENT max_time %.1f seconds exceeded\n", max_time);
 
 #ifdef MPI_ON
+    MPI_Barrier (MPI_COMM_WORLD);
+    MPI_Comm_free (&node_comm);
+    if (leader_comm != MPI_COMM_NULL)
+      MPI_Comm_free (&leader_comm);
     MPI_Finalize ();
 #endif
 

--- a/source/sirocco.c
+++ b/source/sirocco.c
@@ -710,6 +710,9 @@ main (int argc, char *argv[])
     error_summary ("wind definition only (--grid-only).");
 #ifdef MPI_ON
     MPI_Barrier (MPI_COMM_WORLD);
+    MPI_Comm_free (&node_comm);
+    if (leader_comm != MPI_COMM_NULL)
+      MPI_Comm_free (&leader_comm);
     MPI_Finalize ();
 #endif
     return EXIT_SUCCESS;
@@ -831,13 +834,20 @@ main (int argc, char *argv[])
   error_summary ("End of program");
 #endif
 
-  /* clean_on_exit calls free_wind_grid which calls MPI_Win_free — must happen before MPI_Finalize */
+  /* clean_on_exit calls free_wind_grid and free_plasma_grid which call MPI_Win_free.
+   * The barrier ensures all ranks finish cleanup before any rank calls MPI_Finalize. */
+#ifdef MPI_ON
+  MPI_Barrier (MPI_COMM_WORLD);
+#endif
   clean_on_exit ();
 
   print_memory_usage ("After program is complete");
   Log_close ();
 
 #ifdef MPI_ON
+  MPI_Comm_free (&node_comm);
+  if (leader_comm != MPI_COMM_NULL)
+    MPI_Comm_free (&leader_comm);
   MPI_Finalize ();
 #endif
 

--- a/source/unit_test.c
+++ b/source/unit_test.c
@@ -43,6 +43,11 @@ main (int argc, char *argv[])
   MPI_Init (&argc, &argv);
   MPI_Comm_rank (MPI_COMM_WORLD, &my_rank);
   MPI_Comm_size (MPI_COMM_WORLD, &np_mpi);
+  MPI_Comm_split_type (MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, my_rank, MPI_INFO_NULL, &node_comm);
+  MPI_Comm_rank (node_comm, &node_rank);
+  MPI_Comm_size (node_comm, &node_size);
+  MPI_Comm_split (MPI_COMM_WORLD, (node_rank == 0) ? 0 : MPI_UNDEFINED, my_rank, &leader_comm);
+  num_nodes = 1;
 #else
   my_rank = 0;
   np_mpi = 1;
@@ -247,6 +252,13 @@ main (int argc, char *argv[])
 
   printf ("Finished unit test\n");
 
+#ifdef MPI_ON
+  MPI_Barrier (MPI_COMM_WORLD);
+  MPI_Comm_free (&node_comm);
+  if (leader_comm != MPI_COMM_NULL)
+    MPI_Comm_free (&leader_comm);
+  MPI_Finalize ();
+#endif
 
   return (0);
 
@@ -261,7 +273,7 @@ zparse (int argc, char *argv[])
   if (argc != 2)
   {
     printf ("usage: unit_test root\n");
-    exit (1);
+    Exit (1);
   }
 
 


### PR DESCRIPTION
A small error in sirocco existed that caused a segmentation fault when running under MPICH but not OpenMPI.  The error was triggered at the very end, and did not affect any of the actual outputs.  The changes here make it possible to run sirocco with MPICH as well as OpenMPI.